### PR TITLE
Interface: Appliquer les nouvelles règles aux pages de formulaires "job seeker"

### DIFF
--- a/itou/templates/companies/update_admins.html
+++ b/itou/templates/companies/update_admins.html
@@ -19,7 +19,7 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="companies_views" %}
                         {% include "includes/update_admin.html" %}
                     {% endwith %}

--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -2,6 +2,7 @@
 {% load components %}
 
 <div class="c-form">
+    <h2 class="h3">Retirer de la structure</h2>
     {% with request.from_employer|yesno:"structure,organisation" as org_display %}
         {% component_alert content=content variant="warning" icon=False %}
             {% fragment as content %}

--- a/itou/templates/includes/update_admin.html
+++ b/itou/templates/includes/update_admin.html
@@ -2,6 +2,14 @@
 {% load components %}
 
 <div class="c-form">
+    <h2 class="h3">
+        {% if action == "remove" %}
+            Retirer
+        {% else %}
+            Ajouter
+        {% endif %}
+        les droits d'administrateur
+    </h2>
     {% with request.from_employer|yesno:"structure,organisation" as org_display %}
         {% component_alert content=content variant="warning" icon=False %}
             {% fragment as content %}

--- a/itou/templates/institutions/update_admins.html
+++ b/itou/templates/institutions/update_admins.html
@@ -19,7 +19,7 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="institutions_views" %}
                         {% include "includes/update_admin.html" %}
                     {% endwith %}

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -29,7 +29,7 @@
             <div class="row">
                 <div class="col-12">
                     <div class="c-form">
-                        <h3 class="h4">Renseignez les informations de vos collaborateurs</h3>
+                        <h2 class="h3">Renseignez les informations de vos collaborateurs</h2>
 
                         <form method="post" action="{{ form_post_url }}" class="js-prevent-multiple-submit">
                             {% csrf_token %}

--- a/itou/templates/itou_staff_views/import_aci_convergence_phc.html
+++ b/itou/templates/itou_staff_views/import_aci_convergence_phc.html
@@ -21,8 +21,8 @@
             <div class="row">
                 <div class="col-12">
                     {% if request.method == "POST" %}
-                        <div class="c-box mb-5">
-                            <h2>Résultats de l’import</h2>
+                        <div class="c-box mb-3 mb-md-4">
+                            <h2 class="h3">Résultats de l’import</h2>
                             <p>{{ sirets_in_file }} SIRET dans le document.</p>
 
                             <h3>Ajouté{{ to_add|length|pluralizefr }}</h3>
@@ -46,7 +46,7 @@
                     {% endif %}
 
                     <div class="c-form">
-                        <h2>Fichier à importer</h2>
+                        <h2 class="h3">Fichier à importer</h2>
                         <p>
                             Le fichier peut contenir plusieurs feuilles. Dans chaque feuille, une colonne intitulée « SIRET » doit contenir le SIRET d’une ACI Convergence ou PHC. Les espaces et caractères spéciaux sont ignorés.
                         </p>

--- a/itou/templates/itou_staff_views/import_fs_3437_from_asp.html
+++ b/itou/templates/itou_staff_views/import_fs_3437_from_asp.html
@@ -21,8 +21,8 @@
             <div class="row">
                 <div class="col-12">
                     {% if request.method == "POST" %}
-                        <div class="c-box mb-5">
-                            <h2>Résultats de l’import</h2>
+                        <div class="c-box mb-3 md-md-4">
+                            <h2 class="h3">Résultats de l’import</h2>
                             <p>{{ results|length }} ligne{{ results|pluralizefr }} traitée{{ results|pluralizefr }}.</p>
                             {% component_alert content=content variant=wet_run|yesno:"success,warning" %}
                                 {% fragment as content %}
@@ -73,7 +73,7 @@
                     {% endif %}
 
                     <div class="c-form">
-                        <h2>Fichier à importer</h2>
+                        <h2 class="h3">Fichier à importer</h2>
                         <p>
                             Dans la feuille principale, une colonne intitulée « idItou » doit contenir l’ancien identifiant itou et la colonne Commentaires le nouveau.
                         </p>

--- a/itou/templates/job_seekers_views/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/job_seekers_views/create_or_update_job_seeker/step_base.html
@@ -47,7 +47,7 @@
                         </p>
                     </div>
                     <div class="c-form">
-                        <h2>
+                        <h2 class="h3">
                             {% block step_title %}{% endblock %}
                         </h2>
                         {% if readonly_form %}
@@ -61,7 +61,6 @@
                                 {% endfragment %}
                             {% endcomponent_alert %}
                         {% endif %}
-                        <hr class="mt-5">
                         {% bootstrap_form_errors form type="all" %}
                         <form method="post" class="js-collapsable-subfields js-format-nir"{% if matomo_form_name|default:"" %} data-matomo-name="{{ matomo_form_name }}"{% endif %}>
                             {% csrf_token %}

--- a/itou/templates/job_seekers_views/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/job_seekers_views/create_or_update_job_seeker/step_end.html
@@ -59,6 +59,7 @@
                         <p id="currentProgressState">Validation des informations</p>
                     </div>
                     <div class="c-form">
+                        <h2 class="h3">Validation des informations</h2>
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
 

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -31,8 +31,24 @@
                     <div class="tab-content">
                         <div class="tab-pane fade show active">
                             <div class="row">
-                                <div class="col-12 {% if approval %}col-xxl-8 col-xxxl-9 order-2 order-xxl-1{% endif %}">
-                                    <h2>Informations générales</h2>
+                                <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                        <h2 class="mb-0">Informations générales</h2>
+                                        <div class="d-flex flex-column flex-md-row gap-2">
+                                            {% if can_edit_iae_eligibility %}
+                                                <a href="{% url 'eligibility_views:update_iae' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-ico btn-secondary">
+                                                    <i class="ri-checkbox-circle-line fw-normal" aria-hidden="true"></i>
+                                                    {% if iae_eligibility_diagnosis %}
+                                                        <span>Mettre à jour son éligibilité IAE</span>
+                                                    {% else %}
+                                                        <span>Valider son éligibilité IAE</span>
+                                                    {% endif %}
+                                                </a>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12{% if approval %} col-xxl-8 col-xxxl-9{% endif %} order-3 order-xxl-2">
                                     <div class="c-box mb-3 mb-md-4">
                                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=None with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}
                                     </div>
@@ -45,7 +61,7 @@
                                     {% include "gps/includes/membership_referent.html" %}
                                 </div>
                                 {% if approval %}
-                                    <div class="col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 mt-xxl-6">
+                                    <div class="col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                                         {% approval_details_box approval=approval version='box' request=request extra_classes='mb-3 mb-md-4' %}
                                     </div>
                                 {% endif %}

--- a/itou/templates/job_seekers_views/includes/detail_title_content.html
+++ b/itou/templates/job_seekers_views/includes/detail_title_content.html
@@ -13,9 +13,9 @@
 
     {% fragment as c_title__cta %}
         {% if services_search_url %}
-            <a href="{{ services_search_url }}" class="btn btn-lg bin-ico btn-secondary" {% matomo_event "candidat" "clic" service_search_event_option %} id="introjs-orienter-vers-service-insertion">
+            <a href="{{ services_search_url }}" class="btn btn-lg btn-ico btn-secondary" {% matomo_event "candidat" "clic" service_search_event_option %} id="introjs-orienter-vers-service-insertion">
                 <i class="ri-user-location-line fw-medium" aria-hidden="true"></i>
-                Orienter vers un service d’insertion
+                <span>Orienter vers un service d’insertion</span>
             </a>
         {% endif %}
         {% url 'search:employers_results' as search_url %}
@@ -40,6 +40,5 @@
             <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
             <span>Postuler pour cet usager</span>
         </a>
-
     {% endfragment %}
 {% endcomponent_title %}

--- a/itou/templates/job_seekers_views/includes/detail_title_content.html
+++ b/itou/templates/job_seekers_views/includes/detail_title_content.html
@@ -25,17 +25,6 @@
             {% url_add_query search_url job_seeker_public_id=job_seeker.public_id as url_query %}
         {% endif %}
 
-        {% if can_edit_iae_eligibility %}
-            <a href="{% url 'eligibility_views:update_iae' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-secondary">
-                <i class="ri-checkbox-circle-line fw-medium" aria-hidden="true"></i>
-                {% if iae_eligibility_diagnosis %}
-                    <span>Mettre à jour son éligibilité IAE</span>
-                {% else %}
-                    <span>Valider son éligibilité IAE</span>
-                {% endif %}
-            </a>
-        {% endif %}
-
         <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
             <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
             <span>Postuler pour cet usager</span>

--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -47,6 +47,7 @@
 {% block left_column %}
     <form method="post" class="js-prevent-multiple-submit js-format-nir">
         <div class="c-form">
+            <h2 class="h3">{% include 'apply/includes/_submit_title.html' %}</h2>
             {% csrf_token %}
 
             {% bootstrap_form_errors form type="all" %}

--- a/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
+++ b/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
@@ -9,6 +9,7 @@
 {% block left_column %}
     <form method="post" class="js-prevent-multiple-submit js-format-nir">
         <div class="c-form">
+            <h2 class="h3">Créer un compte pour votre {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}</h2>
             {% if nir %}
                 <div class="form-group form-group-required form-group-input-w-lg-66">
                     <label for="id_nir">Numéro de sécurité sociale du {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}</label>
@@ -16,13 +17,12 @@
                 </div>
             {% endif %}
 
-            {% component_alert title=title content=content variant="info" extra_classes="mb-3" %}
-                {% fragment as title %}
-                    Créer un compte pour votre {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}
-                {% endfragment %}
+            {% component_alert content=content variant="info" extra_classes="mb-3" %}
                 {% fragment as content %}
                     <p class="mb-0">
-                        Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale. Merci de renseigner l'adresse e-mail de votre {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }} pour l'inscrire.
+                        Aucun utilisateur n'est inscrit avec ce numéro de sécurité sociale.
+                        <br>
+                        Merci de renseigner l'adresse e-mail de votre {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }} pour l'inscrire.
                     </p>
                 {% endfragment %}
             {% endcomponent_alert %}

--- a/itou/templates/prescribers/update_admins.html
+++ b/itou/templates/prescribers/update_admins.html
@@ -19,7 +19,7 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="prescribers_views" %}
                         {% include "includes/update_admin.html" %}
                     {% endwith %}

--- a/itou/templates/siae_evaluations/evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/evaluated_job_application.html
@@ -84,6 +84,7 @@
                 {% if request.from_institution and not evaluated_siae.evaluation_is_final and not evaluated_job_application.accepted_from_certified_criteria %}
                     <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                         <div class="c-form my-3 my-md-4">
+                            <h2 class="h3">Ajouter un commentaire</h2>
                             <form method="post" class="js-prevent-multiple-submit">
                                 {% csrf_token %}
 

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -2,18 +2,17 @@
 {% load django_bootstrap5 %}
 
 <form method="post" role="form" class="js-prevent-multiple-submit">
+    <h2 class="h3">Critères administratifs déclarés lors de l'embauche</h2>
 
     {% csrf_token %}
-
     {% bootstrap_form_errors form_administrative_criteria type="all" %}
 
-    <h3 class="h2">Critères administratifs déclarés lors de l'embauche</h3>
     <p>
         Vous devez justifier l’embauche du salarié en sélectionnant soit 1 critère administratif de niveau 1, soit {{ form_administrative_criteria.num_level2_admin_criteria }} critères administratifs de niveau 2.
     </p>
 
     {% if level_1_fields %}
-        <h3>Niveau 1</h3>
+        <h3 class="h4">Niveau 1</h3>
 
         {% for field in level_1_fields %}
             {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS %}
@@ -21,7 +20,7 @@
     {% endif %}
 
     {% if level_2_fields %}
-        <h3>Niveau 2</h3>
+        <h3 class="h4">Niveau 2</h3>
 
         {% for field in level_2_fields %}
             {# notice that eligibility/includes/iae/criteria_input.html requires form_administrative_criteria.OBJECTS #}

--- a/itou/templates/signup/includes/no_email_link.html
+++ b/itou/templates/signup/includes/no_email_link.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% if not exclude_button|default:False %}
-    <a href="#" data-bs-toggle="modal" data-bs-target="#no-email-modal">{{ link_text }}</a>
+    <a href="#" class="btn-link" data-bs-toggle="modal" data-bs-target="#no-email-modal">{{ link_text }}</a>
 {% endif %}
 
 <div class="modal fade" id="no-email-modal" tabindex="-1" role="dialog" aria-labelledby="no-email-modal-label" aria-modal="true">

--- a/itou/templates/static/legal/terms/base.html
+++ b/itou/templates/static/legal/terms/base.html
@@ -27,7 +27,7 @@
                 <div class="s-section__col col-12">
                     {% if require_acceptance %}
                         <div class="c-form">
-                            <h2>
+                            <h2 class="h3">
                                 Prenez connaissance des
                                 {% if is_update %}nouvelles{% endif %}
                                 Conditions Générales d'Utilisation

--- a/tests/www/itou_staff_views/__snapshots__/tests.ambr
+++ b/tests/www/itou_staff_views/__snapshots__/tests.ambr
@@ -2796,8 +2796,8 @@
 # ---
 # name: TestImportAciConvergencePHC.test_import_file_summary
   '''
-  <div class="c-box mb-5">
-      <h2>
+  <div class="c-box mb-3 mb-md-4">
+      <h2 class="h3">
           Résultats de l’import
       </h2>
       <p>
@@ -2825,8 +2825,8 @@
 # ---
 # name: TestImportFS3437FromAsp.test_import_file[dry run]
   '''
-  <div class="c-box mb-5">
-      <h2>
+  <div class="c-box mb-3 md-md-4">
+      <h2 class="h3">
           Résultats de l’import
       </h2>
       <p>
@@ -2934,8 +2934,8 @@
 # ---
 # name: TestImportFS3437FromAsp.test_import_file[wet run]
   '''
-  <div class="c-box mb-5">
-      <h2>
+  <div class="c-box mb-3 md-md-4">
+      <h2 class="h3">
           Résultats de l’import
       </h2>
       <p>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -35,10 +35,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-contracts" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fcontracts%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-contracts" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fcontracts%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
@@ -267,7 +269,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -561,7 +563,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -800,10 +802,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
@@ -849,7 +853,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -1040,10 +1044,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
@@ -1089,7 +1095,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -1380,10 +1386,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
@@ -1429,7 +1437,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -1706,10 +1714,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-job-applications" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fjob_applications%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-job-applications" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fjob_applications%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
@@ -2936,10 +2946,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-job-applications" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fjob_applications%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-job-applications" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fjob_applications%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
@@ -4248,7 +4260,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -4518,10 +4530,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
@@ -4567,7 +4581,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -4845,7 +4859,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -5068,7 +5082,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -5314,10 +5328,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
@@ -5363,7 +5379,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -5641,7 +5657,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12">
+                                  <div class="col-12 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -5832,10 +5848,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
@@ -5874,7 +5892,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -6018,7 +6036,7 @@
                                           </div>
                                       </div>
                                   </div>
-                                  <div class="col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 mt-xxl-6">
+                                  <div class="col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                                       <div class="c-box c-box--pass bg-success-lightest border-success mb-3 mb-md-4">
                                           <div class="mb-3 mb-md-4">
                                               <span class="badge badge-base rounded-pill bg-success text-white">
@@ -7173,10 +7191,12 @@
                               </p>
                           </div>
                           <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
-                              <a class="btn btn-lg bin-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
+                              <a class="btn btn-lg btn-ico btn-secondary" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-details-general" href="/search/services/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&back_url=%2Fjob-seekers%2Fdetails%2F7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35" id="introjs-orienter-vers-service-insertion">
                                   <i aria-hidden="true" class="ri-user-location-line fw-medium">
                                   </i>
-                                  Orienter vers un service d’insertion
+                                  <span>
+                                      Orienter vers un service d’insertion
+                                  </span>
                               </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
@@ -7215,7 +7235,7 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1 order-3 order-xxl-2">
                                       <h2>
                                           Informations générales
                                       </h2>
@@ -7409,7 +7429,7 @@
                                           </div>
                                       </div>
                                   </div>
-                                  <div class="col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 mt-xxl-6">
+                                  <div class="col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                                       <div class="c-box c-box--pass bg-success-lightest border-success mb-3 mb-md-4">
                                           <div class="mb-3 mb-md-4">
                                               <span class="badge badge-base rounded-pill bg-success text-white">

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -269,10 +269,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -563,10 +569,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -809,13 +821,6 @@
                                       Orienter vers un service d’insertion
                                   </span>
                               </a>
-                              <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Valider son éligibilité IAE
-                                  </span>
-                              </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
@@ -853,10 +858,23 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                              <a class="btn btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-normal">
+                                                  </i>
+                                                  <span>
+                                                      Valider son éligibilité IAE
+                                                  </span>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -1051,13 +1069,6 @@
                                       Orienter vers un service d’insertion
                                   </span>
                               </a>
-                              <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Mettre à jour son éligibilité IAE
-                                  </span>
-                              </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
@@ -1095,10 +1106,23 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                              <a class="btn btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-normal">
+                                                  </i>
+                                                  <span>
+                                                      Mettre à jour son éligibilité IAE
+                                                  </span>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -1393,13 +1417,6 @@
                                       Orienter vers un service d’insertion
                                   </span>
                               </a>
-                              <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Valider son éligibilité IAE
-                                  </span>
-                              </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
@@ -1437,10 +1454,23 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                              <a class="btn btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-normal">
+                                                  </i>
+                                                  <span>
+                                                      Valider son éligibilité IAE
+                                                  </span>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -4260,10 +4290,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -4537,13 +4573,6 @@
                                       Orienter vers un service d’insertion
                                   </span>
                               </a>
-                              <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Valider son éligibilité IAE
-                                  </span>
-                              </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
@@ -4581,10 +4610,23 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                              <a class="btn btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-normal">
+                                                  </i>
+                                                  <span>
+                                                      Valider son éligibilité IAE
+                                                  </span>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -4859,10 +4901,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -5082,10 +5130,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -5335,13 +5389,6 @@
                                       Orienter vers un service d’insertion
                                   </span>
                               </a>
-                              <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Mettre à jour son éligibilité IAE
-                                  </span>
-                              </a>
                               <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&city=rennes-35">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium">
                                   </i>
@@ -5379,10 +5426,23 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                              <a class="btn btn-ico btn-secondary" href="/eligibility/update/iae/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                                                  <i aria-hidden="true" class="ri-checkbox-circle-line fw-normal">
+                                                  </i>
+                                                  <span>
+                                                      Mettre à jour son éligibilité IAE
+                                                  </span>
+                                              </a>
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -5657,10 +5717,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
                                   <div class="col-12 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -5892,10 +5958,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
+                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-3 order-xxl-2">
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">
@@ -7235,10 +7307,16 @@
                       <div class="tab-content">
                           <div class="tab-pane fade show active">
                               <div class="row">
-                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1 order-3 order-xxl-2">
-                                      <h2>
-                                          Informations générales
-                                      </h2>
+                                  <div class="col-12 col-xxl-12 order-1 order-xxl-1">
+                                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+                                          <h2 class="mb-0">
+                                              Informations générales
+                                          </h2>
+                                          <div class="d-flex flex-column flex-md-row gap-2">
+                                          </div>
+                                      </div>
+                                  </div>
+                                  <div class="col-12 col-xxl-8 col-xxxl-9 order-3 order-xxl-2">
                                       <div class="c-box mb-3 mb-md-4">
                                           <div class="row mb-3">
                                               <div class="col-12 col-sm">

--- a/tests/www/job_seekers_views/test_search_services.py
+++ b/tests/www/job_seekers_views/test_search_services.py
@@ -11,14 +11,14 @@ from tests.users.factories import JobSeekerAssignmentFactory, JobSeekerFactory
 
 def details_markup(expected_url):
     return f"""<a href="{escape(expected_url)}"
-                  class="btn btn-lg bin-ico btn-secondary"
+                  class="btn btn-lg btn-ico btn-secondary"
                   data-matomo-event="true"
                   data-matomo-category="candidat"
                   data-matomo-action="clic"
                   data-matomo-option="services-search-from-details-general"
                   id="introjs-orienter-vers-service-insertion">
                    <i class="ri-user-location-line fw-medium" aria-hidden="true"></i>
-                   Orienter vers un service d’insertion
+                   <span>Orienter vers un service d’insertion</span>
                </a>"""
 
 
@@ -28,14 +28,14 @@ def details_url(job_seeker):
 
 def job_applications_markup(expected_url):
     return f"""<a href="{escape(expected_url)}"
-                  class="btn btn-lg bin-ico btn-secondary"
+                  class="btn btn-lg btn-ico btn-secondary"
                   data-matomo-event="true"
                   data-matomo-category="candidat"
                   data-matomo-action="clic"
                   data-matomo-option="services-search-from-details-job-applications"
                   id="introjs-orienter-vers-service-insertion">
                    <i class="ri-user-location-line fw-medium" aria-hidden="true"></i>
-                   Orienter vers un service d’insertion
+                   <span>Orienter vers un service d’insertion</span>
                </a>"""
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque qu'on a des [règles maintenant ](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-form-detail--docs) et de nombreux [exemples d'incohérences](https://www.notion.so/gip-inclusion/UX-UI-Lister-les-cas-red-finir-les-r-gles-ux-ui-des-titres-sous-titres-puis-harmoniser-dans-les-f-3025f321b60480e28782f1f1e7d84061) 
Aussi pour harmoniser avec les différentes tailles de titres des [pages details](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-box-detail--docs)


## :cake: Comment ? <!-- optionnel -->

Dans les templates restant

Principalement en corrigeant les tailles des titres de `c-form`.
A savoir, toujours au moins un titre (avec un look `.h3`) en intro de `c-form`.

Soit:
- en `<h3>` (mais dans ce cas il faut au moins un `<h2>` dans la page)
- en `<h2 class="h3">`
- ou idéalement en `<fieldset> + <legend class="h3">`


🧹  En passant, modification de l'emplacement du bouton "Valider son éligibilité IAE/ Mettre à jour son éligibilité IAE" pour le placer dans la zone du CTA des onglets prévus a cet effet ( à droite du titre h2 de l'onglet)