### PR TITLE
Stabilité : correction d'un test bagottant lié au fuseau horaire

### DIFF
--- a/tests/api/employee_record_api/tests.py
+++ b/tests/api/employee_record_api/tests.py
@@ -363,9 +363,9 @@ class TestEmployeeRecordAPIParameters:
             "itou.common_apps.address.format.get_geocoding_data",
             side_effect=mock_get_geocoding_data,
         )
-        sooner_ts = timezone.now() - relativedelta(days=3)
+        sooner_ts = timezone.localtime() - relativedelta(days=3)
         sooner = f"{sooner_ts:%Y-%m-%d}"
-        ancient_ts = timezone.now() - relativedelta(months=2)
+        ancient_ts = timezone.localtime() - relativedelta(months=2)
         ancient = f"{ancient_ts:%Y-%m-%d}"
 
         job_application_1 = JobApplicationFactory(sent_by_prescriber_alone=True, for_employee_record=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le test corrigé échouait me semble-t-il entre 22h et minuit heure de Paris. Cette correction aligne le test sur `timezone.localtime()` pour éviter un décalage et stabiliser le test.