### PR TITLE
Stabilité : correction d'un test bagottant du fait de la contrainte `unique_ddets_per_department`

### DIFF
--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -485,7 +485,8 @@ class TestViewProof:
         (lambda: JobSeekerFactory(), 403),
         (lambda: PrescriberFactory(membership=True), 403),
         (lambda: CompanyMembershipFactory(company__evaluable_kind=True).user, 404),
-        (lambda: InstitutionMembershipFactory().user, 404),
+        # '12' below could actually be anything else than 14, see also EvaluationCampaignFactory
+        (lambda: InstitutionMembershipFactory(institution__department="12").user, 404),
     ],
     ids=["job_seeker", "prescriber", "unrelated_employer", "unrelated_inspector"],
 )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le test `test_campaign_calendar_denies_unauthorized` était instable et susceptible d'aboutir à une une erreur `IntegrityError: duplicate key value violates unique constraint "unique_ddets_per_department"`.

Cela se produisait car `EvaluationCampaignFactory` crée par défaut une institution rattachée au département "14". Le cas de test paramétré `unrelated_inspector` faisait appel à `InstitutionMembershipFactory()`, qui attribue les départements via un itérateur global. Selon l'ordre d'exécution aléatoire des tests (`--randomly-seed`), si l'itérateur tombait sur "14", cela créait un conflit en base de données.

## :cake: Comment ?

Le cas de figure `unrelated_inspector` impose désormais un département différent (`institution__department="12"`). Ce `12` est aussi arbitrairement choisi que le `14` dans la `EvaluationCampaignFactory` (tout du moins je ne vois pas la raison du "14" ?). Cela rend le test plus stable.