### PR TITLE
Notifications : Désactivation de la campagne AFPA

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -13,7 +13,6 @@ from django.utils.csp import CSP
 from dotenv import load_dotenv
 
 from config.sentry import sentry_init
-from itou.common_apps.address.departments import REGIONS
 from itou.utils.enums import ItouEnvironment
 from itou.utils.urls import markdown_url_set_protocol, markdown_url_set_target_blank
 
@@ -772,21 +771,7 @@ GPS_SLACK_WEBHOOK_URL = os.getenv("GPS_SLACK_WEBHOOK_URL")
 GPS_CONTACT_EMAIL = "contact.gps@inclusion.gouv.fr"
 
 # Afpa
-AFPA_DEPARTMENTS = [
-    department
-    for region in [
-        "Auvergne-Rhône-Alpes",
-        "Bourgogne-Franche-Comté",
-        "Bretagne",
-        "Corse",
-        "Hauts-de-France",
-        "Nouvelle-Aquitaine",
-        "Occitanie",
-        "Pays de la Loire",
-        "Provence-Alpes-Côte d'Azur",
-    ]
-    for department in REGIONS[region]
-]
+AFPA_DEPARTMENTS = []
 
 # Mon récap
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Supprimer-la-campagne-AFPA-Boost-3665f321b60480809a56eef012a29577

## :cake: Comment ? <!-- optionnel -->

En vidant le settings `AFPA_DEPARTMENTS`
