### PR TITLE
Admin: ajout de validation d'entrée pour les uid ASP

### DIFF
--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -76,6 +76,9 @@ class JobSeekerProfileAdminForm(forms.ModelForm):
             "asp_uid": widgets.AdminTextInputWidget,
         }
 
+    def clean_asp_uid(self):
+        return self.cleaned_data.get("asp_uid").lower()
+
 
 FakeField = namedtuple("FakeField", ("name",))
 

--- a/itou/users/migrations/0001_initial.py
+++ b/itou/users/migrations/0001_initial.py
@@ -809,6 +809,12 @@ class Migration(migrations.Migration):
                         max_length=30,
                         unique=True,
                         verbose_name="ID unique envoyé à l'ASP",
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                r"^[0-9a-f]{30}$",
+                                "L'ID unique envoyé à l'ASP doit être composé de 30 caractères hexadécimaux.",
+                            ),
+                        ],
                     ),
                 ),
                 (

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -937,6 +937,12 @@ class JobSeekerProfile(AbstractFieldsHistoryModel):
         max_length=30,
         blank=True,
         unique=True,
+        validators=[
+            RegexValidator(
+                r"^[0-9a-f]{30}$",
+                "L'ID unique envoyé à l'ASP doit être composé de 30 caractères hexadécimaux.",
+            ),
+        ],
     )
 
     education_level = models.CharField(

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -273,15 +273,37 @@ JOBSEEKERPROFILE_FORMSETS_PAYLOAD = {
 }
 
 
-def test_change_asp_uid(admin_client):
-    profile = JobSeekerProfileFactory(asp_uid="000000000000000000000000000000")
+@pytest.mark.parametrize(
+    "submitted_asp_uid, expected_asp_uid, expects_error",
+    [
+        ("57d76450cd919cc770d1fe9d2ca0f7", "57d76450cd919cc770d1fe9d2ca0f7", False),
+        ("", "d2f4adaea3c94c498322d38aa1768e", False),  # expected generated asp_uid for an user_id of 42
+        ("57D76450CD919CC770D1FE9D2CA0F7", "57d76450cd919cc770d1fe9d2ca0f7", False),
+        ("000000001", "000000000000000000000000000000", True),
+        (
+            "e53ff9a0-2e52-46b2-bda1-76083b",
+            "000000000000000000000000000000",
+            True,
+        ),
+    ],
+    ids=[
+        "valid",
+        "expects_reset",
+        "uppercase",
+        "too_short",
+        "not_hexadecimal",
+    ],
+)
+def test_change_asp_uid(admin_client, submitted_asp_uid, expected_asp_uid, expects_error):
+    # force user_id to get a deterministic asp_uid
+    profile = JobSeekerProfileFactory(asp_uid="000000000000000000000000000000", user__pk=42)
 
-    admin_client.post(
+    response = admin_client.post(
         reverse("admin:users_jobseekerprofile_change", kwargs={"object_id": profile.pk}),
         {
             "_continue": "Enregistrer+et+continuer+les+modifications",
             "user": profile.user.pk,
-            "asp_uid": "000000000000000000000000000001",
+            "asp_uid": submitted_asp_uid,
             "birthdate": profile.birthdate.isoformat(),
             "birth_place": "",
             "birth_country": "",
@@ -311,13 +333,18 @@ def test_change_asp_uid(admin_client):
         },
     )
     profile.refresh_from_db()
-    assert profile.asp_uid == "000000000000000000000000000001"
+    assert profile.asp_uid == expected_asp_uid
+    if expects_error:
+        assertContains(
+            response, "L'ID unique envoyé à l'ASP doit être composé de 30 caractères hexadécimaux.", html=True
+        )
+        return
     assert normalize_fields_history(profile.fields_history) == [
         {
             "_context": {"request_id": "[REQUEST ID]", "user": get_user(admin_client).pk},
             "_timestamp": "[TIMESTAMP]",
             "before": {"asp_uid": "000000000000000000000000000000"},
-            "after": {"asp_uid": "000000000000000000000000000001"},
+            "after": {"asp_uid": expected_asp_uid},
         }
     ]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

TLDR:  le champs de formulaire `asp_uid` acceptait des caractères non-alphanumériques (tirets, p.e)

https://www.notion.so/gip-inclusion/ID-ITOU-autoriser-uniquement-entre-29-et-30-caract-res-alphanum-riques-ni-ni-3495f321b6048090a769d531e68cd5fb

Léo a suggéré de paramétriser le test existant, et de d'également test le cas où l'utilisateur soumet un champs vide, ce qui régénérera un uid asp.

La paramétrisation du test l'a rendu un peu plus complexe (3 paramètres, 1 condition, 6 cas, retrait des string litterals du corps du test pour des variables). Peut-être que ça nous va, peut-être qu'on veut trois tests séparés, mais vu le corps du payload et vu que les 3 tests seraient très similaires, je ne parviens pas à trancher 🤷‍♂️ 

Finalement [j'ai fait une PR d'aperçu pour montrer à quoi ça ressemblerait](https://github.com/gip-inclusion/les-emplois/pull/8079). EDIT: plus à jour avec les derniers changements

Comme c'est ma première PR, je me permets de mettre plusieurs devs qui ont travaillé sur le fichier de test en revue, pour avoir plus de feedbacks.

J'ai pris la liberté de mettre un label "no-changelog", dites-moi si c'est incorrect.

## :cake: Comment ? <!-- optionnel -->

`RegexValidator` Le max_length du champ texte génère un MaxLengthValidator. Le validateur de longueur s'exécute avant le RegexValidator.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Rentrer une valeur de moins de 30 caractères avec des tirets dans le profile du job seeker dans l'admin, tout simplement.

## :computer: Captures d'écran <!-- optionnel -->

<img width="710" height="380" alt="Capture d’écran 2026-05-20 à 11 05 57" src="https://github.com/user-attachments/assets/153b5709-4278-4765-9920-7559b5126c5a" />


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
