### PR TITLE
Tech: ajout automatique d'un marker pytest sur les tests avec snapshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,6 @@ addopts = [
     "--strict-markers",
 ]
 markers = [
-    "no_django_db: mark tests that should not be marked with django_db."
+    "no_django_db: mark tests that should not be marked with django_db.",
+    "snapshot: automic mark added to tests using snapshots",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,8 @@ def pytest_collection_modifyitems(config, items):
         markers = {marker.name for marker in item.iter_markers()}
         if "no_django_db" not in markers and "django_db" not in markers:
             item.add_marker(pytest.mark.django_db)
+        if "snapshot" in item.fixturenames:
+            item.add_marker(pytest.mark.snapshot)
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour facilement sélectionner les tests nécessitant une mise à jour des snapshots avec l'option pytest `-m snapshot`.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
