### PR TITLE
Stabilité : correction d'un mauvais argument passé à `content_disposition_header`

### DIFF
--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -376,7 +376,11 @@ def assessment_get_file(request, pk, *, file_field):
     if file is None:
         raise Http404
     return HttpResponseRedirect(
-        file.url(parameters={"ResponseContentDisposition": content_disposition_header("inline", filename)})
+        file.url(
+            parameters={
+                "ResponseContentDisposition": content_disposition_header(as_attachment=False, filename=filename)
+            }
+        )
     )
 
 

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -825,7 +825,7 @@ class TestAssessmentGetFile:
                                 getattr(assessment, attr_name).key,
                                 parameters={
                                     "ResponseContentDisposition": content_disposition_header(
-                                        "inline", expected_filename
+                                        as_attachment=False, filename=expected_filename
                                     ),
                                 },
                             ),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce qu'on n'aime pas le code qui fait l'inverse de ce qu'il semble faire : correction d’un mauvais argument passé à `content_disposition_header`.

Lors de l'appel à cette fonction, le premier argument attendu correspond au booléen `as_attachment`. Or, l'appel se faisait avec la chaîne `"inline"` qui est toujours _truthy_, ce qui forçait le téléchargement. Ce _commit_ remédie à cette ambiguïté.