### PR TITLE
Interface: Remplacer "Candidats" par "Accompagnements" 

### DIFF
--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -63,7 +63,7 @@
                             <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                                 <h2 class="mb-0">Informations générales</h2>
                                 <div class="d-flex flex-column flex-md-row gap-2" id="copy_public_id">
-                                    {% include "includes/job_seekers/copy_public_id.html" with public_id=job_application.job_seeker.public_id only %}
+                                    {% include "includes/job_seekers/copy_public_id.html" with as_job_seeker=True public_id=job_application.job_seeker.public_id only %}
                                 </div>
                             </div>
                         </div>

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -83,7 +83,7 @@
                             <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                                 <h2 class="mb-0">Informations générales</h2>
                                 <div class="d-flex flex-column flex-md-row gap-2" id="copy_public_id">
-                                    {% include "includes/job_seekers/copy_public_id.html" with public_id=job_application.job_seeker.public_id only %}
+                                    {% include "includes/job_seekers/copy_public_id.html" with as_job_seeker=True public_id=job_application.job_seeker.public_id only %}
                                 </div>
                             </div>
                         </div>

--- a/itou/templates/dashboard/includes/prescriber_job_applications_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_applications_card.html
@@ -15,7 +15,7 @@
             <li class="d-flex justify-content-between align-items-center mb-3">
                 <a href="{% url 'search:employers_results' %}" class="btn-link btn-ico">
                     <i class="ri-draft-line ri-lg fw-normal" aria-hidden="true"></i>
-                    <span>Postuler pour un candidat</span>
+                    <span>Postuler pour un usager</span>
                 </a>
             </li>
             <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -8,12 +8,12 @@
 <div class="col mb-3 mb-md-4">
     {% component_box_dashboard title=title cta=cta list=list extra_boxes=extra_boxes %}
         {% fragment as title %}
-            Candidats
+            Accompagnements
         {% endfragment %}
         {% fragment as cta %}
             <a href="{% url 'job_seekers_views:list' %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
                 <i class="ri-user-line ri-lg fw-normal" aria-hidden="true"></i>
-                <span>Liste de mes candidats</span>
+                <span>Mes accompagnements</span>
             </a>
         {% endfragment %}
         {% fragment as list %}
@@ -41,7 +41,7 @@
                     <div class="d-flex justify-content-between align-items-center">
                         <a href="{% url "job_seekers_views:list" %}?is_stalled=on" class="text-warning fw-bold text-decoration-none btn-ico" {% matomo_event "dashboard" "clic" "candidats-sans-solution" %}>
                             <i class="ri-user-forbid-line fw-normal" aria-hidden="true"></i>
-                            <span>Candidat{{ stalled_job_seekers_count|pluralizefr }} sans solution</span>
+                            <span>Usager{{ stalled_job_seekers_count|pluralizefr }} sans solution</span>
                         </a>
                         <span class="badge rounded-pill badge-xs bg-warning-light text-warning">{{ stalled_job_seekers_count }}</span>
                     </div>

--- a/itou/templates/includes/job_seekers/copy_public_id.html
+++ b/itou/templates/includes/job_seekers/copy_public_id.html
@@ -1,9 +1,13 @@
 {% load matomo %}
 
 {% matomo_event "candidature" "clic" "copied_jobseeker_public_id" as matomo_event_attrs %}
-{% if small|default:False %}
-    Copier l'ID du candidat
-    {% include "includes/copy_to_clipboard.html" with content=public_id matomo_event_attrs=matomo_event_attrs css_classes="btn-link" only_icon=True %}
-{% else %}
-    {% include "includes/copy_to_clipboard.html" with content=public_id matomo_event_attrs=matomo_event_attrs css_classes="btn btn-ico btn-secondary" text="Copier l'ID du candidat" %}
-{% endif %}
+{% with user_type=as_job_seeker|default:False|yesno:"du candidat,de l'usager" %}
+    {% with text="Copier l'ID "|add:user_type %}
+        {% if small|default:False %}
+            {{ text }}
+            {% include "includes/copy_to_clipboard.html" with content=public_id matomo_event_attrs=matomo_event_attrs css_classes="btn-link" only_icon=True %}
+        {% else %}
+            {% include "includes/copy_to_clipboard.html" with content=public_id matomo_event_attrs=matomo_event_attrs css_classes="btn btn-ico btn-secondary" text=text %}
+        {% endif %}
+    {% endwith %}
+{% endwith %}

--- a/itou/templates/job_seekers_views/includes/detail_title_content.html
+++ b/itou/templates/job_seekers_views/includes/detail_title_content.html
@@ -5,7 +5,7 @@
 
 {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria_label="Actions sur le candidat" %}
     {% fragment as c_title__main %}
-        <h1>Candidat : {{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}</h1>
+        <h1>{{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}</h1>
         <p id="copy_public_id">
             {% include "includes/job_seekers/copy_public_id.html" with public_id=job_seeker.public_id small=True only %}
         </p>
@@ -38,7 +38,7 @@
 
         <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
             <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-            <span>Postuler pour ce candidat</span>
+            <span>Postuler pour cet usager</span>
         </a>
 
     {% endfragment %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -7,7 +7,7 @@
             {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form btn_dropdown_filter=True only %}
             <div class="dropdown">
                 <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                    Candidat sans solution
+                    Usagers sans solution
                 </button>
                 <ul class="dropdown-menu">
                     <li>{% bootstrap_field filters_form.is_stalled wrapper_class="dropdown-item" %}</li>
@@ -15,7 +15,7 @@
                         <hr class="dropdown-divider">
                     </li>
                     <li>
-                        <a href="{{ ITOU_HELP_CENTER_URL }}/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" class="btn btn-link has-external-link" target="_blank" rel="noopener">Qu’est-ce qu’un candidat sans solution ?</a>
+                        <a href="{{ ITOU_HELP_CENTER_URL }}/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" class="btn btn-link has-external-link" target="_blank" rel="noopener">Qu’est-ce qu’un usager sans solution</a>
                     </li>
                 </ul>
             </div>

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -8,14 +8,14 @@
         <div class="text-center my-3 my-md-4">
             <img class="img-fluid" src="{% static 'img/illustration-card-no-result.png' %}" alt="" loading="lazy">
             <p class="mb-1 mt-3">
-                <strong>Aucun candidat pour le moment</strong>
+                <strong>Aucun usager pour le moment</strong>
             </p>
         </div>
     {% else %}
         <div class="table-responsive mt-3 mt-md-4">
             <table class="table table-hover table-sortable">
                 <caption class="visually-hidden">
-                    Liste des candidats (les colonnes disposant d’un bouton dans leur entête peuvent être triées en cliquant sur le bouton)
+                    Liste des usagers (les colonnes disposant d’un bouton dans leur entête peuvent être triées en cliquant sur le bouton)
                 </caption>
                 <thead>
                     <tr>
@@ -25,7 +25,7 @@
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.JOB_APPLICATIONS_NB_ASC name="Nombre de candidatures" only %}
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.LAST_UPDATED_AT_ASC name="Dernière action" only %}
                         <th scope="col" class="text-end {% if request.current_organization.is_authorized %}w-100px{% else %}w-50px{% endif %}">
-                            <span class="visually-hidden">Actions possibles sur les candidats</span>
+                            <span class="visually-hidden">Actions possibles sur les usagers</span>
                         </th>
                     </tr>
                 </thead>
@@ -35,7 +35,7 @@
                             <td>
                                 <a href="{% url "job_seekers_views:details" public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_seeker.get_inverted_full_name|mask_unless:job_seeker.user_can_view_personal_information }}</a>
                                 {% if job_seeker.jobseeker_profile.is_considered_stalled %}
-                                    <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning" aria-label="Candidat sans solution"><i class="ri-user-forbid-line" aria-hidden="true" data-bs-title="Candidat sans solution" data-bs-toggle="tooltip"></i></span>
+                                    <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning" aria-label="Usager sans solution"><i class="ri-user-forbid-line" aria-hidden="true" data-bs-title="Usager sans solution" data-bs-toggle="tooltip"></i></span>
                                 {% endif %}
                             </td>
                             <td>
@@ -53,7 +53,7 @@
                                 {% else %}
                                     {% url_add_query search_url job_seeker_public_id=job_seeker.public_id as url_query %}
                                 {% endif %}
-                                <a class="btn btn-sm btn-link btn-ico-only" href="{{ url_query }}" data-bs-toggle="tooltip" data-bs-title="Postuler pour ce candidat" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %}>
+                                <a class="btn btn-sm btn-link btn-ico-only" href="{{ url_query }}" data-bs-toggle="tooltip" data-bs-title="Postuler pour cet usager" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %}>
                                     <i class="ri-draft-line" aria-label="Postuler pour {{ job_seeker.get_inverted_full_name|mask_unless:job_seeker.user_can_view_personal_information }}"></i>
                                 </a>
                                 {% if request.current_organization.is_authorized %}
@@ -83,9 +83,9 @@
                                                     {% csrf_token %}
                                                     <input type="hidden" name="is_not_stalled_anymore" value="{{ job_seeker.jobseeker_profile.is_not_stalled_anymore|yesno:"0,1" }}">
                                                     {% if job_seeker.jobseeker_profile.is_not_stalled_anymore %}
-                                                        <button type="submit" class="dropdown-item">Le candidat est sans solution</button>
+                                                        <button type="submit" class="dropdown-item">L'usager est sans solution</button>
                                                     {% else %}
-                                                        <button type="submit" class="dropdown-item">Le candidat n'est plus sans solution</button>
+                                                        <button type="submit" class="dropdown-item">L'usager n'est plus sans solution</button>
                                                     {% endif %}
                                                 </form>
                                             {% endif %}

--- a/itou/templates/job_seekers_views/job_applications.html
+++ b/itou/templates/job_seekers_views/job_applications.html
@@ -38,7 +38,7 @@
                                         {% endfragment %}
                                         {% fragment as content %}
                                             <p>
-                                                En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures du candidat, y compris celles déposées par d’autres organisations ou par le candidat lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
+                                                En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures de l'usager, y compris celles déposées par d’autres organisations ou par l'usager lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
                                             </p>
                                             <p class="mb-0">
                                                 <a class="btn-link has-external-link" rel="noopener noreferrer" target="_blank" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/44496401665297">En savoir plus</a>
@@ -52,7 +52,7 @@
                                         {% endfragment %}
                                         {% fragment as content %}
                                             <p>
-                                                Votre visibilité sur les candidatures de ce candidat se limite à celles réalisées exclusivement par votre organisation. En tant que prescripteur habilité, vous pouvez toutefois bénéficier d’une vision d’ensemble des candidatures de ce candidat, y compris celles réalisées en dehors de votre structure, si un membre de votre organisation effectue une action pour celui-ci.
+                                                Votre visibilité sur les candidatures de cet usager se limite à celles réalisées exclusivement par votre organisation. En tant que prescripteur habilité, vous pouvez toutefois bénéficier d’une vision d’ensemble des candidatures de cet usager, y compris celles réalisées en dehors de votre structure, si un membre de votre organisation effectue une action pour celui-ci.
                                             </p>
                                             <p class="mb-0">
                                                 <a class="btn-link has-external-link" rel="noopener noreferrer" target="_blank" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/44496401665297">En savoir plus</a>

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -7,7 +7,7 @@
 {% load str_filters %}
 {% load url_add_query %}
 
-{% block title %}Candidats {{ block.super }}{% endblock %}
+{% block title %}Accompagnements {{ block.super }}{% endblock %}
 
 {% block title_navinfo %}
     {% include "layout/previous_step.html" with back_url=back_url only %}
@@ -16,7 +16,7 @@
 {% block title_content %}
     {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria_label="Actions sur les candidatures" %}
         {% fragment as c_title__main %}
-            <h1>Candidats</h1>
+            <h1>Accompagnements</h1>
         {% endfragment %}
         {% fragment as c_title__cta %}
             {% url "job_seekers_views:get_or_create_start" as get_or_create_url %}
@@ -24,11 +24,11 @@
                {% matomo_event "compte-candidat" "clic" "creer-un-compte-candidat" %}
                class="btn btn-lg btn-secondary btn-ico">
                 <i class="ri-user-add-line fw-medium" aria-hidden="true"></i>
-                <span>Créer un compte candidat</span>
+                <span>Créer un compte usager</span>
             </a>
             <a href="{% url 'search:employers_results' %}" class="btn btn-lg btn-primary btn-ico">
                 <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                <span>Postuler pour un candidat</span>
+                <span>Postuler pour un usager</span>
             </a>
         {% endfragment %}
     {% endcomponent_title %}
@@ -39,12 +39,12 @@
         <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
             <li class="nav-item">
                 <a class="nav-link{% if not list_organization %} active{% endif %}" href="{% url 'job_seekers_views:list' %}">
-                    Mes candidats
+                    Mes accompagnements
                 </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link{% if list_organization %} active{% endif %}" href="{% url 'job_seekers_views:list_organization' %}">
-                    Tous les candidats de la structure
+                    Tous les accompagnements de la structure
                 </a>
             </li>
         </ul>
@@ -59,9 +59,9 @@
                 <div class="col-12">
                     <h2>
                         {% if list_organization %}
-                            Tous les candidats de la structure
+                            Tous les accompagnements de la structure
                         {% else %}
-                            Mes candidats
+                            Mes accompagnements
                         {% endif %}
                     </h2>
                 </div>

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -126,7 +126,7 @@ NAV_ENTRIES = {
     ),
     # Prescribers.
     "prescriber-jobseekers-user": NavItem(
-        label="Mes candidats",
+        label="Mes accompagnements",
         target=reverse("job_seekers_views:list"),
         active_view_names=["job_seekers_views:list"],
         matomo_event_category="offcanvasNav",
@@ -134,7 +134,7 @@ NAV_ENTRIES = {
         matomo_event_option="candidats-utilisateur",
     ),
     "prescriber-jobseekers-organization": NavItem(
-        label="Tous les candidats de la structure",
+        label="Tous les accompagnements de la structure",
         target=reverse("job_seekers_views:list_organization"),
         active_view_names=["job_seekers_views:list_organization"],
         matomo_event_category="offcanvasNav",
@@ -328,7 +328,7 @@ def nav(request):
             jobseekers_items.append(NAV_ENTRIES["prescriber-jobseekers-organization"])
             if request.from_authorized_prescriber:
                 jobseekers_items.append(NAV_ENTRIES["prescriber-approval-prolongations"])
-            menu_items.append(NavGroup(label="Candidats", icon="ri-user-line", items=jobseekers_items))
+            menu_items.append(NavGroup(label="Accompagnements", icon="ri-user-line", items=jobseekers_items))
             menu_items.append(NAV_ENTRIES["gps"])
             organization_items = [
                 (

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -23,10 +23,10 @@ from itou.utils.widgets import DuetDatePickerWidget
 class FilterForm(forms.Form):
     job_seeker = forms.ChoiceField(
         required=False,
-        label="Nom du candidat",
+        label="Nom de l'usager",
         widget=Select2Widget(
             attrs={
-                "data-placeholder": "Nom du candidat",
+                "data-placeholder": "Nom de l'usager",
             }
         ),
     )
@@ -38,7 +38,7 @@ class FilterForm(forms.Form):
     pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
     no_pass_iae = forms.BooleanField(label="Aucun", required=False)
 
-    is_stalled = forms.BooleanField(label="N’afficher que les candidats sans solution", required=False)
+    is_stalled = forms.BooleanField(label="N’afficher que les usagers sans solution", required=False)
 
     organization_members = forms.MultipleChoiceField(
         label="Nom de la personne", required=False, widget=Select2MultipleWidget

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -1210,23 +1210,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                               <li>
@@ -1553,23 +1553,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                           </ul>
@@ -2246,23 +2246,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                           </ul>
@@ -2514,23 +2514,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                           </ul>
@@ -2826,23 +2826,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                           </ul>
@@ -3153,23 +3153,23 @@
                       </a>
                   </li>
                   <li class="nav-item">
-                      <button aria-controls="collapse-nav-candidats" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-candidats" data-bs-toggle="collapse" type="button">
+                      <button aria-controls="collapse-nav-accompagnements" aria-expanded="false" class="nav-link has-collapse-caret w-100 text-start" data-bs-target="#collapse-nav-accompagnements" data-bs-toggle="collapse" type="button">
                           <i aria-hidden="true" class="ri-user-line fw-medium">
                           </i>
                           <span>
-                              Candidats
+                              Accompagnements
                           </span>
                       </button>
-                      <div class="collapse" id="collapse-nav-candidats">
+                      <div class="collapse" id="collapse-nav-accompagnements">
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-utilisateur" href="/job-seekers/list">
-                                      Mes candidats
+                                      Mes accompagnements
                                   </a>
                               </li>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="candidats-organisation" href="/job-seekers/list-organization">
-                                      Tous les candidats de la structure
+                                      Tous les accompagnements de la structure
                                   </a>
                               </li>
                           </ul>

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -61,7 +61,7 @@ class TestApplyAsPrescriber:
             f"""
             <a class="btn btn-sm btn-link btn-ico-only"
                 data-bs-toggle="tooltip"
-                data-bs-title="Postuler pour ce candidat"
+                data-bs-title="Postuler pour cet usager"
                 data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"
                 data-matomo-option="postuler-pour-ce-candidat"
                 href="{next_url}">
@@ -86,7 +86,7 @@ class TestApplyAsPrescriber:
                     data-matomo-action="clic"
                     data-matomo-option="postuler-pour-ce-candidat">
                     <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                    <span>Postuler pour ce candidat</span>
+                    <span>Postuler pour cet usager</span>
                 </a>
                 """
             ),
@@ -231,7 +231,7 @@ class TestApplyAsPrescriber:
             f"""
             <a class="btn btn-sm btn-link btn-ico-only"
                 data-bs-toggle="tooltip"
-                data-bs-title="Postuler pour ce candidat"
+                data-bs-title="Postuler pour cet usager"
                 data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"
                 data-matomo-option="postuler-pour-ce-candidat"
                 href="{next_url}">
@@ -255,7 +255,7 @@ class TestApplyAsPrescriber:
                     data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"
                     data-matomo-option="postuler-pour-ce-candidat">
                     <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                    <span>Postuler pour ce candidat</span>
+                    <span>Postuler pour cet usager</span>
                 </a>
                 """
             ),
@@ -414,7 +414,7 @@ class TestApplyAsCompany:
                     data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"
                     data-matomo-option="postuler-pour-ce-candidat">
                     <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                    <span>Postuler pour ce candidat</span>
+                    <span>Postuler pour cet usager</span>
                 </a>
                 """
             ),

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -134,7 +134,7 @@ class TestDashboardView:
 
         response = client.get(reverse("dashboard:index"))
         assertContains(response, format_siret(prescriber_organization.siret))
-        assertContains(response, "Liste de mes candidats")
+        assertContains(response, "Mes accompagnements")
 
     def test_dashboard_displays_asp_badge(self, client):
         WARNING_CLASS = "bg-warning"
@@ -1084,4 +1084,4 @@ def test_stalled_job_seekers_box(client):
 
     response = client.get(reverse("dashboard:index"))
     assert response.context["stalled_job_seekers_count"] == 1
-    assertContains(response, "<span>Candidat sans solution</span>", count=1)
+    assertContains(response, "<span>Usager sans solution</span>", count=1)

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -2,12 +2,12 @@
 # name: TestEmployeeDetailView.test_detail_view[copy_public_id]
   '''
   <p id="copy_public_id">
-      Copier l'ID du candidat
+      Copier l'ID de l'usager
       <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="PUBLIC_ID" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
           <i aria-hidden="true" class="ri-file-copy-line fw-normal">
           </i>
           <span class="visually-hidden">
-              Copier
+              Copier l'ID de l'usager
           </span>
       </button>
   </p>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -21,15 +21,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -44,7 +44,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -221,15 +221,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -239,7 +239,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -515,15 +515,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -533,7 +533,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -786,15 +786,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -816,7 +816,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -1026,15 +1026,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -1056,7 +1056,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -1366,15 +1366,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -1396,7 +1396,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -1692,15 +1692,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -1715,7 +1715,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -1763,7 +1763,7 @@
                                               </strong>
                                           </p>
                                           <p>
-                                              En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures du candidat, y compris celles déposées par d’autres organisations ou par le candidat lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
+                                              En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures de l'usager, y compris celles déposées par d’autres organisations ou par l'usager lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
                                           </p>
                                           <p class="mb-0">
                                               <a class="btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/44496401665297" rel="noopener noreferrer" target="_blank">
@@ -2922,15 +2922,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -2945,7 +2945,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -2993,7 +2993,7 @@
                                               </strong>
                                           </p>
                                           <p>
-                                              En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures du candidat, y compris celles déposées par d’autres organisations ou par le candidat lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
+                                              En tant que prescripteur habilité, vous bénéficiez d’une vision d’ensemble sur toutes les candidatures de l'usager, y compris celles déposées par d’autres organisations ou par l'usager lui-même. Cette visibilité étendue est rendue possible car votre structure a réalisé une action visant à faciliter son entrée dans un parcours d’insertion ou à favoriser son maintien dans celui-ci.
                                           </p>
                                           <p class="mb-0">
                                               <a class="btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/44496401665297" rel="noopener noreferrer" target="_blank">
@@ -4202,15 +4202,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -4220,7 +4220,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -4504,15 +4504,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -4534,7 +4534,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -4799,15 +4799,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -4817,7 +4817,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -5022,15 +5022,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -5040,7 +5040,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -5300,15 +5300,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -5330,7 +5330,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -5595,15 +5595,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -5613,7 +5613,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -5818,15 +5818,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -5841,7 +5841,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>
@@ -7159,15 +7159,15 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidat : DOE Jane
+                                  DOE Jane
                               </h1>
                               <p id="copy_public_id">
-                                  Copier l'ID du candidat
+                                  Copier l'ID de l'usager
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="copied_jobseeker_public_id" type="button">
                                       <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                       </i>
                                       <span class="visually-hidden">
-                                          Copier
+                                          Copier l'ID de l'usager
                                       </span>
                                   </button>
                               </p>
@@ -7182,7 +7182,7 @@
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour ce candidat
+                                      Postuler pour cet usager
                                   </span>
                               </a>
                           </div>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -11,7 +11,7 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidats
+                                  Accompagnements
                               </h1>
                           </div>
                           <div aria-label="Actions sur les candidatures" class="c-title__cta" role="group">
@@ -19,14 +19,14 @@
                                   <i aria-hidden="true" class="ri-user-add-line fw-medium">
                                   </i>
                                   <span>
-                                      Créer un compte candidat
+                                      Créer un compte usager
                                   </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" href="/search/employers/results">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour un candidat
+                                      Postuler pour un usager
                                   </span>
                               </a>
                           </div>
@@ -34,12 +34,12 @@
                       <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
                           <li class="nav-item">
                               <a class="nav-link" href="/job-seekers/list">
-                                  Mes candidats
+                                  Mes accompagnements
                               </a>
                           </li>
                           <li class="nav-item">
                               <a class="nav-link active" href="/job-seekers/list-organization">
-                                  Tous les candidats de la structure
+                                  Tous les accompagnements de la structure
                               </a>
                           </li>
                       </ul>
@@ -162,7 +162,7 @@
               <div class="s-section__row row">
                   <div class="col-12">
                       <h2>
-                          Tous les candidats de la structure
+                          Tous les accompagnements de la structure
                       </h2>
                   </div>
               </div>
@@ -244,7 +244,7 @@
                               </div>
                               <div class="dropdown">
                                   <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown" type="button">
-                                      Candidat sans solution
+                                      Usagers sans solution
                                   </button>
                                   <ul class="dropdown-menu">
                                       <li>
@@ -252,7 +252,7 @@
                                               <div class="form-check">
                                                   <input class="form-check-input is-valid" id="id_is_stalled" name="is_stalled" type="checkbox"/>
                                                   <label class="form-check-label" for="id_is_stalled">
-                                                      N’afficher que les candidats sans solution
+                                                      N’afficher que les usagers sans solution
                                                   </label>
                                               </div>
                                           </div>
@@ -262,7 +262,7 @@
                                       </li>
                                       <li>
                                           <a class="btn btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" rel="noopener" target="_blank">
-                                              Qu’est-ce qu’un candidat sans solution ?
+                                              Qu’est-ce qu’un usager sans solution
                                           </a>
                                       </li>
                                   </ul>
@@ -294,9 +294,9 @@
                           <div class="flex-column flex-md-row mt-3 mt-md-0">
                               <div class="w-lg-400px">
                                   <label class="visually-hidden" for="id_job_seeker">
-                                      Nom du candidat
+                                      Nom de l'usager
                                   </label>
-                                  <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du candidat" data-theme="bootstrap-5" id="id_job_seeker" lang="fr" name="job_seeker">
+                                  <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom de l'usager" data-theme="bootstrap-5" id="id_job_seeker" lang="fr" name="job_seeker">
                                       <option selected="" value="">
                                       </option>
                                   </select>
@@ -308,7 +308,7 @@
                               <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-card-no-result.png"/>
                               <p class="mb-1 mt-3">
                                   <strong>
-                                      Aucun candidat pour le moment
+                                      Aucun usager pour le moment
                                   </strong>
                               </p>
                           </div>
@@ -333,7 +333,7 @@
                       <div class="c-title">
                           <div class="c-title__main">
                               <h1>
-                                  Candidats
+                                  Accompagnements
                               </h1>
                           </div>
                           <div aria-label="Actions sur les candidatures" class="c-title__cta" role="group">
@@ -341,14 +341,14 @@
                                   <i aria-hidden="true" class="ri-user-add-line fw-medium">
                                   </i>
                                   <span>
-                                      Créer un compte candidat
+                                      Créer un compte usager
                                   </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" href="/search/employers/results">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
                                   <span>
-                                      Postuler pour un candidat
+                                      Postuler pour un usager
                                   </span>
                               </a>
                           </div>
@@ -356,12 +356,12 @@
                       <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
                           <li class="nav-item">
                               <a class="nav-link active" href="/job-seekers/list">
-                                  Mes candidats
+                                  Mes accompagnements
                               </a>
                           </li>
                           <li class="nav-item">
                               <a class="nav-link" href="/job-seekers/list-organization">
-                                  Tous les candidats de la structure
+                                  Tous les accompagnements de la structure
                               </a>
                           </li>
                       </ul>
@@ -467,7 +467,7 @@
               <div class="s-section__row row">
                   <div class="col-12">
                       <h2>
-                          Mes candidats
+                          Mes accompagnements
                       </h2>
                   </div>
               </div>
@@ -549,7 +549,7 @@
                               </div>
                               <div class="dropdown">
                                   <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown" type="button">
-                                      Candidat sans solution
+                                      Usagers sans solution
                                   </button>
                                   <ul class="dropdown-menu">
                                       <li>
@@ -557,7 +557,7 @@
                                               <div class="form-check">
                                                   <input class="form-check-input is-valid" id="id_is_stalled" name="is_stalled" type="checkbox"/>
                                                   <label class="form-check-label" for="id_is_stalled">
-                                                      N’afficher que les candidats sans solution
+                                                      N’afficher que les usagers sans solution
                                                   </label>
                                               </div>
                                           </div>
@@ -567,7 +567,7 @@
                                       </li>
                                       <li>
                                           <a class="btn btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" rel="noopener" target="_blank">
-                                              Qu’est-ce qu’un candidat sans solution ?
+                                              Qu’est-ce qu’un usager sans solution
                                           </a>
                                       </li>
                                   </ul>
@@ -590,9 +590,9 @@
                           <div class="flex-column flex-md-row mt-3 mt-md-0">
                               <div class="w-lg-400px">
                                   <label class="visually-hidden" for="id_job_seeker">
-                                      Nom du candidat
+                                      Nom de l'usager
                                   </label>
-                                  <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du candidat" data-theme="bootstrap-5" id="id_job_seeker" lang="fr" name="job_seeker">
+                                  <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom de l'usager" data-theme="bootstrap-5" id="id_job_seeker" lang="fr" name="job_seeker">
                                       <option selected="" value="">
                                       </option>
                                   </select>
@@ -604,7 +604,7 @@
                               <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-card-no-result.png"/>
                               <p class="mb-1 mt-3">
                                   <strong>
-                                      Aucun candidat pour le moment
+                                      Aucun usager pour le moment
                                   </strong>
                               </p>
                           </div>
@@ -1604,7 +1604,7 @@
   '''
   <table class="table table-hover table-sortable">
       <caption class="visually-hidden">
-          Liste des candidats (les colonnes disposant d’un bouton dans leur entête peuvent être triées en cliquant sur le bouton)
+          Liste des usagers (les colonnes disposant d’un bouton dans leur entête peuvent être triées en cliquant sur le bouton)
       </caption>
       <thead>
           <tr>
@@ -1631,7 +1631,7 @@
               </th>
               <th class="text-end w-100px" scope="col">
                   <span class="visually-hidden">
-                      Actions possibles sur les candidats
+                      Actions possibles sur les usagers
                   </span>
               </th>
           </tr>
@@ -1660,7 +1660,7 @@
                   30/08/2024
               </td>
               <td class="text-end w-100px">
-                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=44444444-4444-4444-4444-444444444444">
+                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=44444444-4444-4444-4444-444444444444">
                       <i aria-label="Postuler pour WATERFORD David" class="ri-draft-line">
                       </i>
                   </a>
@@ -1683,8 +1683,8 @@
                   <a class="btn-link" href="/job-seekers/details/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list">
                       YGREC Bernard
                   </a>
-                  <span aria-label="Candidat sans solution" class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                      <i aria-hidden="true" class="ri-user-forbid-line" data-bs-title="Candidat sans solution" data-bs-toggle="tooltip">
+                  <span aria-label="Usager sans solution" class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                      <i aria-hidden="true" class="ri-user-forbid-line" data-bs-title="Usager sans solution" data-bs-toggle="tooltip">
                       </i>
                   </span>
               </td>
@@ -1705,7 +1705,7 @@
                   30/08/2024
               </td>
               <td class="text-end w-100px">
-                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&city=brest-29">
+                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&city=brest-29">
                       <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                       </i>
                   </a>
@@ -1721,7 +1721,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="1"/>
                           <button class="dropdown-item" type="submit">
-                              Le candidat n'est plus sans solution
+                              L'usager n'est plus sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -1753,7 +1753,7 @@
                   28/08/2024
               </td>
               <td class="text-end w-100px">
-                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
+                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
                       <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
                       </i>
                   </a>
@@ -1766,7 +1766,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="0"/>
                           <button class="dropdown-item" type="submit">
-                              Le candidat est sans solution
+                              L'usager est sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -1780,8 +1780,8 @@
                   <a class="btn-link" href="/job-seekers/details/11111111-1111-1111-1111-111111111111?back_url=/job-seekers/list">
                       ZORRO Alain
                   </a>
-                  <span aria-label="Candidat sans solution" class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                      <i aria-hidden="true" class="ri-user-forbid-line" data-bs-title="Candidat sans solution" data-bs-toggle="tooltip">
+                  <span aria-label="Usager sans solution" class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                      <i aria-hidden="true" class="ri-user-forbid-line" data-bs-title="Usager sans solution" data-bs-toggle="tooltip">
                       </i>
                   </span>
               </td>
@@ -1802,7 +1802,7 @@
                   28/08/2024
               </td>
               <td class="text-end w-100px">
-                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
+                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
                       <i aria-label="Postuler pour ZORRO Alain" class="ri-draft-line">
                       </i>
                   </a>
@@ -1818,7 +1818,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="1"/>
                           <button class="dropdown-item" type="submit">
-                              Le candidat n'est plus sans solution
+                              L'usager n'est plus sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -2805,7 +2805,7 @@
               30/08/2024
           </td>
           <td class="text-end w-100px">
-              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&city=brest-29">
+              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&city=brest-29">
                   <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                   </i>
               </a>
@@ -2846,7 +2846,7 @@
               29/08/2024
           </td>
           <td class="text-end w-100px">
-              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
+              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
                   <i aria-label="Postuler pour ZORRO Alain" class="ri-draft-line">
                   </i>
               </a>
@@ -2887,7 +2887,7 @@
               31/08/2022
           </td>
           <td class="text-end w-100px">
-              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
+              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour cet usager" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
                   <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
                   </i>
               </a>

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -434,7 +434,7 @@ def test_apply_for_button_as_authorized_prescriber(client):
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'
-            "<span>Postuler pour ce candidat</span>"
+            "<span>Postuler pour cet usager</span>"
             "</a>"
         ),
         html=True,
@@ -453,7 +453,7 @@ def test_apply_for_button_as_authorized_prescriber(client):
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'
-            "<span>Postuler pour ce candidat</span>"
+            "<span>Postuler pour cet usager</span>"
             "</a>"
         ),
         html=True,
@@ -486,7 +486,7 @@ def test_apply_for_button_as_unauthorized_prescriber(client):
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'
-            "<span>Postuler pour ce candidat</span>"
+            "<span>Postuler pour cet usager</span>"
             "</a>"
         ),
         html=True,

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -48,7 +48,7 @@ def assert_contains_button_apply_for(response, job_seeker, with_city=True, with_
         f"""
             <a class="btn btn-sm btn-link btn-ico-only"
                 data-bs-toggle="tooltip"
-                data-bs-title="Postuler pour ce candidat"
+                data-bs-title="Postuler pour cet usager"
                 data-matomo-event="true"
                 data-matomo-category="candidature" data-matomo-action="clic"
                 data-matomo-option="postuler-pour-ce-candidat"
@@ -146,7 +146,7 @@ def test_displayed_tabs(client, user_factory, assertion):
     assertion(
         response,
         f"""<a class="nav-link" href="{reverse("job_seekers_views:list_organization")}">
-        Tous les candidats de la structure</a>""",
+        Tous les accompagnements de la structure</a>""",
         html=True,
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte Notion](https://www.notion.so/gip-inclusion/Remplacer-le-nom-de-la-page-Mes-candidats-3345f321b604800abafbc4c089549e3e)
Le terme de "Candidat" a aussi été remplacé par "Usager"

## :rotating_light: À vérifier

- [x] Faut-il aussi modifier les events matomo ?

## :computer: Captures d'écran <!-- optionnel -->

Liste des accompagnements avant/après : 
<img width="2013" height="557" alt="Capture d&#39;écran_20260518_114410" src="https://github.com/user-attachments/assets/e5a0eeee-a299-40f6-823b-8ffc59f35350" />
<img width="2013" height="573" alt="Capture d&#39;écran_20260518_114546" src="https://github.com/user-attachments/assets/4a59d538-ada2-4e8d-8bdd-ea3f3c8e6b5a" />


Profil d'un usager avant/après : 
<img width="1649" height="156" alt="Capture d&#39;écran_20260518_114455" src="https://github.com/user-attachments/assets/65c2ea30-456d-47c4-bb74-34ec299481c7" />
<img width="1625" height="135" alt="Capture d&#39;écran_20260518_114616" src="https://github.com/user-attachments/assets/2e0d2c1f-58bd-4a0b-8690-6e397c900dc6" />