### PR TITLE
Tech : Pas de cooldown Dependabot pour itoutils

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 5
+      exclude:
+        - "itoutils"
     commit-message:
       prefix: "requirement"
       prefix-development: "dev requirement"


### PR DESCRIPTION
itoutils uses rolling releases. We don't want to wait 5 days to upgrade.
