### PR TITLE
GEIQ : Ajout des données de gestion de contrat (motifs dérogatoires et motif de refus) dans les exports Excel

### DIFF
--- a/itou/www/geiq_assessments_views/export.py
+++ b/itou/www/geiq_assessments_views/export.py
@@ -1,4 +1,4 @@
-from itou.geiq_assessments.enums import AllowanceRefusalReason
+from itou.geiq_assessments.enums import AllowanceJustificationReason, AllowanceRefusalReason
 from itou.utils.export import Format
 
 
@@ -188,6 +188,12 @@ EMPLOYEE_CONTRACT_XLSX_FORMAT = {
     "Type de rupture anticipée": with_format(Format.TEXT, lambda contract: contract.rupture_kind_display()),
     "Situation post-contrat": with_format(
         Format.TEXT, lambda contract: get_libelle(contract.other_data.get("emploi_sorti", {}))
+    ),
+    "Motif de dérogation": with_format(
+        Format.TEXT,
+        lambda contract: get_choice_label(
+            contract.allowance_request_justification_reason, AllowanceJustificationReason
+        ),
     ),
 }
 

--- a/itou/www/geiq_assessments_views/export.py
+++ b/itou/www/geiq_assessments_views/export.py
@@ -1,3 +1,4 @@
+from itou.geiq_assessments.enums import AllowanceRefusalReason
 from itou.utils.export import Format
 
 
@@ -10,6 +11,12 @@ def get_libelle(item):
     if not item:  # item can be a dict or False
         return ""
     return item.get("libelle", "")
+
+
+def get_choice_label(choice, choice_class):
+    if not choice:  # choice can be empty
+        return ""
+    return choice_class(choice).label
 
 
 def oui_non(value):
@@ -194,6 +201,9 @@ def get_export_format(request):
     elif request.from_institution:
         user_fields["Éligible à l’aide"] = with_format(
             Format.TEXT, lambda contract: oui_non(contract.allowance_granted)
+        )
+        user_fields["Motif de refus"] = with_format(
+            Format.TEXT, lambda contract: get_choice_label(contract.allowance_refusal_reason, AllowanceRefusalReason)
         )
     return {**EMPLOYEE_CONTRACT_XLSX_FORMAT, **user_fields}
 

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5026,6 +5026,7 @@
     'Type de rupture anticipée',
     'Situation post-contrat',
     'Éligible à l’aide',
+    'Motif de refus',
   ])
 # ---
 # name: TestAssessmentContractsExportView.test_export[excel export headers for the employer]

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5025,6 +5025,7 @@
     'Date de rupture anticipée',
     'Type de rupture anticipée',
     'Situation post-contrat',
+    'Motif de dérogation',
     'Éligible à l’aide',
     'Motif de refus',
   ])
@@ -5089,6 +5090,7 @@
     'Date de rupture anticipée',
     'Type de rupture anticipée',
     'Situation post-contrat',
+    'Motif de dérogation',
     'Demande d’aide',
   ])
 # ---

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -1591,6 +1591,9 @@ class TestAssessmentContractsExportView:
             allowance_requested=False,
             allowance_granted=False,
         )
+        allowance_justification_reason = random.choice(
+            AllowanceJustificationReason.choices
+        )  # tuple: first value is value, second one is label
         allowance_refusal_reason = random.choice(
             AllowanceRefusalReason.choices
         )  # tuple: first value is value, second one is label
@@ -1603,9 +1606,11 @@ class TestAssessmentContractsExportView:
             employee__birthdate="1992-02-02",
             employee__allowance_amount=814,
             start_at=datetime.date(2024, 2, 1),
-            end_at=datetime.date(2024, 3, 30),
+            end_at=datetime.date(2024, 3, 30),  # less than 90 days
             planned_end_at=datetime.date(2024, 6, 30),
             allowance_requested=True,
+            allowance_request_justification_reason=allowance_justification_reason[0],
+            allowance_request_justification_details="Détails de la dérogation.",
             allowance_granted=False,
             allowance_refusal_reason=allowance_refusal_reason[0],
             allowance_refusal_details="Détails de la justification",
@@ -1637,6 +1642,7 @@ class TestAssessmentContractsExportView:
         assert excel_export[0] == snapshot(name="excel export headers for the employer")
         rupture_anticipee_idx = excel_export[0].index("Date de rupture anticipée")
         allowance_requested_idx = excel_export[0].index("Demande d’aide")
+        allowance_justification_reason_idx = excel_export[0].index("Motif de dérogation")
         assert excel_export[1][:4] == [
             "Dupond",
             "Jean-Pierre",
@@ -1653,12 +1659,14 @@ class TestAssessmentContractsExportView:
         ]
         assert excel_export[2][rupture_anticipee_idx] == datetime.datetime(2024, 4, 30)
         assert excel_export[2][allowance_requested_idx] == "Non"
+        assert excel_export[2][allowance_justification_reason_idx] == ""
         assert excel_export[3][:4] == [
             "Martin",
             "Cécile",
             "F",
             datetime.datetime(1992, 2, 2, 0, 0),
         ]
+        assert excel_export[3][allowance_justification_reason_idx] == allowance_justification_reason[1]
         assert excel_export[3][rupture_anticipee_idx] == datetime.datetime(2024, 3, 30)
         assert excel_export[3][allowance_requested_idx] == "Oui"
 
@@ -1671,6 +1679,7 @@ class TestAssessmentContractsExportView:
         assert response["Content-Disposition"] == 'attachment; filename="Contrats - Un Joli GEIQ - 2025-06-01.xlsx"'
         assert len(excel_export) == 3  # 2 contracts + header
         assert excel_export[0] == snapshot(name="excel export headers for the DDETS")
+        allowance_justification_reason_idx = excel_export[0].index("Motif de dérogation")
         allowance_granted_idx = excel_export[0].index("Éligible à l’aide")
         assert excel_export[1][:4] == [
             "Dupond",
@@ -1678,6 +1687,7 @@ class TestAssessmentContractsExportView:
             "H",
             datetime.datetime(1993, 3, 3, 0, 0),
         ]
+        assert excel_export[1][allowance_justification_reason_idx] == ""
         assert excel_export[1][allowance_granted_idx] == "Oui"
         assert excel_export[1][-1] == ""  # allowance refusal reason
         assert excel_export[2][:4] == [
@@ -1686,5 +1696,6 @@ class TestAssessmentContractsExportView:
             "F",
             datetime.datetime(1992, 2, 2, 0, 0),
         ]
+        assert excel_export[2][allowance_justification_reason_idx] == allowance_justification_reason[1]
         assert excel_export[2][allowance_granted_idx] == "Non"
         assert excel_export[2][-1] == allowance_refusal_reason[1]  # allowance refusal reason

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -1591,6 +1591,9 @@ class TestAssessmentContractsExportView:
             allowance_requested=False,
             allowance_granted=False,
         )
+        allowance_refusal_reason = random.choice(
+            AllowanceRefusalReason.choices
+        )  # tuple: first value is value, second one is label
         EmployeeContractFactory(
             id=uuid.UUID("22222222-4444-4444-4444-444444444444"),
             employee__assessment=assessment,
@@ -1604,6 +1607,8 @@ class TestAssessmentContractsExportView:
             planned_end_at=datetime.date(2024, 6, 30),
             allowance_requested=True,
             allowance_granted=False,
+            allowance_refusal_reason=allowance_refusal_reason[0],
+            allowance_refusal_details="Détails de la justification",
         )
         EmployeeContractFactory(
             id=uuid.UUID("33333333-4444-4444-4444-444444444444"),
@@ -1631,6 +1636,7 @@ class TestAssessmentContractsExportView:
         assert len(excel_export) == 4  # 3 contracts + header
         assert excel_export[0] == snapshot(name="excel export headers for the employer")
         rupture_anticipee_idx = excel_export[0].index("Date de rupture anticipée")
+        allowance_requested_idx = excel_export[0].index("Demande d’aide")
         assert excel_export[1][:4] == [
             "Dupond",
             "Jean-Pierre",
@@ -1638,7 +1644,7 @@ class TestAssessmentContractsExportView:
             datetime.datetime(1993, 3, 3, 0, 0),
         ]
         assert excel_export[1][rupture_anticipee_idx] == ""
-        assert excel_export[1][-1] == "Oui"  # allowance requested
+        assert excel_export[1][allowance_requested_idx] == "Oui"
         assert excel_export[2][:4] == [
             "Dupont",
             "Jean",
@@ -1646,7 +1652,7 @@ class TestAssessmentContractsExportView:
             datetime.datetime(1990, 1, 1, 0, 0),
         ]
         assert excel_export[2][rupture_anticipee_idx] == datetime.datetime(2024, 4, 30)
-        assert excel_export[2][-1] == "Non"  # allowance requested
+        assert excel_export[2][allowance_requested_idx] == "Non"
         assert excel_export[3][:4] == [
             "Martin",
             "Cécile",
@@ -1654,8 +1660,7 @@ class TestAssessmentContractsExportView:
             datetime.datetime(1992, 2, 2, 0, 0),
         ]
         assert excel_export[3][rupture_anticipee_idx] == datetime.datetime(2024, 3, 30)
-        assert excel_export[2][-1] == "Non"  # allowance requested
-        assert excel_export[3][-1] == "Oui"  # allowance requested
+        assert excel_export[3][allowance_requested_idx] == "Oui"
 
         client.force_login(ddets_membership.user)
         response = client.get(url)
@@ -1666,17 +1671,20 @@ class TestAssessmentContractsExportView:
         assert response["Content-Disposition"] == 'attachment; filename="Contrats - Un Joli GEIQ - 2025-06-01.xlsx"'
         assert len(excel_export) == 3  # 2 contracts + header
         assert excel_export[0] == snapshot(name="excel export headers for the DDETS")
+        allowance_granted_idx = excel_export[0].index("Éligible à l’aide")
         assert excel_export[1][:4] == [
             "Dupond",
             "Jean-Pierre",
             "H",
             datetime.datetime(1993, 3, 3, 0, 0),
         ]
-        assert excel_export[1][-1] == "Oui"  # allowance granted
+        assert excel_export[1][allowance_granted_idx] == "Oui"
+        assert excel_export[1][-1] == ""  # allowance refusal reason
         assert excel_export[2][:4] == [
             "Martin",
             "Cécile",
             "F",
             datetime.datetime(1992, 2, 2, 0, 0),
         ]
-        assert excel_export[2][-1] == "Non"  # allowance granted
+        assert excel_export[2][allowance_granted_idx] == "Non"
+        assert excel_export[2][-1] == allowance_refusal_reason[1]  # allowance refusal reason


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à l'ajout des champs de justification de sélection de contrat (côté GEIQ, #7971) et de refus d'aide (côté institutions, #8020), on veut ajouter de nouvelles colonnes dans l’export Excel.

Pré-requis : #7971 et #8020

[Carte Notion](https://www.notion.so/gip-inclusion/Bilan-GEIQ-Ajout-les-donn-es-de-gestion-de-contrat-motifs-d-rogatoires-et-motif-de-refus-dans-l-3555f321b6048006aa71d5c4de703450?v=2845f321b60480bd9ef6000c92a2d6ab)


---

Les derniers commits ne sont pas à relire, ils concernent #8149 
Ils sont ici temporairement pour ne pas à avoir à générer une énième recette jetable.
