### PR TITLE
Interface: Harmoniser les vues lorsqu'on postule 2 fois pour une même entreprise en moins de 24h

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -212,11 +212,11 @@ class StartViewForSubmit(ApplicationPermissionMixin, View):
 
         self.apply_session = initialize_apply_session(request, session_data)
 
-        # Go directly to step ApplicationJobsView if we're carrying the job seeker public id with us.
+        # Go directly to step CheckPreviousApplicationsForSubmitView if we're carrying the job seeker public id with us
         if job_seeker_tunnel == "sender" and job_seeker:
             return HttpResponseRedirect(
                 reverse(
-                    "apply:application_jobs",
+                    "apply:step_check_prev_applications",
                     kwargs={"session_uuid": self.apply_session.name},
                     query={"job_description_id": job_description_id} if job_description_id else {},
                 )

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -118,8 +118,42 @@ class TestApplyAsPrescriber:
             reverse("apply:start", kwargs={"company_pk": guerande_company.pk})
             + f"?job_seeker_public_id={job_seeker.public_id}"
         )
+
+        # Check previous applications if there are any
+        previous_jobapp = JobApplicationFactory(
+            job_seeker=job_seeker,
+            to_company=guerande_company,
+            sent_by_job_seeker=True,
+        )
         response = client.get(apply_company_url)
         apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Cannot continue if the job application was sent in the last 24 hours
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name}))
+        assert response.status_code == 403
+
+        previous_jobapp.created_at = timezone.now() - relativedelta(days=7)
+        previous_jobapp.save()
+
+        # Session needs to be recreated after it was deleted by trying to access the jobs view
+        response = client.get(apply_company_url)
+        new_apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+        assert new_apply_session_name != apply_session_name
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": new_apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Can still proceed if the job application was sent more than 24 hours ago
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": new_apply_session_name}))
+        assert response.status_code == 200
+
+        previous_jobapp.delete()
+
+        response = client.get(apply_company_url, follow=True)
+        apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND, ignore=[new_apply_session_name])
 
         next_url = reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name})
         assertRedirects(response, next_url)
@@ -287,8 +321,42 @@ class TestApplyAsPrescriber:
             reverse("apply:start", kwargs={"company_pk": guerande_company.pk})
             + f"?job_seeker_public_id={job_seeker.public_id}"
         )
+
+        # Check previous applications if there are any
+        previous_jobapp = JobApplicationFactory(
+            job_seeker=job_seeker,
+            to_company=guerande_company,
+            sent_by_job_seeker=True,
+        )
         response = client.get(apply_company_url)
         apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Cannot continue if the job application was sent in the last 24 hours
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name}))
+        assert response.status_code == 403
+
+        previous_jobapp.created_at = timezone.now() - relativedelta(days=7)
+        previous_jobapp.save()
+
+        # Session needs to be recreated after it was deleted by trying to access the jobs view
+        response = client.get(apply_company_url)
+        new_apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+        assert new_apply_session_name != apply_session_name
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": new_apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Can still proceed if the job application was sent more than 24 hours ago
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": new_apply_session_name}))
+        assert response.status_code == 200
+
+        previous_jobapp.delete()
+
+        response = client.get(apply_company_url, follow=True)
+        apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND, ignore=[new_apply_session_name])
 
         next_url = reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name})
         assertRedirects(response, next_url)
@@ -444,8 +512,42 @@ class TestApplyAsCompany:
             reverse("apply:start", kwargs={"company_pk": other_company.pk})
             + f"?job_seeker_public_id={job_seeker.public_id}"
         )
+
+        # Check previous applications if there are any
+        previous_jobapp = JobApplicationFactory(
+            job_seeker=job_seeker,
+            to_company=other_company,
+            sent_by_job_seeker=True,
+        )
         response = client.get(apply_company_url)
         apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Cannot continue if the job application was sent in the last 24 hours
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name}))
+        assert response.status_code == 403
+
+        previous_jobapp.created_at = timezone.now() - relativedelta(days=7)
+        previous_jobapp.save()
+
+        # Session needs to be recreated after it was deleted by trying to access the jobs view
+        response = client.get(apply_company_url)
+        new_apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+        assert new_apply_session_name != apply_session_name
+
+        next_url = reverse("apply:step_check_prev_applications", kwargs={"session_uuid": new_apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Can still proceed if the job application was sent more than 24 hours ago
+        response = client.get(reverse("apply:application_jobs", kwargs={"session_uuid": new_apply_session_name}))
+        assert response.status_code == 200
+
+        previous_jobapp.delete()
+
+        response = client.get(apply_company_url, follow=True)
+        apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND, ignore=[new_apply_session_name])
 
         next_url = reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name})
         assertRedirects(response, next_url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si, en partant de la page de recherche et en entrant le NIR du candidat manuellement, on postule 2 fois pour une même entreprise en moins de 24h, on atterrit sur une vue qui nous indique le nom de l'entreprise et la date de la dernière candidature.
Si on fait la même chose mais directement depuis le profil du candidat, on atterrit sur une page pas très accueillante dédiée aux erreurs 403, qui n'affiche ni le nom du candidat, ni le nom de l'entreprise.

## :cake: Comment ? <!-- optionnel -->

Lorsqu'on démarre une candidature, plutôt que de rediriger vers la vue de sélection des postes, redirigeons vers la vue de vérification des candidatures précédentes. Le bouton "Annuler" permet en outre de revenir vers les résultats de la recherche.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
Avant :

<img width="1616" height="712" alt="Screenshot from 2026-05-26 09-00-50" src="https://github.com/user-attachments/assets/0ea420bc-ce76-4cd6-8ab4-2d82ca6fa8bd" />

Après : 

<img width="1616" height="712" alt="Screenshot from 2026-05-26 09-02-11" src="https://github.com/user-attachments/assets/b97d93e8-46eb-42b6-8fb8-27efc5cfecd5" />


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
