### PR TITLE
Stabilité : amélioration des commandes d'archivage et d'anonymisation

### DIFF
--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -11,7 +11,7 @@ from itou.archive.anonymize import (
 )
 from itou.archive.constants import GRACE_PERIOD
 from itou.archive.tasks import async_delete_contact
-from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+from itou.archive.utils import exclude_users_with_blocking_relations
 from itou.users.models import User, UserKind
 from itou.users.notifications import ArchiveUser
 from itou.utils.command import BaseCommand
@@ -91,10 +91,9 @@ class Command(BaseCommand):
         )
 
     def get_users_to_anonymize_and_delete(self, users):
-        related_objects_to_check = get_filter_kwargs_on_user_for_related_objects_to_check()
         return list(
             annotate_and_prefetch_for_anonymization(
-                User.objects.filter(id__in=[user.id for user in users]).filter(**related_objects_to_check)
+                exclude_users_with_blocking_relations(User.objects.filter(id__in=[user.id for user in users]))
             )
         )
 

--- a/itou/archive/management/commands/cleanup_ea_eatt_members.py
+++ b/itou/archive/management/commands/cleanup_ea_eatt_members.py
@@ -8,7 +8,7 @@ from itou.archive.anonymize import (
     anonymize_professionals_without_deletion,
 )
 from itou.archive.tasks import async_delete_contact
-from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+from itou.archive.utils import exclude_users_with_blocking_relations
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, CompanyMembership
 from itou.institutions.models import InstitutionMembership
@@ -97,9 +97,10 @@ class Command(BaseCommand):
         total_anonymized = 0
         total_removed_from_contact = 0
         for batch_ids in self._batched(user_ids):
-            related_objects_to_check = get_filter_kwargs_on_user_for_related_objects_to_check()
             deletable_ids = set(
-                User.objects.filter(id__in=batch_ids).filter(**related_objects_to_check).values_list("id", flat=True)
+                exclude_users_with_blocking_relations(User.objects.filter(id__in=batch_ids)).values_list(
+                    "id", flat=True
+                )
             )
 
             users = list(annotate_and_prefetch_for_anonymization(User.objects.filter(id__in=batch_ids)))

--- a/itou/archive/utils.py
+++ b/itou/archive/utils.py
@@ -13,16 +13,38 @@ from itou.siae_evaluations.models import EvaluatedJobApplication
 from itou.users.models import User, UserKind
 
 
-def get_filter_kwargs_on_user_for_related_objects_to_check():
+def get_user_reverse_relations(is_cascade):
+    fields = []
+    for field in User._meta.get_fields(include_hidden=True):
+        if not (field.is_relation and field.auto_created and not field.concrete):
+            continue
+        on_delete = getattr(field, "on_delete", None)
+        if not on_delete:
+            continue
+        if is_cascade != (on_delete == models.CASCADE):
+            continue
+        fields.append(field)
+    return fields
+
+
+def exclude_users_with_blocking_relations(qs):
+    """Narrow a `User` queryset to users that have no non-CASCADE reverse FK rows pointing at them.
+
+    Returned instances correspond to users we can actually `.delete()` without hitting `RestrictedError`
+    or `ProtectedError`.
+
+    This function also covers relations declared with `related_name="+"`, which `User._meta.related_objects`
+    silently skips because Django marks them hidden. Using `_base_manager` is intentional: a soft-deleted
+    related row or a filtered-by-default row hidden by a custom default manager could still hold the FK that
+    would block `.delete()`.
     """
-    Returns a dictionary of filter parameters to check for objects related
-    to the User model that are not cascade deleted.
-    """
-    return {
-        f"{obj.name}__isnull": True
-        for obj in User._meta.related_objects
-        if getattr(obj, "on_delete", None) and obj.on_delete != models.CASCADE
-    }
+    exists_clauses = [
+        Exists(field.related_model._base_manager.filter(**{field.field.name: OuterRef("pk")}))
+        for field in get_user_reverse_relations(is_cascade=False)
+    ]
+    if not exists_clauses:
+        return qs
+    return qs.exclude(Q(*exists_clauses, _connector=Q.OR))
 
 
 def get_year_month_or_none(date=None):

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -1109,44 +1109,6 @@
                     AND U0."user_id" = ("users_user"."id"))
              LIMIT 1) AS "has_membership_in_authorized_organization"
           FROM "users_user"
-          LEFT OUTER JOIN "approvals_approval" ON ("users_user"."id" = "approvals_approval"."created_by_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."approval_manually_delivered_by_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" T4 ON ("users_user"."id" = T4."approval_manually_refused_by_id")
-          LEFT OUTER JOIN "approvals_approval" T5 ON ("users_user"."id" = T5."user_id")
-          LEFT OUTER JOIN "approvals_suspension" ON ("users_user"."id" = "approvals_suspension"."created_by_id")
-          LEFT OUTER JOIN "geiq_assessments_assessmenttransitionlog" ON ("users_user"."id" = "geiq_assessments_assessmenttransitionlog"."user_id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_user"."id" = "prescribers_prescriberorganization"."authorization_updated_by_id")
-          LEFT OUTER JOIN "companies_contract" ON ("users_user"."id" = "companies_contract"."job_seeker_id")
-          LEFT OUTER JOIN "geiq_assessments_assessment" ON ("users_user"."id" = "geiq_assessments_assessment"."created_by_id")
-          LEFT OUTER JOIN "companies_company" ON ("users_user"."id" = "companies_company"."created_by_id")
-          LEFT OUTER JOIN "gps_followupgroupmembership" ON ("users_user"."id" = "gps_followupgroupmembership"."creator_id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" T13 ON ("users_user"."id" = T13."created_by_id")
-          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."author_id")
-          LEFT OUTER JOIN "geiq_assessments_assessment" T15 ON ("users_user"."id" = T15."final_reviewed_by_id")
-          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("users_user"."id" = "eligibility_geiqeligibilitydiagnosis"."author_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" T17 ON ("users_user"."id" = T17."job_seeker_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" T18 ON ("users_user"."id" = T18."sender_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" T19 ON ("users_user"."id" = T19."transferred_by_id")
-          LEFT OUTER JOIN "job_applications_jobapplicationcomment" ON ("users_user"."id" = "job_applications_jobapplicationcomment"."created_by_id")
-          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("users_user"."id" = "job_applications_jobapplicationtransitionlog"."user_id")
-          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."professional_id")
-          LEFT OUTER JOIN "approvals_prolongationrequest" ON ("users_user"."id" = "approvals_prolongationrequest"."processed_by_id")
-          LEFT OUTER JOIN "approvals_prolongationrequest" T24 ON ("users_user"."id" = T24."assigned_to_id")
-          LEFT OUTER JOIN "approvals_prolongationrequest" T25 ON ("users_user"."id" = T25."created_by_id")
-          LEFT OUTER JOIN "approvals_prolongationrequest" T26 ON ("users_user"."id" = T26."declared_by_id")
-          LEFT OUTER JOIN "approvals_prolongationrequest" T27 ON ("users_user"."id" = T27."updated_by_id")
-          LEFT OUTER JOIN "approvals_prolongation" ON ("users_user"."id" = "approvals_prolongation"."created_by_id")
-          LEFT OUTER JOIN "approvals_prolongation" T29 ON ("users_user"."id" = T29."declared_by_id")
-          LEFT OUTER JOIN "approvals_prolongation" T30 ON ("users_user"."id" = T30."updated_by_id")
-          LEFT OUTER JOIN "approvals_prolongation" T31 ON ("users_user"."id" = T31."validated_by_id")
-          LEFT OUTER JOIN "companies_siaeconvention" ON ("users_user"."id" = "companies_siaeconvention"."reactivated_by_id")
-          LEFT OUTER JOIN "geiq_assessments_assessment" T33 ON ("users_user"."id" = T33."reviewed_by_id")
-          LEFT OUTER JOIN "geiq_assessments_assessment" T34 ON ("users_user"."id" = T34."submitted_by_id")
-          LEFT OUTER JOIN "approvals_suspension" T35 ON ("users_user"."id" = T35."updated_by_id")
-          LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."updated_by_id")
-          LEFT OUTER JOIN "institutions_institutionmembership" ON ("users_user"."id" = "institutions_institutionmembership"."updated_by_id")
-          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."updated_by_id")
-          LEFT OUTER JOIN "users_user" T39 ON ("users_user"."id" = T39."created_by_id")
           WHERE ("users_user"."id" IN (%s,
                                        %s,
                                        %s,
@@ -1156,44 +1118,211 @@
                                        %s,
                                        %s,
                                        %s)
-                 AND "approvals_approval"."id" IS NULL
-                 AND "job_applications_jobapplication"."id" IS NULL
-                 AND T4."id" IS NULL
-                 AND T5."id" IS NULL
-                 AND "approvals_suspension"."id" IS NULL
-                 AND "geiq_assessments_assessmenttransitionlog"."id" IS NULL
-                 AND "prescribers_prescriberorganization"."id" IS NULL
-                 AND "companies_contract"."id" IS NULL
-                 AND "geiq_assessments_assessment"."id" IS NULL
-                 AND "companies_company"."id" IS NULL
-                 AND "gps_followupgroupmembership"."id" IS NULL
-                 AND T13."id" IS NULL
-                 AND "eligibility_eligibilitydiagnosis"."id" IS NULL
-                 AND T15."id" IS NULL
-                 AND "eligibility_geiqeligibilitydiagnosis"."id" IS NULL
-                 AND T17."id" IS NULL
-                 AND T18."id" IS NULL
-                 AND T19."id" IS NULL
-                 AND "job_applications_jobapplicationcomment"."id" IS NULL
-                 AND "job_applications_jobapplicationtransitionlog"."id" IS NULL
-                 AND "users_jobseekerassignment"."id" IS NULL
-                 AND "approvals_prolongationrequest"."id" IS NULL
-                 AND T24."id" IS NULL
-                 AND T25."id" IS NULL
-                 AND T26."id" IS NULL
-                 AND T27."id" IS NULL
-                 AND "approvals_prolongation"."id" IS NULL
-                 AND T29."id" IS NULL
-                 AND T30."id" IS NULL
-                 AND T31."id" IS NULL
-                 AND "companies_siaeconvention"."id" IS NULL
-                 AND T33."id" IS NULL
-                 AND T34."id" IS NULL
-                 AND T35."id" IS NULL
-                 AND "companies_companymembership"."id" IS NULL
-                 AND "institutions_institutionmembership"."id" IS NULL
-                 AND "prescribers_prescribermembership"."id" IS NULL
-                 AND T39."id" IS NULL)
+                 AND NOT ((EXISTS
+                             (SELECT %s AS "a"
+                              FROM "companies_company" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "companies_companymembership" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "companies_siaeconvention" U0
+                              WHERE U0."reactivated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "companies_contract" U0
+                              WHERE U0."job_seeker_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "users_user" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "users_nirmodificationrequest" U0
+                              WHERE U0."requested_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "users_jobseekerassignment" U0
+                              WHERE U0."professional_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "prescribers_prescriberorganization" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "prescribers_prescriberorganization" U0
+                              WHERE U0."authorization_updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "prescribers_prescribermembership" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "institutions_institutionmembership" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."job_seeker_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."sender_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."archived_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."approval_manually_delivered_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."approval_manually_refused_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplication" U0
+                              WHERE U0."transferred_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplicationtransitionlog" U0
+                              WHERE U0."user_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "job_applications_jobapplicationcomment" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_approval" U0
+                              WHERE U0."user_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_approval" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_suspension" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_suspension" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongationrequest" U0
+                              WHERE U0."declared_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongationrequest" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongationrequest" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongationrequest" U0
+                              WHERE U0."assigned_to_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongationrequest" U0
+                              WHERE U0."processed_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongation" U0
+                              WHERE U0."declared_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongation" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongation" U0
+                              WHERE U0."updated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "approvals_prolongation" U0
+                              WHERE U0."validated_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "eligibility_geiqeligibilitydiagnosis" U0
+                              WHERE U0."author_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "eligibility_eligibilitydiagnosis" U0
+                              WHERE U0."author_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "employee_record_employeerecordtransitionlog" U0
+                              WHERE U0."user_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "geiq_assessments_assessment" U0
+                              WHERE U0."created_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "geiq_assessments_assessment" U0
+                              WHERE U0."submitted_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "geiq_assessments_assessment" U0
+                              WHERE U0."reviewed_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "geiq_assessments_assessment" U0
+                              WHERE U0."final_reviewed_by_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "geiq_assessments_assessmenttransitionlog" U0
+                              WHERE U0."user_id" = ("users_user"."id")
+                              LIMIT 1)
+                           OR EXISTS
+                             (SELECT %s AS "a"
+                              FROM "gps_followupgroupmembership" U0
+                              WHERE U0."creator_id" = ("users_user"."id")
+                              LIMIT 1))))
           ORDER BY RANDOM() ASC
         ''',
       }),

--- a/tests/archive/__snapshots__/tests_utils.ambr
+++ b/tests/archive/__snapshots__/tests_utils.ambr
@@ -1,116 +1,339 @@
 # serializer version: 1
-# name: TestRelatedObjectsConsistency.test_get_filter_kwargs_on_user_for_related_objects_to_check[filter_kwargs_on_user_for_related_objects_to_check]
-  dict({
-    'approval__isnull': True,
-    'approval_manually_delivered__isnull': True,
-    'approval_manually_refused__isnull': True,
-    'approvals__isnull': True,
-    'approvals_suspended_set__isnull': True,
-    'assessmenttransitionlog__isnull': True,
-    'authorization_status_set__isnull': True,
-    'contracts__isnull': True,
-    'created_assessments__isnull': True,
-    'created_company_set__isnull': True,
-    'created_follow_up_groups__isnull': True,
-    'created_prescriber_organization_set__isnull': True,
-    'eligibilitydiagnosis__isnull': True,
-    'final_reviewed_assessments__isnull': True,
-    'geiqeligibilitydiagnosis__isnull': True,
-    'job_applications__isnull': True,
-    'job_applications_sent__isnull': True,
-    'jobapplication__isnull': True,
-    'jobapplicationcomment__isnull': True,
-    'jobapplicationtransitionlog__isnull': True,
-    'professional_assignments__isnull': True,
-    'prolongationrequest_processed__isnull': True,
-    'prolongationrequests_assigned__isnull': True,
-    'prolongationrequests_created__isnull': True,
-    'prolongationrequests_declared__isnull': True,
-    'prolongationrequests_updated__isnull': True,
-    'prolongations_created__isnull': True,
-    'prolongations_declared__isnull': True,
-    'prolongations_updated__isnull': True,
-    'prolongations_validated__isnull': True,
-    'reactivated_siae_convention_set__isnull': True,
-    'reviewed_assessments__isnull': True,
-    'submitted_assessments__isnull': True,
-    'suspension__isnull': True,
-    'updated_companymembership_set__isnull': True,
-    'updated_institutionmembership_set__isnull': True,
-    'updated_prescribermembership_set__isnull': True,
-    'user__isnull': True,
-  })
-# ---
-# name: TestRelatedObjectsConsistency.test_user_related_objects_deleted_on_cascade[user_related_objects_deleted_on_cascade]
+# name: TestRelatedObjectsConsistency.test_user_related_objects_blocking_deletion[False]
   list([
     dict({
-      'logentry': <class 'django.contrib.admin.models.LogEntry'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'approvals.Approval',
     }),
     dict({
-      'auth_token': <class 'rest_framework.authtoken.models.Token'>,
+      'field': 'user',
+      'hidden': False,
+      'model': 'approvals.Approval',
     }),
     dict({
-      'totpdevice': <class 'django_otp.plugins.otp_totp.models.TOTPDevice'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'approvals.Prolongation',
     }),
     dict({
-      'emailaddress': <class 'allauth.account.models.EmailAddress'>,
+      'field': 'declared_by',
+      'hidden': False,
+      'model': 'approvals.Prolongation',
     }),
     dict({
-      'companymembership': <class 'itou.companies.models.CompanyMembership'>,
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'approvals.Prolongation',
     }),
     dict({
-      'jobseeker_profile': <class 'itou.users.models.JobSeekerProfile'>,
+      'field': 'validated_by',
+      'hidden': False,
+      'model': 'approvals.Prolongation',
     }),
     dict({
-      'job_seeker_assignments': <class 'itou.users.models.JobSeekerAssignment'>,
+      'field': 'assigned_to',
+      'hidden': False,
+      'model': 'approvals.ProlongationRequest',
     }),
     dict({
-      'prescribermembership': <class 'itou.prescribers.models.PrescriberMembership'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'approvals.ProlongationRequest',
     }),
     dict({
-      'institutionmembership': <class 'itou.institutions.models.InstitutionMembership'>,
+      'field': 'declared_by',
+      'hidden': False,
+      'model': 'approvals.ProlongationRequest',
     }),
     dict({
-      'geiq_eligibility_diagnoses': <class 'itou.eligibility.models.geiq.GEIQEligibilityDiagnosis'>,
+      'field': 'processed_by',
+      'hidden': False,
+      'model': 'approvals.ProlongationRequest',
     }),
     dict({
-      'eligibility_diagnoses': <class 'itou.eligibility.models.iae.EligibilityDiagnosis'>,
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'approvals.ProlongationRequest',
     }),
     dict({
-      'prescriber_org_invitations': <class 'itou.invitations.models.PrescriberWithOrgInvitation'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'approvals.Suspension',
     }),
     dict({
-      'company_invitations': <class 'itou.invitations.models.EmployerInvitation'>,
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'approvals.Suspension',
     }),
     dict({
-      'institution_invitations': <class 'itou.invitations.models.LaborInspectorInvitation'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'companies.Company',
     }),
     dict({
-      'externaldataimport': <class 'itou.external_data.models.ExternalDataImport'>,
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'companies.CompanyMembership',
     }),
     dict({
-      'jobseekerexternaldata': <class 'itou.external_data.models.JobSeekerExternalData'>,
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'companies.Contract',
     }),
     dict({
-      'saved_searches': <class 'itou.search.models.SavedSearch'>,
+      'field': 'reactivated_by',
+      'hidden': False,
+      'model': 'companies.SiaeConvention',
     }),
     dict({
-      'notification_settings': <class 'itou.communications.models.NotificationSettings'>,
+      'field': 'author',
+      'hidden': False,
+      'model': 'eligibility.EligibilityDiagnosis',
     }),
     dict({
-      'follow_up_group': <class 'itou.gps.models.FollowUpGroup'>,
+      'field': 'author',
+      'hidden': False,
+      'model': 'eligibility.GEIQEligibilityDiagnosis',
     }),
     dict({
-      'follow_up_groups': <class 'itou.gps.models.FollowUpGroupMembership'>,
+      'field': 'user',
+      'hidden': True,
+      'model': 'employee_record.EmployeeRecordTransitionLog',
     }),
     dict({
-      'rdvi_invitation_requests': <class 'itou.rdv_insertion.models.InvitationRequest'>,
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'geiq_assessments.Assessment',
     }),
     dict({
-      'rdvi_participations': <class 'itou.rdv_insertion.models.Participation'>,
+      'field': 'final_reviewed_by',
+      'hidden': False,
+      'model': 'geiq_assessments.Assessment',
     }),
     dict({
-      'activated_services': <class 'itou.nexus.models.ActivatedService'>,
+      'field': 'reviewed_by',
+      'hidden': False,
+      'model': 'geiq_assessments.Assessment',
+    }),
+    dict({
+      'field': 'submitted_by',
+      'hidden': False,
+      'model': 'geiq_assessments.Assessment',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'geiq_assessments.AssessmentTransitionLog',
+    }),
+    dict({
+      'field': 'creator',
+      'hidden': False,
+      'model': 'gps.FollowUpGroupMembership',
+    }),
+    dict({
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'institutions.InstitutionMembership',
+    }),
+    dict({
+      'field': 'approval_manually_delivered_by',
+      'hidden': False,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'approval_manually_refused_by',
+      'hidden': False,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'archived_by',
+      'hidden': True,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'sender',
+      'hidden': False,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'transferred_by',
+      'hidden': False,
+      'model': 'job_applications.JobApplication',
+    }),
+    dict({
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'job_applications.JobApplicationComment',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'job_applications.JobApplicationTransitionLog',
+    }),
+    dict({
+      'field': 'updated_by',
+      'hidden': False,
+      'model': 'prescribers.PrescriberMembership',
+    }),
+    dict({
+      'field': 'authorization_updated_by',
+      'hidden': False,
+      'model': 'prescribers.PrescriberOrganization',
+    }),
+    dict({
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'prescribers.PrescriberOrganization',
+    }),
+    dict({
+      'field': 'professional',
+      'hidden': False,
+      'model': 'users.JobSeekerAssignment',
+    }),
+    dict({
+      'field': 'requested_by',
+      'hidden': True,
+      'model': 'users.NirModificationRequest',
+    }),
+    dict({
+      'field': 'created_by',
+      'hidden': False,
+      'model': 'users.User',
+    }),
+  ])
+# ---
+# name: TestRelatedObjectsConsistency.test_user_related_objects_blocking_deletion[True]
+  list([
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'account.EmailAddress',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'admin.LogEntry',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'authtoken.Token',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'communications.NotificationSettings',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'companies.CompanyMembership',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'eligibility.EligibilityDiagnosis',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'eligibility.GEIQEligibilityDiagnosis',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'external_data.ExternalDataImport',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'external_data.JobSeekerExternalData',
+    }),
+    dict({
+      'field': 'beneficiary',
+      'hidden': False,
+      'model': 'gps.FollowUpGroup',
+    }),
+    dict({
+      'field': 'member',
+      'hidden': False,
+      'model': 'gps.FollowUpGroupMembership',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'institutions.InstitutionMembership',
+    }),
+    dict({
+      'field': 'sender',
+      'hidden': False,
+      'model': 'invitations.EmployerInvitation',
+    }),
+    dict({
+      'field': 'sender',
+      'hidden': False,
+      'model': 'invitations.LaborInspectorInvitation',
+    }),
+    dict({
+      'field': 'sender',
+      'hidden': False,
+      'model': 'invitations.PrescriberWithOrgInvitation',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'nexus.ActivatedService',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'otp_totp.TOTPDevice',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'prescribers.PrescriberMembership',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'rdv_insertion.InvitationRequest',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'rdv_insertion.Participation',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'search.SavedSearch',
+    }),
+    dict({
+      'field': 'job_seeker',
+      'hidden': False,
+      'model': 'users.JobSeekerAssignment',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': False,
+      'model': 'users.JobSeekerProfile',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': True,
+      'model': 'users.User_groups',
+    }),
+    dict({
+      'field': 'user',
+      'hidden': True,
+      'model': 'users.User_user_permissions',
     }),
   ])
 # ---

--- a/tests/archive/test_cleanup_ea_eatt_members.py
+++ b/tests/archive/test_cleanup_ea_eatt_members.py
@@ -7,11 +7,13 @@ from django.core.management import call_command
 from itou.archive.models import AnonymizedProfessional
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, CompanyMembership
-from itou.users.models import User
+from itou.users.models import NirModificationRequest, User
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
+from tests.employee_record.factories import EmployeeRecordTransitionLogFactory
 from tests.institutions.factories import InstitutionMembershipFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
+from tests.users.factories import JobSeekerFactory
 
 
 pytestmark = pytest.mark.django_db
@@ -94,6 +96,54 @@ class TestCleanupEaEattMembers:
         assert user.is_active is False
         assert user.email is None
         assert user.phone == ""
+        assert AnonymizedProfessional.objects.count() == 0
+
+    def test_user_with_archived_job_application_is_anonymized_without_deletion(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, user__email="pro@example.com")
+        user = membership.user
+        job_app = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            archived_at="2025-01-01T00:00:00Z",
+            archived_by=user,
+        )
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        user.refresh_from_db()
+        assert user.is_active is False
+        assert user.email is None
+        assert AnonymizedProfessional.objects.count() == 0
+        job_app.refresh_from_db()
+        assert job_app.archived_by_id == user.id
+
+    def test_user_with_nir_modification_request_is_anonymized_without_deletion(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, user__email="pro@example.com")
+        user = membership.user
+        job_seeker = JobSeekerFactory()
+        NirModificationRequest.objects.create(
+            jobseeker_profile=job_seeker.jobseeker_profile,
+            nir="269054958815780",
+            requested_by=user,
+        )
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        user.refresh_from_db()
+        assert user.is_active is False
+        assert user.email is None
+        assert AnonymizedProfessional.objects.count() == 0
+        assert NirModificationRequest.objects.filter(requested_by=user).exists()
+
+    def test_user_with_employee_record_transition_log_is_anonymized_without_deletion(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, user__email="pro@example.com")
+        user = membership.user
+        EmployeeRecordTransitionLogFactory(user=user)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        user.refresh_from_db()
+        assert user.is_active is False
+        assert user.email is None
         assert AnonymizedProfessional.objects.count() == 0
 
     def test_dry_run_makes_no_changes(self):

--- a/tests/archive/tests_utils.py
+++ b/tests/archive/tests_utils.py
@@ -1,36 +1,52 @@
 import datetime
 
 import pytest
-from django.db import models
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from itou.archive.utils import (
     count_related_subquery,
-    get_filter_kwargs_on_user_for_related_objects_to_check,
+    exclude_users_with_blocking_relations,
+    get_user_reverse_relations,
     get_year_month_or_none,
 )
 from itou.invitations.models import EmployerInvitation
 from itou.users.models import User
 from tests.invitations.factories import EmployerInvitationFactory
+from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import EmployerFactory
 
 
 class TestRelatedObjectsConsistency:
-    # Theses tests aims to prevent any add or update FK relationship on User model
-    # that would not be handled by the management command `notify_archive_users`.
-    # If one of these tests fails, consider looking at this command and updating it
-    def test_get_filter_kwargs_on_user_for_related_objects_to_check(self, snapshot):
-        filter_kwargs = get_filter_kwargs_on_user_for_related_objects_to_check()
-        assert filter_kwargs == snapshot(name="filter_kwargs_on_user_for_related_objects_to_check")
+    def test_exclude_users_with_blocking_relations(self):
+        # Smoke test: a user with a reverse FK to a non-CASCADE relation must be
+        # excluded from the queryset, including hidden relations
+        clean = EmployerFactory()
+        blocked = EmployerFactory()
+        # JobApplication.archived_by has on_delete=PROTECT, so it should block deletion
+        # even if it has related_name="+" (which makes it hidden to User._meta.related_objects)
+        JobApplicationFactory(sent_by_prescriber_alone=True, archived_at="2025-01-01T00:00:00Z", archived_by=blocked)
+        result_ids = set(
+            exclude_users_with_blocking_relations(User.objects.filter(id__in=[clean.id, blocked.id])).values_list(
+                "id", flat=True
+            )
+        )
+        assert clean.id in result_ids
+        assert blocked.id not in result_ids
 
-    def test_user_related_objects_deleted_on_cascade(self, snapshot):
-        user_related_objects = [
-            {obj.name: obj.related_model}
-            for obj in User._meta.related_objects
-            if getattr(obj, "on_delete", None) and obj.on_delete == models.CASCADE
+    @pytest.mark.parametrize("is_cascade", [True, False])
+    def test_user_related_objects_blocking_deletion(self, is_cascade, snapshot):
+        """Needs to be updated if a new CASCADE / non-CASCADE relation to User is added."""
+        relations = [
+            {
+                "model": field.related_model._meta.label,
+                "field": field.field.name,
+                "hidden": field.hidden,
+            }
+            for field in get_user_reverse_relations(is_cascade=is_cascade)
         ]
-        assert user_related_objects == snapshot(name="user_related_objects_deleted_on_cascade")
+        relations.sort(key=lambda r: (r["model"], r["field"]))
+        assert relations == snapshot()
 
 
 class TestCountRelatedSubquery:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce _commit_ traite un bug de suppression d’utilisateurs dans les commandes d’archivage/anonymisation.
Certaines relations inverses vers `User` utilisent `related_name="+"` et sont donc cachées par Django dans `User._meta.related_objects`.
Ces relations non-CASCADE (par exemple `JobApplication.archived_by`, `NirModificationRequest.requested_by` et `EmployeeRecordTransitionLog.user`) pouvaient masquer le fait qu’un utilisateur ne peut pas être supprimé, ce qui provoquait une `RestrictedError`.

## :cake: Comment ?

La logique a été remplacée par `exclude_users_with_blocking_relations(qs)` dans `itou/archive/utils.py`.
Cette fonction parcourt `User._meta.get_fields(include_hidden=True)` pour trouver toutes les relations inverses auto-créées non concrètes et dont `on_delete != CASCADE`.
Pour chaque relation bloquante, elle ajoute un `Exists(...)` et exclut les utilisateurs ayant au moins une ligne liée.

Les commandes `anonymize_professionals` et `cleanup_ea_eatt_members` utilisent désormais cette fonction au lieu de l’ancien filtre basé sur `User._meta.related_objects`.

## :desert_island: Comment tester ?

`pytest tests/archive/tests_utils.py tests/archive/test_cleanup_ea_eatt_members.py`