### PR TITLE
Tech : Suppression du feature flag `FEATURE_ENABLE_PROCONNECT_SOFT_MFA`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -762,8 +762,6 @@ DORA_WWW_BASE_URL = os.getenv("DORA_WWW_BASE_URL", "https://dora.inclusion.gouv.
 DORA_API_BASE_URL = os.getenv("DORA_API_BASE_URL", "https://api.dora.inclusion.gouv.fr")
 DORA_API_TOKEN = os.getenv("DORA_API_TOKEN")
 
-FEATURE_ENABLE_PROCONNECT_SOFT_MFA = os.getenv("FEATURE_ENABLE_PROCONNECT_SOFT_MFA", "True") == "True"
-
 # GPS
 # ------------------------------------------------------------------------------
 GPS_GROUPS_CREATED_BY_EMAIL = os.getenv("GPS_GROUPS_CREATED_BY_EMAIL", None)

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -92,38 +92,35 @@ def _generate_pro_params_from_session(pc_data):
         "state": state,
         "nonce": nonce,
     }
-    if settings.FEATURE_ENABLE_PROCONNECT_SOFT_MFA:
-        data.update(
-            {
-                "claims": json.dumps(
-                    {
-                        "id_token": {
-                            # Ask ProConnect to return the `amr` claim, which
-                            # tells us which authentication methods have been
-                            # used.
-                            "amr": {"essential": True},
-                            # Request the use of 2FA _if possible_. Until all
-                            # identity providers implement 2FA, we must NOT
-                            # mention `"essential": True`. If we do, we'll get
-                            # an error in `pro_connect_callback` (missing
-                            # "code" ) that says that the requested ACRs could
-                            # not be satisfied.
-                            "acr": {
-                                "essential": False,
-                                "values": [
-                                    "eidas2",
-                                    "eidas3",
-                                    "https://proconnect.gouv.fr/assurance/self-asserted-2fa",
-                                    "https://proconnect.gouv.fr/assurance/consistency-checked-2fa",
-                                ],
-                            },
+    data.update(
+        {
+            "claims": json.dumps(
+                {
+                    "id_token": {
+                        # Ask ProConnect to return the `amr` claim, which
+                        # tells us which authentication methods have been
+                        # used.
+                        "amr": {"essential": True},
+                        # Request the use of 2FA _if possible_. Until all
+                        # identity providers implement 2FA, we must NOT
+                        # mention `"essential": True`. If we do, we'll get
+                        # an error in `pro_connect_callback` (missing
+                        # "code" ) that says that the requested ACRs could
+                        # not be satisfied.
+                        "acr": {
+                            "essential": False,
+                            "values": [
+                                "eidas2",
+                                "eidas3",
+                                "https://proconnect.gouv.fr/assurance/self-asserted-2fa",
+                                "https://proconnect.gouv.fr/assurance/consistency-checked-2fa",
+                            ],
                         },
-                    }
-                )
-            }
-        )
-    else:
-        data["acr_values"] = "eidas1"
+                    },
+                }
+            )
+        }
+    )
 
     if pc_data.get("channel") == ProConnectChannel.MAP_CONSEILLER:
         data["idp_hint"] = constants.PRO_CONNECT_FT_IDP_HINT
@@ -367,26 +364,25 @@ def pro_connect_callback(request):
         next_url = f"{reverse('pro_connect:logout')}?{urlencode(logout_url_params)}"
         return HttpResponseRedirect(next_url)
 
-    if settings.FEATURE_ENABLE_PROCONNECT_SOFT_MFA:
-        amr = idp_id = None
-        try:
-            id_token_data = _decode_token(token_data["id_token"])
-            amr = id_token_data.get("amr", ())
-            idp_id = user_data.get("idp_id", "")
-            ProConnectAuthentication.objects.create(
-                user_public_id=user.public_id,
-                amr=amr,
-                idp_id=idp_id,
-            )
-        except Exception:
-            logger.exception(
-                "Could not record ProConnect authentication",
-                extra={
-                    "user_public_id": user.public_id,
-                    "amr": amr,
-                    "idp_id": idp_id,
-                },
-            )
+    amr = idp_id = None
+    try:
+        id_token_data = _decode_token(token_data["id_token"])
+        amr = id_token_data.get("amr", ())
+        idp_id = user_data.get("idp_id", "")
+        ProConnectAuthentication.objects.create(
+            user_public_id=user.public_id,
+            amr=amr,
+            idp_id=idp_id,
+        )
+    except Exception:
+        logger.exception(
+            "Could not record ProConnect authentication",
+            extra={
+                "user_public_id": user.public_id,
+                "amr": amr,
+                "idp_id": idp_id,
+            },
+        )
 
     login(request, user)
 

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -15,7 +15,6 @@ from django.contrib.messages import Message
 from django.core import signing
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -397,13 +396,6 @@ class TestProConnectCallbackView:
         assert record.user_public_id == user.public_id
         assert record.amr == ["pwd"]
         assert record.idp_id == "3a47433c-9bf2-48ec-9ac5-33d4fe3afdf7"
-
-    @override_settings(FEATURE_ENABLE_PROCONNECT_SOFT_MFA=False)
-    def test_callback_do_not_record_authentication_if_disabled(self, client, pro_connect):
-        pro_connect.mock_oauth_dance(client, UserKind.PRESCRIBER)
-        user = User.objects.get(email=pro_connect.oidc_userinfo["email"])
-        assert user is not None
-        assert ProConnectAuthentication.objects.count() == 0
 
     def test_callback_existing_django_user(self, client, pro_connect):
         # User created with django already exists on Itou but some attributes differs.


### PR DESCRIPTION
C'était un feature flag pour désactiver la demande de MFA (auprès de ProConnect), pour éviter de casser l'authentification en cas d'erreur d'implémentation ou autre. Le setting est activé depuis plus d'1 mois, pas de problème rapporté : on peut supprimer le feature flag.
