### PR TITLE
Tableau de bord: Maj url pour bandeau d’info webinaire

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -55,7 +55,7 @@
                                 <a class="btn btn-sm btn-primary has-external-link"
                                    target="_blank"
                                    rel="noopener"
-                                   href="https://tally.so/r/b55KY0?event_id=gestion-du-pass-iae-2026-06-16-1777898236003&titre_event=Gestion%20du%20PASS%20IAE&date_event=16%20Juin%202026%20-%2014h00">Je m'inscris</a>
+                                   href="https://tally.so/r/b55KY0?event_id=orientation-vers-l-iae-2026-07-06-1779450573403&titre_event=Orientation%20vers%20l%E2%80%99IAE&date_event=06%20juillet%202026%20-%2011h00">Je m'inscris</a>
                             {% endfragment %}
                         {% endcomponent_alert %}
                         {% include "includes/mon_recap_banner.html" with request=request mon_recap_banner_departments=mon_recap_banner_departments only %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -144,7 +144,7 @@
                 <a class="btn btn-sm btn-primary has-external-link"
                    target="_blank"
                    rel="noopener"
-                   href="https://tally.so/r/b55KY0?event_id=orientation-vers-l-iae-2026-06-18-1777898055204&titre_event=Orientation%20vers%20l%E2%80%99IAE&date_event=18%20Juin%202026%20-%2010h00">Je m'inscris</a>
+                   href="https://tally.so/r/b55KY0?event_id=orientation-vers-l-iae-2026-07-06-1779450573403&titre_event=Orientation%20vers%20l%E2%80%99IAE&date_event=06%20juillet%202026%20-%2011h00">Je m'inscris</a>
             {% endfragment %}
         {% endcomponent_alert %}
     {% endif %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Petite u[rgence](https://www.notion.so/Suppirmer-le-bandeau-d-info-webinaire-sur-la-page-salari-s-et-PASS-IAE-34c5f321b60480c8a91be193ed08cc37?d=e855f321b60482dea8e303b53f32ac80&source=copy_link) qui fait suite a [cette PR](https://github.com/gip-inclusion/les-emplois/pull/7990)