### PR TITLE
feat: Ajout du nouveau "tunnel" d'orientation depuis les Emplois

### DIFF
--- a/itou/files/forms.py
+++ b/itou/files/forms.py
@@ -13,7 +13,7 @@ from itou.utils.templatetags.matomo import matomo_event
 class ItouFileInput(forms.FileInput):
     template_name = "utils/widgets/file_input.html"
 
-    def __init__(self, *, attrs=None, content_type, max_upload_size_mb):
+    def __init__(self, *, attrs=None, content_type, max_upload_size_mb, accepted_formats_label=None):
         if attrs is None:
             attrs = {}
         else:
@@ -22,11 +22,13 @@ class ItouFileInput(forms.FileInput):
         super().__init__(attrs=attrs)
         self.content_type = content_type
         self.max_upload_size_mb = max_upload_size_mb
+        self.accepted_formats_label = accepted_formats_label
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context["widget"]["content_type"] = self.content_type
         context["widget"]["max_upload_size_mb"] = self.max_upload_size_mb
+        context["widget"]["accepted_formats_label"] = self.accepted_formats_label
         return context
 
 
@@ -119,3 +121,26 @@ class ItouFileField(forms.FileField):
             if validator := self.CONTENT_TYPE_TO_VALIDATOR.get(self.content_type):
                 validator(data)
         return cleaned_data
+
+
+class ItouMultiFileInput(ItouFileInput):
+    allow_multiple_selected = True
+    template_name = "utils/widgets/multi_file_input.html"
+
+
+class ItouMultiFileField(ItouFileField):
+    def __init__(self, *args, content_type, max_upload_size, allowed_extensions, **kwargs):
+        kwargs.setdefault(
+            "widget",
+            ItouMultiFileInput(
+                content_type=content_type,
+                max_upload_size_mb=max_upload_size / MB,
+                accepted_formats_label=", ".join(allowed_extensions),
+            ),
+        )
+        super().__init__(*args, content_type=content_type, max_upload_size=max_upload_size, **kwargs)
+        self.validators.append(FileExtensionValidator(allowed_extensions))
+
+    def clean(self, data, initial=None):
+        files = data if isinstance(data, (list, tuple)) else [data]
+        return [super().clean(f, initial) for f in files]

--- a/itou/files/forms.py
+++ b/itou/files/forms.py
@@ -116,6 +116,6 @@ class ItouFileField(forms.FileField):
         if data:
             if data.size > self.max_upload_size:
                 raise forms.ValidationError(f"Le fichier doit faire moins de {localize(self.max_upload_size_mb)} Mo.")
-            validator = self.CONTENT_TYPE_TO_VALIDATOR[self.content_type]
-            validator(data)
+            if validator := self.CONTENT_TYPE_TO_VALIDATOR.get(self.content_type):
+                validator(data)
         return cleaned_data

--- a/itou/insertion/utils.py
+++ b/itou/insertion/utils.py
@@ -7,6 +7,20 @@ from itoutils.django.nexus.token import generate_token
 
 from itou.users.enums import UserKind
 from itou.users.models import User
+from itou.utils.phone import normalize_phone_number
+
+
+def get_missing_orientation_beneficiary_field_labels(job_seeker: User) -> list[str]:
+    missing = []
+    if not job_seeker.first_name or not job_seeker.first_name.strip():
+        missing.append("Prénom")
+    if not job_seeker.last_name or not job_seeker.last_name.strip():
+        missing.append("Nom")
+    if not job_seeker.email or not job_seeker.email.strip():
+        missing.append("Adresse e-mail")
+    if not normalize_phone_number(job_seeker.phone or ""):
+        missing.append("Téléphone")
+    return missing
 
 
 def get_job_seeker_from_request(request) -> User | None:

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -87,6 +87,15 @@ Force the display of `.invalid-feedback` for django-bootstrap5 25.2.
     border: 2px dashed var(--bs-danger);
 }
 
+/*
+The theme only renders the required asterisk on direct .form-label/label children,
+so checkbox labels (nested in .form-check) never get it. Restore it here.
+*/
+.form-group-required-check .form-check-label::after {
+    content: " *";
+    font-weight: 700;
+}
+
 .form-group > .select2-container--bootstrap-5 {
     width: 100% !important;
 }

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -116,6 +116,13 @@ input[type="file"] {
     width: 1px;
 }
 
+.c-multi-file-input input[type="file"] {
+    opacity: 1;
+    position: static;
+    z-index: auto;
+    width: auto;
+}
+
 /* Dropdown menus.
 --------------------------------------------------------------------------- */
 

--- a/itou/templates/insertion/includes/orientation_beneficiary_contact.html
+++ b/itou/templates/insertion/includes/orientation_beneficiary_contact.html
@@ -1,0 +1,36 @@
+{% load format_filters %}
+{% load str_filters %}
+
+<div class="c-box mb-3 mb-md-4 position-relative">
+    <div class="position-absolute top-0 end-0 m-3">
+        {% if can_edit_personal_information %}
+            <a href="{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}"
+               class="btn btn-outline-primary w-100 w-md-auto"
+               aria-label="Modifier les coordonnées de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
+                Modifier
+            </a>
+        {% else %}
+            <span tabindex="0"
+                  class="btn btn-outline-primary w-100 w-md-auto disabled"
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="top"
+                  data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.">
+                Modifier
+            </span>
+        {% endif %}
+    </div>
+    <ul class="list-data mb-0 pe-md-5">
+        <li class="has-forced-line-break">
+            <small>Adresse</small>
+            {{ job_seeker.address_on_one_line|default:""|mask_unless:can_view_personal_information|strong_or_disabled_non_filled:"Non renseignée" }}
+        </li>
+        <li class="has-forced-line-break">
+            <small>N&deg; de téléphone</small>
+            {{ job_seeker.phone|default:""|format_phone|mask_unless:can_view_personal_information|strong_or_disabled_non_filled }}
+        </li>
+        <li class="has-forced-line-break">
+            <small>Adresse mail</small>
+            {{ job_seeker.email|default:""|mask_unless:can_view_personal_information|strong_or_disabled_non_filled:"Non renseignée" }}
+        </li>
+    </ul>
+</div>

--- a/itou/templates/insertion/includes/orientation_conditions.html
+++ b/itou/templates/insertion/includes/orientation_conditions.html
@@ -1,0 +1,42 @@
+{% load components %}
+{% load django_bootstrap5 %}
+{% load str_filters %}
+
+<h2 class="h3">Conditions et critères requis</h2>
+
+{% if service.fee %}
+    {% component_alert content=fee_alert_content variant="info" extra_classes="mb-3 mb-md-4" %}
+        {% fragment as fee_alert_content %}
+            <p class="mb-0">
+                Frais à la charge de l'usager : {{ service.fee.label }}
+                {% if service.fee_details %}
+                    <i class="ri-information-line ri-xl text-info" aria-label="{{ service.fee_details }}" data-bs-toggle="tooltip" data-bs-title="{{ service.fee_details }}" role="button" tabindex="0"></i>
+                {% endif %}
+            </p>
+        {% endfragment %}
+    {% endcomponent_alert %}
+{% endif %}
+
+{% if service.publics.exists %}
+    <p class="fw-bold mb-2">Publics concernés par ce service</p>
+    <ul class="mb-3 mb-md-4">
+        {% for public in service.publics.all %}
+            <li>{{ public.label }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+
+{% if service.is_dora and service.access_conditions_dora or not service.is_dora and service.access_conditions_di %}
+    <p class="fw-bold mb-2">Critères de condition d'accès</p>
+    <ul class="mb-3 mb-md-4">
+        {% if service.is_dora %}
+            {% for condition in service.access_conditions_dora %}<li>{{ condition }}</li>{% endfor %}
+        {% else %}
+            {% for condition in service.access_conditions_di|split_literal_newlines %}
+                <li>{{ condition }}</li>
+            {% endfor %}
+        {% endif %}
+    </ul>
+{% endif %}
+
+{% bootstrap_field form.confirms_conditions wrapper_class="form-group form-group-required-check" %}

--- a/itou/templates/insertion/includes/orientation_disclaimer_alert.html
+++ b/itou/templates/insertion/includes/orientation_disclaimer_alert.html
@@ -1,0 +1,20 @@
+<div class="alert alert-warning alert-dismissible fade show mb-3 mb-md-4" role="status">
+    <form method="post" action="{% url 'insertion_views:orientation_dismiss_disclaimer' session_uuid=orientation_session_uuid %}">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.get_full_path }}">
+        <button type="submit" class="btn-close" aria-label="Fermer"></button>
+    </form>
+    <div class="row">
+        <div class="col-auto pe-0">
+            <i class="ri-error-warning-line ri-xl text-warning" aria-hidden="true"></i>
+        </div>
+        <div class="col">
+            <p class="mb-2">
+                <strong>Rappel</strong>
+            </p>
+            <p class="mb-0">
+                Les orientations non valides (test/fictives) nécessitent une vérification manuelle, ce qui augmente la charge de travail de nos équipes. Pour comprendre le fonctionnement du formulaire, nous vous invitons à consulter <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" class="has-external-link">notre documentation</a>.
+            </p>
+        </div>
+    </div>
+</div>

--- a/itou/templates/insertion/includes/orientation_service_info.html
+++ b/itou/templates/insertion/includes/orientation_service_info.html
@@ -1,0 +1,33 @@
+{% load matomo %}
+
+<div class="c-box c-box--organization mb-3 mb-md-4">
+    <button class="c-box--organization__summary w-100"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#collapseOrientationService-{{ service.uid }}"
+            aria-expanded="false"
+            aria-controls="collapseOrientationService-{{ service.uid }}">
+        <i class="ri-community-line" aria-hidden="true"></i>
+        <div>
+            {% if service.kind %}
+                <span data-bs-toggle="tooltip" data-bs-title="{{ service.kind.label }}">{{ service.kind.label }}</span>
+            {% endif %}
+            <span class="d-block h3">{{ service.name }}</span>
+        </div>
+    </button>
+    <div class="c-box--organization__detail collapse" id="collapseOrientationService-{{ service.uid }}">
+        <hr class="my-4">
+        <p class="mb-0">{{ service.structure.name }}</p>
+        {% if service.structure.address_on_one_line %}
+            <ul class="c-box--organization__list-contact mt-4">
+                <li>
+                    <i class="ri-map-pin-2-line fw-normal me-2" aria-hidden="true"></i>
+                    <address class="m-0">{{ service.structure.address_on_one_line }}</address>
+                </li>
+            </ul>
+        {% endif %}
+        <a href="{% url 'insertion_views:structure_card' structure_uid=service.structure.uid %}?back_url={{ request.get_full_path|urlencode }}"
+           class="btn btn-secondary btn-block mt-4"
+           {% matomo_event "orientation" "clic" "voir-fiche-structure" %}>Voir la fiche structure</a>
+    </div>
+</div>

--- a/itou/templates/insertion/includes/orientation_wizard_form_buttons.html
+++ b/itou/templates/insertion/includes/orientation_wizard_form_buttons.html
@@ -1,0 +1,24 @@
+<div class="row">
+    <div class="col-12">
+        <hr class="mb-3">
+        <small class="d-inline-block mb-3">* champs obligatoires</small>
+        <div class="form-row align-items-center justify-content-end gx-3">
+            <div class="form-group col-12 col-lg order-3 order-lg-1">
+                <a href="{{ reset_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                    <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                    <span>Annuler</span>
+                </a>
+            </div>
+            <div class="form-group col col-lg-auto order-1 order-lg-2">
+                <a href="{{ prev_url }}" class="btn btn-block btn-outline-primary" aria-label="Retourner à l’étape précédente">
+                    <span>Retour</span>
+                </a>
+            </div>
+            <div class="form-group col col-lg-auto order-2 order-lg-3">
+                <button type="submit" class="btn btn-block btn-primary" aria-label="Passer à l’étape suivante">
+                    <span>{{ primary_label }}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/itou/templates/insertion/includes/orientation_wizard_stepper.html
+++ b/itou/templates/insertion/includes/orientation_wizard_stepper.html
@@ -1,0 +1,22 @@
+{% load theme_inclusion %}
+
+<div class="c-stepper mb-3 mb-md-4">
+    <div class="progress">
+        <div class="progress-bar progress-bar-{{ wizard_steps|stepper_progress }}"
+             role="progressbar"
+             aria-valuenow="{{ wizard_steps|stepper_progress }}"
+             aria-valuemin="0"
+             aria-valuemax="100"
+             aria-labelledby="currentProgressState"></div>
+    </div>
+    <p id="currentProgressState">
+        <strong>Étape {{ wizard_steps.step1 }}/{{ wizard_steps.count }}</strong> :
+        {% if wizard_steps.current == OrientationStep.CONFORMITY %}
+            Valider la conformité
+        {% elif wizard_steps.current == OrientationStep.REFERENT %}
+            Compléter la demande
+        {% elif wizard_steps.current == OrientationStep.DOCUMENTS %}
+            Documents et justificatifs requis
+        {% endif %}
+    </p>
+</div>

--- a/itou/templates/insertion/orientation_confirmation.html
+++ b/itou/templates/insertion/orientation_confirmation.html
@@ -1,0 +1,36 @@
+{% extends "layout/base.html" %}
+{% load components %}
+{% load str_filters %}
+
+{% block title %}Demande d'orientation transmise{{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Orienter {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }} vers un service d'insertion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                    <div class="c-form">
+                        <h2 class="h3">Votre demande a bien été transmise !</h2>
+                        <p>
+                            Le récapitulatif de la demande vous a été envoyé, ainsi qu'à l'adresse e-mail de
+                            {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }} :
+                            {{ job_seeker.email|mask_unless:can_view_personal_information }}.
+                        </p>
+                        <a href="{% url 'dashboard:index' %}" class="btn btn-primary">Retour à l'accueil</a>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                    {% include "insertion/includes/orientation_service_info.html" with service=service request=request only %}
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/insertion/orientation_select_job_seeker.html
+++ b/itou/templates/insertion/orientation_select_job_seeker.html
@@ -1,0 +1,43 @@
+{% extends "layout/base.html" %}
+{% load buttons_form %}
+{% load components %}
+{% load django_bootstrap5 %}
+{% load matomo %}
+
+{% block title %}Orienter vers un service d'insertion{{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Orienter vers un service d'insertion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                    <div class="c-form mb-5">
+                        <h2 class="h3">Rechercher un usager</h2>
+                        <p>Dans le menu déroulant ci-dessous, vous trouverez la liste de vos usagers.</p>
+                        <form method="post" class="c-form js-prevent-multiple-submit">
+                            {% csrf_token %}
+                            {% bootstrap_form_errors form type="all" %}
+                            {% bootstrap_field form.job_seeker wrapper_class="form-group form-group-input-w-lg-66" %}
+                            {% itou_buttons_form reset_url=reset_url primary_label="Suivant" %}
+                        </form>
+                    </div>
+                    <hr data-it-text="ou" class="my-5">
+                    <div class="text-center mb-3">
+                        Votre usager n'a pas encore de compte ? <a href="{{ create_job_seeker_url }}" class="btn-link" {% matomo_event "compte-candidat" "clic" "creer-un-compte-candidat-orientation" %}>Créer un compte usager</a>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                    {% include "insertion/includes/orientation_service_info.html" with service=service request=request only %}
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/insertion/orientation_wizard.html
+++ b/itou/templates/insertion/orientation_wizard.html
@@ -1,0 +1,173 @@
+{% extends "layout/base.html" %}
+{% load buttons_form %}
+{% load components %}
+{% load django_bootstrap5 %}
+{% load str_filters %}
+
+{% block title %}Orienter vers un service d'insertion{{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Orienter {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }} vers un service d'insertion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block title_messages %}
+    {{ block.super }}
+    {% if show_orientation_disclaimer %}
+        {% include "insertion/includes/orientation_disclaimer_alert.html" with orientation_session_uuid=orientation_session_uuid request=request csrf_token=csrf_token ITOU_HELP_CENTER_URL=ITOU_HELP_CENTER_URL only %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    {% include "insertion/includes/orientation_wizard_stepper.html" with wizard_steps=wizard_steps OrientationStep=OrientationStep only %}
+                </div>
+            </div>
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+
+                    {% if wizard_steps.current == OrientationStep.CONFORMITY %}
+                        {% if missing_beneficiary_fields %}
+                            {% component_alert title=alert_title content=alert_content variant="warning" extra_id="missing-beneficiary-infos-warning" extra_classes="mb-3 mb-md-4" %}
+                                {% fragment as alert_title %}
+                                    Informations manquantes
+                                {% endfragment %}
+                                {% fragment as alert_content %}
+                                    <p class="mb-0">Les informations suivantes doivent être renseignées pour poursuivre l'orientation :</p>
+                                    <ul class="mb-0">
+                                        {% for field in missing_beneficiary_fields %}
+                                            <li>
+                                                <strong>{{ field }}</strong>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                    {% if can_edit_personal_information %}
+                                        <p class="mb-0 mt-3">
+                                            <a href="{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-outline-primary btn-sm">Compléter les informations du candidat</a>
+                                        </p>
+                                    {% endif %}
+                                {% endfragment %}
+                            {% endcomponent_alert %}
+                        {% endif %}
+                        <div class="c-form mb-3 mb-md-4">
+                            <form method="post" class="js-prevent-multiple-submit">
+                                {% csrf_token %}
+                                {% bootstrap_form_errors form type="all" %}
+                                {% component_alert content=coordinates_alert_content variant="info" extra_classes="mb-3 mb-md-4" %}
+                                    {% fragment as coordinates_alert_content %}
+                                        <p class="mb-0">Veuillez vous assurer que les coordonnées de votre usager sont bien à jour</p>
+                                    {% endfragment %}
+                                {% endcomponent_alert %}
+                                {% include "insertion/includes/orientation_beneficiary_contact.html" with job_seeker=job_seeker can_edit_personal_information=can_edit_personal_information can_view_personal_information=can_view_personal_information request=request only %}
+                                <hr class="my-3">
+                                {% include "insertion/includes/orientation_conditions.html" with service=service form=form only %}
+                                {% itou_buttons_form reset_url=reset_url primary_label="Suivant" primary_disabled=missing_beneficiary_fields %}
+                            </form>
+                        </div>
+
+                    {% elif wizard_steps.current == OrientationStep.REFERENT %}
+                        <div class="c-form mb-3 mb-md-4">
+                            <form method="post" class="js-prevent-multiple-submit">
+                                {% csrf_token %}
+                                {% bootstrap_form_errors form type="all" %}
+                                <fieldset>
+                                    <legend class="mb-0">Conseiller ou conseillère référent(e)</legend>
+                                    <p class="fs-sm">
+                                        Personne en charge de l'accompagnement et du suivi professionnel de la situation
+                                        de l'usager. Si ce n'est pas vous, veuillez modifier les informations ci-dessous
+                                    </p>
+                                    {% bootstrap_field form.referent_last_name wrapper_class="form-group form-group-input-w-lg-66" %}
+                                    {% bootstrap_field form.referent_first_name wrapper_class="form-group form-group-input-w-lg-66" %}
+                                    {% bootstrap_field form.referent_phone wrapper_class="form-group form-group-input-w-lg-66" %}
+                                    {% bootstrap_field form.referent_email wrapper_class="form-group form-group-input-w-lg-66" %}
+                                </fieldset>
+                                <hr class="my-3">
+                                <fieldset>
+                                    <legend>Motif de l'orientation (facultatif)</legend>
+                                    {% bootstrap_field form.orientation_reason %}
+                                </fieldset>
+                                {% include "insertion/includes/orientation_wizard_form_buttons.html" with reset_url=reset_url prev_url=wizard_steps.prev primary_label="Suivant" only %}
+                            </form>
+                        </div>
+
+                    {% elif wizard_steps.current == OrientationStep.DOCUMENTS %}
+                        <div class="c-form mb-3 mb-md-4">
+                            <form method="post" enctype="multipart/form-data" class="js-prevent-multiple-submit">
+                                {% csrf_token %}
+                                {% bootstrap_form_errors form type="all" %}
+
+                                <h2 class="h3">Documents et justificatifs requis</h2>
+
+                                {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail extra_classes="mb-3 mb-md-4" %}
+                                    {% fragment as c_info__summary %}
+                                        Attention à ne télécharger que les pièces strictement nécessaires à la demande.
+                                    {% endfragment %}
+                                    {% fragment as c_info__detail %}
+                                        <p class="mb-0">
+                                            Pour des raisons de confidentialité, l'envoi de la carte vitale, des attestations
+                                            de droits santé/CPAM ou de tout autre document contenant le NIR (numéro de sécurité
+                                            sociale) n'est pas autorisé.
+                                        </p>
+                                    {% endfragment %}
+                                {% endcomponent_info %}
+
+                                {% if service.credentials_documents %}
+                                    <h3 class="h4">Documents à compléter</h3>
+                                    <ul class="list-unstyled mb-3">
+                                        {% for document_name, document_url in credential_documents %}
+                                            <li class="mb-2">
+                                                <a href="{{ document_url }}" target="_blank" rel="noopener noreferrer" class="has-external-link" download>
+                                                    <i class="ri-download-line fw-medium" aria-hidden="true"></i>
+                                                    {{ document_name }}
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                    {% bootstrap_field form.credentials_documents_files show_label=False %}
+                                    <hr class="my-3">
+                                {% endif %}
+
+                                {% if service.credentials_online_form %}
+                                    <h3 class="h4">Liens</h3>
+                                    <p>Informations complémentaires ou formulaires à compléter</p>
+                                    <ul>
+                                        <li>
+                                            <a href="{{ service.credentials_online_form }}" target="_blank" rel="noopener" class="has-external-link">
+                                                {{ service.credentials_online_form }}
+                                            </a>
+                                        </li>
+                                    </ul>
+                                    <hr class="my-3">
+                                {% endif %}
+
+                                {% if service.credentials %}
+                                    <h3 class="h4">Pré-requis et justificatifs</h3>
+                                    <p>(A récupérer auprès de l'usager)</p>
+                                    <ul>
+                                        {% for credential in service.credentials %}
+                                            <li>{{ credential }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                    {% bootstrap_field form.credentials_proof_files show_label=False %}
+                                    <hr class="my-3">
+                                {% endif %}
+
+                                {% bootstrap_field form.gdpr_consent %}
+                                {% include "insertion/includes/orientation_wizard_form_buttons.html" with reset_url=reset_url prev_url=wizard_steps.prev primary_label="Suivant" only %}
+                            </form>
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                    {% include "insertion/includes/orientation_service_info.html" with service=service request=request only %}
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -1,8 +1,8 @@
 {% extends "layout/base.html" %}
-{% load dora %}
 {% load format_filters %}
 {% load matomo %}
 {% load str_filters %}
+{% load url_add_query %}
 
 
 {% block title %}{{ service.name }} {{ block.super }}{% endblock %}
@@ -27,22 +27,35 @@
         <div class="form-row align-items-center gx-3">
             {% if service.is_orientable_with_form or service.mobilization_modes_professionals_external_form_link %}
                 <div class="form-group col-12 col-lg-auto">
+                    {% if request.GET.job_seeker_public_id %}
+                        {% url_add_query 'insertion_views:start_orientation' service_uid=service.uid job_seeker_public_id=request.GET.job_seeker_public_id as start_orientation_url %}
+                    {% else %}
+                        {% url 'insertion_views:start_orientation' service_uid=service.uid as start_orientation_url %}
+                    {% endif %}
                     {% if service.is_orientable_with_form and user.is_authenticated %}
-                        <a class="btn btn-lg btn-white btn-block justify-content-center"
-                           rel="noopener"
-                           target="_blank"
-                           href="{% dora_orientation_url service orientation_jwt=orientation_jwt source=request.user.kind|default:"accueil" %}"
-                           {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}>Orienter le bénéficiaire</a>
+                        <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" href="{{ start_orientation_url }}" {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}> <span>
+                            {% if request.GET.job_seeker_public_id %}
+                                Orienter le bénéficiaire
+                            {% else %}
+                                Orienter un bénéficiaire
+                            {% endif %}
+                        </span> </a>
                     {% elif service.is_orientable_with_form and not user.is_authenticated %}
-                        <a class="btn btn-lg btn-white btn-block justify-content-center"
+                        <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
                            href="{% url 'login:existing_user' %}?next={{ request.get_full_path|urlencode }}"
-                           {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}>Orienter le bénéficiaire</a>
+                           {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}> <span>
+                            {% if request.GET.job_seeker_public_id %}
+                                Orienter le bénéficiaire
+                            {% else %}
+                                Orienter un bénéficiaire
+                            {% endif %}
+                        </span> </a>
                     {% elif service.mobilization_modes_professionals_external_form_link %}
-                        <a class="btn btn-lg btn-white btn-block justify-content-center"
+                        <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
                            rel="noopener"
                            target="_blank"
                            href="{{ service.mobilization_modes_professionals_external_form_link }}"
-                           {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}>Orienter le bénéficiaire</a>
+                           {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}> <span>{{ service.mobilization_modes_professionals_external_form_link_text }}</span> </a>
                     {% endif %}
                 </div>
             {% endif %}

--- a/itou/templates/search/services/includes/results.html
+++ b/itou/templates/search/services/includes/results.html
@@ -17,6 +17,12 @@
                 <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
                     <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                         {% if service.is_local %}
+                            {% if service.distance is not None %}
+                                <li>
+                                    <i class="ri-navigation-line fw-normal me-1" aria-hidden="true"></i>
+                                    à <strong class="text-info mx-1">{{ service.distance|floatformat:"-1" }}&nbsp;km</strong> de votre lieu de recherche
+                                </li>
+                            {% endif %}
                             <li>
                                 <i class="ri-map-pin-2-line fw-normal me-1" aria-hidden="true"></i>
                                 {% if service.code_postal and service.commune %}
@@ -28,13 +34,12 @@
                                         {% endif %}
                                     </address>
                                 {% endif %}
-                                {% if service.distance is not None %}
-                                    <span class="badge badge-xs rounded-pill bg-light text-primary ms-1">{{ service.distance|floatformat:"-1" }} km</span>
-                                {% endif %}
-                                {% if service.is_remote %}
-                                    <span class="badge badge-xs rounded-pill bg-light text-primary">Également disponible à distance</span>
-                                {% endif %}
                             </li>
+                            {% if service.is_remote %}
+                                <li>
+                                    <span class="badge badge-sm rounded-pill bg-info text-white">Également disponible à distance</span>
+                                </li>
+                            {% endif %}
                         {% elif service.is_remote %}
                             <li>
                                 <i class="ri-map-pin-2-line fw-normal me-1" aria-hidden="true"></i>
@@ -68,17 +73,13 @@
         </div>
     {% empty %}
         {% if api_error %}
-            <div class="c-box c-box--results mb-3 mb-md-4">
-                <div class="c-box--results__body">
-                    {% component_alert content=content variant="warning" %}
-                        {% fragment as content %}
-                            <p class="mb-0">
-                                Une erreur est survenue lors de l'appel à <a href="https://data.inclusion.gouv.fr/" target="_blank" rel="noopener" class="has-external-link">data·inclusion</a>. Veuillez réessayer ultérieurement.
-                            </p>
-                        {% endfragment %}
-                    {% endcomponent_alert %}
-                </div>
-            </div>
+            {% component_alert content=content variant="warning" %}
+                {% fragment as content %}
+                    <p class="mb-0">
+                        Une erreur est survenue lors de l'appel à <a href="https://data.inclusion.gouv.fr/" target="_blank" rel="noopener" class="has-external-link">data·inclusion</a>. Veuillez réessayer ultérieurement.
+                    </p>
+                {% endfragment %}
+            {% endcomponent_alert %}
         {% else %}
             <div class="c-box c-box--results mb-3 mb-md-4">
                 <div class="c-box--results__body">

--- a/itou/templates/search/services/results.html
+++ b/itou/templates/search/services/results.html
@@ -18,9 +18,7 @@
 {% block title_content %}
     {% component_title c_title__main=c_title__main %}
         {% fragment as c_title__main %}
-            <div class="d-flex align-items-center pb-4">
-                <h1 class="mb-0">Rechercher un service d'insertion {% beta_badge extra_classes="badge-base" %}</h1>
-            </div>
+            <h1>Rechercher un service d'insertion {% beta_badge extra_classes="badge-base" %}</h1>
         {% endfragment %}
     {% endcomponent_title %}
 {% endblock %}
@@ -46,7 +44,7 @@
             {% fragment as content %}
                 {# Authorized prescribers can_view_personal_information, it is not checked here. #}
                 {# Needs to change with can_prefill_orientation_on_dora #}
-                <strong>Vous recherchez un service pour {{ orientation.job_seeker.get_inverted_full_name }}</strong>
+                <strong>Vous recherchez un service pour {{ orientation.job_seeker.get_full_name }}</strong>
             {% endfragment %}
         {% endcomponent_alert_global %}
     {% endif %}

--- a/itou/templates/utils/widgets/file_input.html
+++ b/itou/templates/utils/widgets/file_input.html
@@ -12,16 +12,7 @@
             <i class="ri-folder-line ri-xl" aria-hidden="true"></i>
             <span>Rechercher dans vos fichiers</span>
         </label>
-        <p class="small text-nuance-06 mb-0">
-            Taille maximale : {{ widget.max_upload_size_mb|floatformat }} Mo
-            {% if widget.content_type == "application/pdf" %}
-                <br>
-                Type de fichier : PDF
-            {% elif widget.content_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" %}
-                <br>
-                Type de fichier : Excel / XLSX
-            {% endif %}
-        </p>
+        {% include "utils/widgets/file_input_constraints.html" %}
     </div>
 
     <div class="file-dropzone-preview d-none p-5">

--- a/itou/templates/utils/widgets/file_input_constraints.html
+++ b/itou/templates/utils/widgets/file_input_constraints.html
@@ -1,0 +1,13 @@
+<p class="small text-nuance-06 mb-0">
+    Taille maximale : {{ widget.max_upload_size_mb|floatformat }} Mo
+    {% if widget.accepted_formats_label %}
+        <br>
+        Formats supportés : {{ widget.accepted_formats_label }}
+    {% elif widget.content_type == "application/pdf" %}
+        <br>
+        Type de fichier : PDF
+    {% elif widget.content_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" %}
+        <br>
+        Type de fichier : Excel / XLSX
+    {% endif %}
+</p>

--- a/itou/templates/utils/widgets/multi_file_input.html
+++ b/itou/templates/utils/widgets/multi_file_input.html
@@ -1,0 +1,4 @@
+<div class="c-multi-file-input">
+    {% include "django/forms/widgets/file.html" %}
+    <div class="mt-1 mb-2">{% include "utils/widgets/file_input_constraints.html" %}</div>
+</div>

--- a/itou/utils/apis/dora.py
+++ b/itou/utils/apis/dora.py
@@ -1,5 +1,4 @@
 import dataclasses
-import json
 import logging
 
 import httpx
@@ -82,10 +81,18 @@ class DoraAPIClient:
 
     def create_orientation(self, payload: dict, attachments=()) -> dict:
         files = [("attachments", (file_name, file_obj)) for file_name, file_obj in attachments]
+        form_data = {}
+        for key, value in payload.items():
+            if key == "emplois_data":
+                for nested_key, nested_value in value.items():
+                    if nested_value is not None:
+                        form_data[f"emplois_data.{nested_key}"] = nested_value
+            elif value is not None:
+                form_data[key] = value
         try:
             response = self.client.post(
                 "/orientations/",
-                data={"data": json.dumps(payload)},
+                data=form_data,
                 files=files or None,
                 timeout=httpx.Timeout(5, read=60),
             ).raise_for_status()

--- a/itou/utils/apis/dora.py
+++ b/itou/utils/apis/dora.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import logging
 
 import httpx
@@ -40,8 +41,9 @@ class DoraApiItemsIterator:
 
 class DoraAPIClient:
     def __init__(self, base_url: str, token: str):
+        self._base_url = base_url.rstrip("/")
         self.client = httpx.Client(
-            base_url=base_url.rstrip("/") + "/api/emplois/",
+            base_url=self._base_url + "/api/emplois/",
             headers={"Authorization": f"Token {token}"},
         )
 
@@ -77,3 +79,27 @@ class DoraAPIClient:
             r["source"] + "--" + r["structure_id"]
             for r in self._request("/disabled-dora-form-di-structures/", params).json()
         }
+
+    def create_orientation(self, payload: dict, attachments=()) -> dict:
+        files = [("attachments", (file_name, file_obj)) for file_name, file_obj in attachments]
+        try:
+            response = self.client.post(
+                "/orientations/",
+                data={"data": json.dumps(payload)},
+                files=files or None,
+                timeout=httpx.Timeout(5, read=60),
+            ).raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.info(
+                "DORA create-orientation error di_service_id=%r error=%s",
+                payload.get("di_service_id"),
+                exc,
+            )
+            raise DoraAPIException()
+        orientation_response = response.json()
+        logger.info(
+            "DORA create-orientation success di_service_id=%r orientation_id=%s",
+            payload.get("di_service_id"),
+            orientation_response.get("id"),
+        )
+        return orientation_response

--- a/itou/utils/phone.py
+++ b/itou/utils/phone.py
@@ -1,0 +1,18 @@
+import re
+
+
+def normalize_phone_number(phone_number: str) -> str | None:
+    if not phone_number:
+        return None
+    normalized = phone_number.strip()
+    if normalized.startswith("+33"):
+        rest = re.sub(r"\D", "", normalized[3:])
+        if rest:
+            normalized = f"0{rest}"
+    else:
+        normalized = re.sub(r"\D", "", normalized)
+        if normalized.startswith("0033"):
+            normalized = f"0{normalized[4:]}"
+    if len(normalized) == 10 and normalized.startswith("0"):
+        return normalized
+    return None

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -11,6 +11,8 @@ from django.template.defaultfilters import floatformat, stringfilter
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 
+from itou.utils.phone import normalize_phone_number
+
 
 register = template.Library()
 
@@ -27,12 +29,7 @@ def format_phone(phone_number):
     """
     if not phone_number:
         return ""
-    normalized = phone_number.strip()
-    if normalized.startswith("+33"):
-        rest = re.sub(r"\D", "", normalized[3:])
-        if rest:
-            normalized = f"0{rest}"
-    return " ".join(wrap(normalized, 2))
+    return " ".join(wrap(normalize_phone_number(phone_number) or phone_number.strip(), 2))
 
 
 @register.filter

--- a/itou/www/insertion_views/forms.py
+++ b/itou/www/insertion_views/forms.py
@@ -1,0 +1,138 @@
+from django import forms
+from django.forms import ValidationError
+from django_select2.forms import Select2Widget
+
+from itou.files.forms import ItouMultiFileField
+from itou.insertion.utils import get_missing_orientation_beneficiary_field_labels
+from itou.users.enums import UserKind
+from itou.users.models import User
+from itou.utils.constants import MB
+from itou.utils.perms.utils import can_view_personal_information
+from itou.utils.phone import normalize_phone_number
+from itou.utils.templatetags.str_filters import mask_unless
+
+
+# FIXME(vperron): ensure those files match DORA's allowed file types
+ORIENTATION_FILE_EXTENSIONS = ["doc", "docx", "pdf", "png", "jpeg", "jpg", "odt", "xls", "xlsx", "ods"]
+ORIENTATION_FILE_CONTENT_TYPES = ".doc,.docx,.pdf,.png,.jpeg,.jpg,.odt,.xls,.xlsx,.ods"
+ORIENTATION_FILE_MAX_SIZE_MB = 5
+
+
+class OrientationSelectJobSeekerForm(forms.Form):
+    job_seeker = forms.ChoiceField(
+        required=True,
+        label="Nom de l'usager",
+        widget=Select2Widget(
+            attrs={
+                "data-placeholder": "Nom de l'usager",
+            }
+        ),
+    )
+
+    def __init__(self, request, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        job_seekers_ids = User.objects.assigned_job_seeker_ids(request.user, request.current_organization)
+        job_seeker_qs = (
+            User.objects.filter(
+                kind=UserKind.JOB_SEEKER,
+                pk__in=job_seekers_ids,
+                # FIXME: will be fixed when last_name/first_name are enforced by a SQL constraint
+                last_name__isnull=False,
+                first_name__isnull=False,
+            )
+            .select_related("jobseeker_profile")
+            .order_by("last_name", "first_name")
+        )
+        self.valid_public_ids = set()
+        choices = [("", "---------")]
+        for job_seeker in job_seeker_qs:
+            self.valid_public_ids.add(str(job_seeker.public_id))
+            choices.append(
+                (
+                    str(job_seeker.public_id),
+                    mask_unless(
+                        job_seeker.get_inverted_full_name(),
+                        predicate=can_view_personal_information(request, job_seeker),
+                    ),
+                )
+            )
+        self.fields["job_seeker"].choices = choices
+
+    def clean_job_seeker(self):
+        public_id = self.cleaned_data["job_seeker"]
+        if public_id not in self.valid_public_ids:
+            raise ValidationError("Sélectionnez un usager valide.")
+        return public_id
+
+
+class OrientationConformityForm(forms.Form):
+    confirms_conditions = forms.BooleanField(
+        required=True,
+        label="Je confirme que l'usager remplit au moins une condition et un critère requis.",
+    )
+
+    def __init__(self, job_seeker, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.job_seeker = job_seeker
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if missing_fields := get_missing_orientation_beneficiary_field_labels(self.job_seeker):
+            raise ValidationError(
+                "Les informations du candidat sont incomplètes : %(fields)s.",
+                params={"fields": ", ".join(missing_fields)},
+                code="incomplete_beneficiary",
+            )
+        return cleaned_data
+
+
+class OrientationReferentForm(forms.Form):
+    referent_last_name = forms.CharField(required=True, label="Nom")
+    referent_first_name = forms.CharField(required=True, label="Prénom")
+    referent_phone = forms.CharField(
+        required=True,
+        label="Téléphone",
+        help_text="Ex : 0123456789",
+        widget=forms.TextInput(attrs={"type": "tel"}),
+    )
+    referent_email = forms.EmailField(required=True, label="Adresse e-mail", help_text="Ex : mail@domaine.fr")
+    orientation_reason = forms.CharField(
+        required=False,
+        label="Si besoin, détaillez ici le motif de l'orientation",
+        help_text=(
+            "Merci de ne pas fournir des informations considérées comme sensibles "
+            "(situation personnelle ou professionnelle autre que celles cochées à l'étape 1 "
+            "de la demande, etc.)."
+        ),
+        widget=forms.Textarea(attrs={"rows": 4}),
+    )
+
+    def clean_referent_phone(self):
+        phone = self.cleaned_data["referent_phone"]
+        if normalized_phone := normalize_phone_number(phone):
+            return normalized_phone
+        raise ValidationError("Saisissez un numéro de téléphone valide à 10 chiffres.")
+
+
+class OrientationDocumentsForm(forms.Form):
+    credentials_documents_files = ItouMultiFileField(
+        required=False,
+        label="Documents à compléter",
+        content_type=ORIENTATION_FILE_CONTENT_TYPES,
+        max_upload_size=ORIENTATION_FILE_MAX_SIZE_MB * MB,
+        allowed_extensions=ORIENTATION_FILE_EXTENSIONS,
+    )
+    credentials_proof_files = ItouMultiFileField(
+        required=False,
+        label="Pré-requis et justificatifs",
+        content_type=ORIENTATION_FILE_CONTENT_TYPES,
+        max_upload_size=ORIENTATION_FILE_MAX_SIZE_MB * MB,
+        allowed_extensions=ORIENTATION_FILE_EXTENSIONS,
+    )
+    gdpr_consent = forms.BooleanField(
+        required=True,
+        label=(
+            "Je m'engage en tant qu'accompagnateur, à informer la personne concernée du traitement de ses "
+            "données personnelles dans le cadre de cette orientation."
+        ),
+    )

--- a/itou/www/insertion_views/urls.py
+++ b/itou/www/insertion_views/urls.py
@@ -8,4 +8,29 @@ app_name = "insertion_views"
 urlpatterns = [
     path("structures/<str:structure_uid>/", views.StructureCardView.as_view(), name="structure_card"),
     path("services/<str:service_uid>/", views.ServiceDetailView.as_view(), name="service_detail"),
+    path(
+        "orientations/<str:service_uid>/start/",
+        views.start_orientation,
+        name="start_orientation",
+    ),
+    path(
+        "orientations/<str:service_uid>/job-seeker/",
+        views.OrientationSelectJobSeekerView.as_view(),
+        name="orientation_select_job_seeker",
+    ),
+    path(
+        "orientations/<uuid:session_uuid>/create/<slug:step>/",
+        views.OrientationWizardView.as_view(),
+        name="orientation_steps",
+    ),
+    path(
+        "orientations/<uuid:session_uuid>/dismiss-disclaimer/",
+        views.dismiss_orientation_disclaimer,
+        name="orientation_dismiss_disclaimer",
+    ),
+    path(
+        "orientations/<str:service_uid>/confirmation/",
+        views.OrientationConfirmationView.as_view(),
+        name="orientation_confirmation",
+    ),
 ]

--- a/itou/www/insertion_views/urls.py
+++ b/itou/www/insertion_views/urls.py
@@ -6,6 +6,6 @@ from itou.www.insertion_views import views
 app_name = "insertion_views"
 
 urlpatterns = [
-    path("structure/<str:structure_uid>/card", views.StructureCardView.as_view(), name="structure_card"),
-    path("service/<str:service_uid>/card", views.ServiceDetailView.as_view(), name="service_detail"),
+    path("structures/<str:structure_uid>/", views.StructureCardView.as_view(), name="structure_card"),
+    path("services/<str:service_uid>/", views.ServiceDetailView.as_view(), name="service_detail"),
 ]

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -1,18 +1,43 @@
+import enum
+import logging
+
 from data_inclusion.schema.v1.thematiques import Categorie
+from django.conf import settings
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import Prefetch
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
+from django.views.generic.edit import FormView
 from itoutils.django.decoupage_administratif.admin_division_parsing import get_division_label
 
-from itou.insertion.models import GenericReferenceItem, Service, Structure
+from itou.insertion import models as insertion_models
 from itou.insertion.opening_hours import format_osm_hours
-from itou.insertion.utils import get_orientation_jwt
+from itou.insertion.utils import get_missing_orientation_beneficiary_field_labels, get_orientation_jwt
+from itou.users.enums import UserKind
+from itou.users.models import User
 from itou.users.perms import can_prefill_orientation_on_dora
+from itou.utils.apis.dora import DoraAPIClient, DoraAPIException
 from itou.utils.auth import LoginNotRequiredMixin
+from itou.utils.perms.utils import can_edit_personal_information, can_view_personal_information
+from itou.utils.phone import normalize_phone_number
 from itou.utils.readonly import ReadonlyViewMixin
+from itou.utils.session import SessionNamespace, SessionNamespaceException
 from itou.utils.urls import get_safe_url
+from itou.www.insertion_views.forms import (
+    OrientationConformityForm,
+    OrientationDocumentsForm,
+    OrientationReferentForm,
+    OrientationSelectJobSeekerForm,
+)
+from itou.www.utils.wizard import WizardView
+
+
+logger = logging.getLogger(__name__)
 
 
 class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
@@ -21,10 +46,10 @@ class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
     def setup(self, request, structure_uid, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.structure = get_object_or_404(
-            Structure.objects.select_related("source").prefetch_related(
+            insertion_models.Structure.objects.select_related("source").prefetch_related(
                 Prefetch(
                     "services",
-                    queryset=Service.objects.order_by("name").select_related("kind"),
+                    queryset=insertion_models.Service.objects.order_by("name").select_related("kind"),
                 ),
             ),
             uid=structure_uid,
@@ -39,8 +64,8 @@ class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
 
 
 class ServiceDetailView(LoginNotRequiredMixin, DetailView):
-    model = Service
-    queryset = Service.objects.select_related(
+    model = insertion_models.Service
+    queryset = insertion_models.Service.objects.select_related(
         "source",
         "fee",
         "kind",
@@ -50,7 +75,7 @@ class ServiceDetailView(LoginNotRequiredMixin, DetailView):
     ).prefetch_related(
         "thematics",
         "publics",
-        Prefetch("receptions", queryset=GenericReferenceItem.objects.order_by("label")),
+        Prefetch("receptions", queryset=insertion_models.GenericReferenceItem.objects.order_by("label")),
         "mobilizations",
         "mobilization_publics",
         "mobilization_modes_beneficiaries",
@@ -93,3 +118,300 @@ class ServiceDetailView(LoginNotRequiredMixin, DetailView):
         )
         context["formatted_categories"] = self.format_categories()
         return context
+
+
+class OrientationStep(enum.StrEnum):
+    CONFORMITY = "confirm"
+    REFERENT = "fill"
+    DOCUMENTS = "submit"
+    do_not_call_in_templates = enum.nonmember(True)
+
+
+def start_orientation(request, service_uid):
+    service = get_object_or_404(insertion_models.Service, uid=service_uid, is_orientable_with_form=True)
+    if not (job_seeker_public_id := request.GET.get("job_seeker_public_id")):
+        logger.info(
+            "orientation wizard start_without_job_seeker user=%s service_uid=%s",
+            request.user.pk,
+            service.uid,
+        )
+        return HttpResponseRedirect(
+            reverse(
+                "insertion_views:orientation_select_job_seeker",
+                kwargs={"service_uid": service.uid},
+            )
+        )
+    job_seeker = get_object_or_404(User, public_id=job_seeker_public_id, kind=UserKind.JOB_SEEKER)
+    logger.info(
+        "orientation wizard start user=%s service_uid=%s job_seeker=%s",
+        request.user.pk,
+        service.uid,
+        job_seeker.public_id,
+    )
+    return OrientationWizardView.initialize_session_and_start(
+        request,
+        reset_url=reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid}),
+        extra_session_data={
+            "service_uid": service.uid,
+            "job_seeker_public_id": str(job_seeker.public_id),
+        },
+    )
+
+
+class OrientationSelectJobSeekerView(FormView):
+    form_class = OrientationSelectJobSeekerForm
+    template_name = "insertion/orientation_select_job_seeker.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not (request.from_employer or request.from_prescriber):
+            raise PermissionDenied("Vous n'êtes pas autorisé à orienter un usager.")
+        return super().dispatch(request, *args, **kwargs)
+
+    def setup(self, request, *args, service_uid, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.service = get_object_or_404(
+            insertion_models.Service.objects.select_related("kind", "structure"),
+            uid=service_uid,
+            is_orientable_with_form=True,
+        )
+
+    def get_form_kwargs(self):
+        return super().get_form_kwargs() | {"request": self.request}
+
+    def form_valid(self, form):
+        return HttpResponseRedirect(
+            reverse(
+                "insertion_views:start_orientation",
+                kwargs={"service_uid": self.service.uid},
+                query={"job_seeker_public_id": form.cleaned_data["job_seeker"]},
+            )
+        )
+
+    def get_context_data(self, **kwargs):
+        service_detail_url = reverse("insertion_views:service_detail", kwargs={"service_uid": self.service.uid})
+        return super().get_context_data(**kwargs) | {
+            "service": self.service,
+            "reset_url": service_detail_url,
+            "create_job_seeker_url": reverse(
+                "job_seekers_views:get_or_create_start",
+                query={
+                    "tunnel": "orientation",
+                    "from_url": service_detail_url,
+                    "service_uid": self.service.uid,
+                },
+            ),
+            "matomo_custom_title": "Orientation service - rechercher un usager",
+        }
+
+
+class OrientationResultBaseView(TemplateView):
+    matomo_custom_title = None
+
+    def get_context_data(self, **kwargs):
+        service = get_object_or_404(
+            insertion_models.Service.objects.select_related("kind", "structure"),
+            uid=self.kwargs["service_uid"],
+        )
+        job_seeker = get_object_or_404(
+            User.objects.select_related("jobseeker_profile"),
+            public_id=self.request.GET.get("job_seeker_public_id"),
+            kind=UserKind.JOB_SEEKER,
+        )
+        return super().get_context_data(**kwargs) | {
+            "service": service,
+            "job_seeker": job_seeker,
+            "can_view_personal_information": can_view_personal_information(self.request, job_seeker),
+            "matomo_custom_title": self.matomo_custom_title,
+        }
+
+
+class OrientationConfirmationView(OrientationResultBaseView):
+    template_name = "insertion/orientation_confirmation.html"
+    matomo_custom_title = "Demande d'orientation transmise"
+
+
+class OrientationWizardView(WizardView):
+    url_name = "insertion_views:orientation_steps"
+    expected_session_kind = "orientation"
+    template_name = "insertion/orientation_wizard.html"
+    steps_config = {
+        OrientationStep.CONFORMITY: OrientationConformityForm,
+        OrientationStep.REFERENT: OrientationReferentForm,
+        OrientationStep.DOCUMENTS: OrientationDocumentsForm,
+    }
+
+    def setup_wizard(self):
+        self.dora_client = DoraAPIClient(settings.DORA_API_BASE_URL, settings.DORA_API_TOKEN)
+        self.service = get_object_or_404(
+            insertion_models.Service.objects.select_related("kind", "structure", "fee", "source").prefetch_related(
+                "publics",
+            ),
+            uid=self.wizard_session.get("service_uid"),
+        )
+        self.job_seeker = get_object_or_404(
+            User.objects.select_related("jobseeker_profile"),
+            public_id=self.wizard_session.get("job_seeker_public_id"),
+            kind=UserKind.JOB_SEEKER,
+        )
+
+    def get_form(self, step, data):
+        files = self.request.FILES if self.request.method == "POST" else None
+        return self.get_form_class(step)(
+            initial=self.get_form_initial(step), data=data, files=files, **self.get_form_kwargs(step)
+        )
+
+    def get_form_kwargs(self, step):
+        if step == OrientationStep.CONFORMITY:
+            return {"job_seeker": self.job_seeker}
+        return {}
+
+    def get_form_initial(self, step):
+        if step == OrientationStep.REFERENT and self.wizard_session.get(step) is self.wizard_session.NOT_SET:
+            user = self.request.user
+            return {
+                "referent_last_name": user.last_name,
+                "referent_first_name": user.first_name,
+                "referent_phone": user.phone,
+                "referent_email": user.email,
+            }
+        return super().get_form_initial(step)
+
+    def get(self, request, *args, **kwargs):
+        logger.info(
+            "orientation wizard step_viewed step=%s user=%s service_uid=%s job_seeker=%s",
+            self.step,
+            request.user.pk,
+            self.service.uid,
+            self.job_seeker.public_id,
+        )
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        if self.step == OrientationStep.DOCUMENTS:
+            if invalid_step := self.find_step_with_invalid_data_until_step(self.step):
+                return HttpResponseRedirect(self.get_step_url(invalid_step))
+
+            if not self.form.is_valid():
+                return self.render_to_response(self.get_context_data(**kwargs))
+
+            cleaned = self.form.cleaned_data
+            attachments = []
+            for field in ("credentials_documents_files", "credentials_proof_files"):
+                for uploaded_file in cleaned.get(field) or []:
+                    uploaded_file.seek(0)
+                    attachments.append((uploaded_file.name, uploaded_file))
+
+            referent_data = self.wizard_session.get(OrientationStep.REFERENT)
+            payload = {
+                "di_service_id": self.service.uid,
+                "beneficiary_first_name": self.job_seeker.first_name,
+                "beneficiary_last_name": self.job_seeker.last_name,
+                "beneficiary_email": self.job_seeker.email,
+                "beneficiary_phone": normalize_phone_number(self.job_seeker.phone),
+                "referent_first_name": referent_data["referent_first_name"],
+                "referent_last_name": referent_data["referent_last_name"],
+                "referent_email": referent_data["referent_email"],
+                "referent_phone": referent_data["referent_phone"],
+                "data_protection_commitment": cleaned["gdpr_consent"],
+            }
+            if orientation_reason := referent_data.get("orientation_reason"):
+                payload["orientation_reasons"] = orientation_reason
+            if pole_emploi_id := self.job_seeker.jobseeker_profile.pole_emploi_id:
+                payload["beneficiary_france_travail_number"] = pole_emploi_id
+            if (organization := request.current_organization) and (prescriber := request.user):
+                emplois_data = {
+                    "beneficiary_id": str(self.job_seeker.public_id),
+                    "structure_id": str(organization.uid),
+                    "structure_name": organization.name,
+                    "prescriber_id": str(prescriber.public_id),
+                    "prescriber_email": prescriber.email,
+                    "prescriber_first_name": prescriber.first_name,
+                    "prescriber_last_name": prescriber.last_name,
+                }
+                if prescriber_phone := normalize_phone_number(prescriber.phone or referent_data["referent_phone"]):
+                    emplois_data["prescriber_phone"] = prescriber_phone
+                if organization.siret:
+                    emplois_data["structure_siret"] = organization.siret
+                payload["emplois_data"] = emplois_data
+
+            try:
+                self.dora_client.create_orientation(payload, attachments)
+            except DoraAPIException:
+                logger.info(
+                    "orientation wizard submission_failed reason=create_orientation "
+                    "user=%s service_uid=%s job_seeker=%s",
+                    request.user.pk,
+                    self.service.uid,
+                    self.job_seeker.public_id,
+                )
+                messages.error(
+                    request,
+                    "Votre demande n'a pas été transmise suite à un problème technique. Merci de réessayer.",
+                )
+                return self.render_to_response(self.get_context_data(**kwargs))
+
+            logger.info(
+                "orientation wizard submitted user=%s service_uid=%s job_seeker=%s",
+                request.user.pk,
+                self.service.uid,
+                self.job_seeker.public_id,
+            )
+            confirmation_url = reverse(
+                "insertion_views:orientation_confirmation",
+                kwargs={"service_uid": self.service.uid},
+                query={"job_seeker_public_id": self.job_seeker.public_id},
+            )
+            self.wizard_session.delete()
+            return HttpResponseRedirect(confirmation_url)
+
+        if self.form.is_valid():
+            logger.info(
+                "orientation wizard step_completed step=%s user=%s service_uid=%s job_seeker=%s",
+                self.step,
+                request.user.pk,
+                self.service.uid,
+                self.job_seeker.public_id,
+            )
+        return super().post(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        matomo_titles = {
+            OrientationStep.CONFORMITY: "Orientation service - valider conformité",
+            OrientationStep.REFERENT: "Orientation service - compléter demande",
+            OrientationStep.DOCUMENTS: "Orientation service - documents justificatifs",
+        }
+        return super().get_context_data(**kwargs) | {
+            "service": self.service,
+            "job_seeker": self.job_seeker,
+            "can_view_personal_information": can_view_personal_information(self.request, self.job_seeker),
+            "can_edit_personal_information": can_edit_personal_information(self.request, self.job_seeker),
+            "missing_beneficiary_fields": get_missing_orientation_beneficiary_field_labels(self.job_seeker),
+            "credential_documents": self.service.generate_credential_documents_info(),
+            "OrientationStep": OrientationStep,
+            "matomo_custom_title": matomo_titles[self.step],
+            "show_orientation_disclaimer": not self.wizard_session.get("disclaimer_dismissed", False),
+            "orientation_session_uuid": self.wizard_session.name,
+        }
+
+
+@require_POST
+def dismiss_orientation_disclaimer(request, session_uuid):
+    try:
+        wizard_session = SessionNamespace(
+            request.session,
+            OrientationWizardView.expected_session_kind,
+            session_uuid,
+        )
+    except SessionNamespaceException:
+        raise Http404
+    wizard_session.set("disclaimer_dismissed", True)
+    return HttpResponseRedirect(
+        get_safe_url(
+            request,
+            "next",
+            fallback_url=reverse(
+                OrientationWizardView.url_name,
+                kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+            ),
+        )
+    )

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -377,7 +377,7 @@ class GetOrCreateJobSeekerStartView(View):
         super().setup(request, *args, **kwargs)
 
         self.tunnel = request.GET.get("tunnel")
-        if self.tunnel not in ("sender", "hire", "gps", "standalone"):
+        if self.tunnel not in ("sender", "hire", "gps", "standalone", "orientation"):
             raise Http404
         self.from_url = get_safe_url(request, "from_url")
         if not self.from_url:
@@ -409,6 +409,11 @@ class GetOrCreateJobSeekerStartView(View):
             except ValueError:  # In case the pk isn't an integer
                 raise Http404("Aucune entreprise n'a été trouvée")
             data["apply"] = apply_data
+        elif self.tunnel == "orientation":
+            service_uid = request.GET.get("service_uid")
+            if not service_uid:
+                raise Http404
+            data["orientation"] = {"service_uid": service_uid}
 
         self.job_seeker_session = SessionNamespace.create(request.session, JobSeekerSessionKinds.GET_OR_CREATE, data)
 
@@ -419,7 +424,7 @@ class GetOrCreateJobSeekerStartView(View):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        if self.tunnel in ("sender", "gps", "standalone"):
+        if self.tunnel in ("sender", "gps", "standalone", "orientation"):
             view_name = "job_seekers_views:check_nir_for_sender"
         elif self.tunnel == "hire":
             view_name = "job_seekers_views:check_nir_for_hire"
@@ -461,15 +466,17 @@ class JobSeekerBaseView(ExpectedJobSeekerSessionMixin, TemplateView):
         self.prescription_process = None
         self.auto_prescription_process = None
         self.standalone_creation = None
+        self.is_orientation = False
         self.is_gps = False
 
     def setup(self, request, *args, hire_process=False, **kwargs):
         super().setup(request, *args, **kwargs)
         self.is_gps = self.job_seeker_session.get("config", {}).get("tunnel") == "gps"
+        self.is_orientation = self.job_seeker_session.get("config", {}).get("tunnel") == "orientation"
         if company_pk := self.job_seeker_session.get("apply", {}).get("company_pk"):
             if not self.is_gps:
                 self.company = get_object_or_404(Company.objects.with_has_active_members(), pk=company_pk)
-        self.standalone_creation = not self.is_gps and self.company is None
+        self.standalone_creation = not self.is_gps and self.company is None and not self.is_orientation
         self.hire_process = hire_process
         self.prescription_process = (
             not self.hire_process
@@ -495,6 +502,13 @@ class JobSeekerBaseView(ExpectedJobSeekerSessionMixin, TemplateView):
     def get_exit_url(self, job_seeker, created=False):
         if self.is_gps:
             return reverse("gps:group_list")
+        if self.is_orientation:
+            service_uid = self.job_seeker_session.get("orientation", {}).get("service_uid")
+            return reverse(
+                "insertion_views:start_orientation",
+                kwargs={"service_uid": service_uid},
+                query={"job_seeker_public_id": job_seeker.public_id},
+            )
         if self.standalone_creation and self.is_job_seeker_in_user_jobseekers_list(job_seeker) and not created:
             params = {
                 "job_seeker_public_id": job_seeker.public_id,

--- a/tests/files/test_forms.py
+++ b/tests/files/test_forms.py
@@ -51,7 +51,12 @@ def test_clean_returns_list(data, expected_count):
 
 def test_clean_rejects_invalid_extension():
     with pytest.raises(forms.ValidationError):
-        _create_multifile_input().clean([SimpleUploadedFile("left-pad.exe", b"boo")])
+        _create_multifile_input().clean(
+            [
+                SimpleUploadedFile("ok.pdf", b"valid"),
+                SimpleUploadedFile("left-pad.exe", b"boo"),
+            ]
+        )
 
 
 def test_clean_rejects_oversized_file():

--- a/tests/files/test_forms.py
+++ b/tests/files/test_forms.py
@@ -1,0 +1,60 @@
+import pytest
+from django import forms
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from itou.files.forms import ItouFileInput, ItouMultiFileField, ItouMultiFileInput
+
+
+ALLOWED_EXTENSIONS = ["pdf", "png"]
+
+
+def _create_multifile_input(max_upload_size=42):
+    return ItouMultiFileField(
+        required=False,
+        content_type=".pdf,.png",
+        max_upload_size=max_upload_size,
+        allowed_extensions=ALLOWED_EXTENSIONS,
+    )
+
+
+def test_input_inherits_and_specializes_minimally():
+    widget = ItouMultiFileInput(
+        content_type="foo/bar",
+        max_upload_size_mb=5,
+        accepted_formats_label="On prend tout !",
+    )
+    assert isinstance(widget, ItouFileInput)
+    assert widget.allow_multiple_selected is True
+    assert widget.template_name == "utils/widgets/multi_file_input.html"
+    assert widget.attrs["accept"] == "foo/bar"
+    context = widget.get_context("docs", None, {"id": "id_docs"})["widget"]
+    assert context["max_upload_size_mb"] == 5
+    assert context["accepted_formats_label"] == "On prend tout !"
+
+
+@pytest.mark.parametrize(
+    "data,expected_count",
+    [
+        (SimpleUploadedFile("a.pdf", b"some_content"), 1),
+        (
+            [
+                SimpleUploadedFile("a.pdf", b"some_content"),
+                SimpleUploadedFile("b.png", b"other_content"),
+            ],
+            2,
+        ),
+    ],
+)
+def test_clean_returns_list(data, expected_count):
+    assert len(_create_multifile_input().clean(data)) == expected_count
+
+
+def test_clean_rejects_invalid_extension():
+    with pytest.raises(forms.ValidationError):
+        _create_multifile_input().clean([SimpleUploadedFile("left-pad.exe", b"boo")])
+
+
+def test_clean_rejects_oversized_file():
+    field = _create_multifile_input(max_upload_size=10)
+    with pytest.raises(forms.ValidationError):
+        field.clean([SimpleUploadedFile("a.pdf", b"x" * 11)])

--- a/tests/utils/apis/test_dora.py
+++ b/tests/utils/apis/test_dora.py
@@ -1,0 +1,60 @@
+import io
+import json
+
+import pytest
+import respx
+
+from itou.utils.apis.dora import DoraAPIClient, DoraAPIException
+
+
+DORA_BASE_URL = "https://dora-api.example.com"
+
+
+@pytest.fixture
+def dora_client():
+    return DoraAPIClient(DORA_BASE_URL, "token")
+
+
+def test_reference_data(dora_client):
+    with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
+        route = respx_mock.get("/reference-data/").respond(200, json={"foo": "bar"})
+        response = dora_client.reference_data(page=1)
+
+    assert response == {"foo": "bar"}
+    assert route.called
+
+
+def test_create_orientation_posts_multipart_with_attachments(dora_client):
+    payload = {"di_service_id": "soliguide--svc-1", "beneficiary_email": "boris@example.org"}
+
+    with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
+        route = respx_mock.post("/orientations/").respond(201, json={"id": "orientation-1"})
+        response = dora_client.create_orientation(payload, [("doc.pdf", io.BytesIO(b"file-content"))])
+
+    assert response == {"id": "orientation-1"}
+    assert route.called
+    request = route.calls.last.request
+    assert request.headers["content-type"].startswith("multipart/form-data")
+    body = request.content
+    assert b'name="data"' in body
+    assert json.dumps(payload).encode() in body
+    assert b'name="attachments"; filename="doc.pdf"' in body
+    assert b"file-content" in body
+
+
+def test_create_orientation_without_attachments_sends_data_only(dora_client):
+    payload = {"di_service_id": "soliguide--svc-1"}
+
+    with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
+        route = respx_mock.post("/orientations/").respond(201, json={"id": "orientation-1"})
+        response = dora_client.create_orientation(payload)
+
+    assert response == {"id": "orientation-1"}
+    assert b"di_service_id" in route.calls.last.request.content
+
+
+def test_create_orientation_raises_on_http_error(dora_client):
+    with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
+        respx_mock.post("/orientations/").respond(500)
+        with pytest.raises(DoraAPIException):
+            dora_client.create_orientation({"di_service_id": "soliguide--svc-1"})

--- a/tests/utils/apis/test_dora.py
+++ b/tests/utils/apis/test_dora.py
@@ -1,5 +1,4 @@
 import io
-import json
 
 import pytest
 import respx
@@ -25,7 +24,11 @@ def test_reference_data(dora_client):
 
 
 def test_create_orientation_posts_multipart_with_attachments(dora_client):
-    payload = {"di_service_id": "soliguide--svc-1", "beneficiary_email": "boris@example.org"}
+    payload = {
+        "di_service_id": "soliguide--svc-1",
+        "beneficiary_email": "boris@example.org",
+        "emplois_data": {"beneficiary_id": "123", "prescriber_phone": "0612345678"},
+    }
 
     with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
         route = respx_mock.post("/orientations/").respond(201, json={"id": "orientation-1"})
@@ -36,13 +39,15 @@ def test_create_orientation_posts_multipart_with_attachments(dora_client):
     request = route.calls.last.request
     assert request.headers["content-type"].startswith("multipart/form-data")
     body = request.content
-    assert b'name="data"' in body
-    assert json.dumps(payload).encode() in body
+    assert b'name="di_service_id"' in body
+    assert b"soliguide--svc-1" in body
+    assert b'name="emplois_data.beneficiary_id"' in body
     assert b'name="attachments"; filename="doc.pdf"' in body
     assert b"file-content" in body
+    assert b'name="data"' not in body
 
 
-def test_create_orientation_without_attachments_sends_data_only(dora_client):
+def test_create_orientation_without_attachments_sends_flat_form_fields(dora_client):
     payload = {"di_service_id": "soliguide--svc-1"}
 
     with respx.mock(base_url=f"{DORA_BASE_URL}/api/emplois/") as respx_mock:
@@ -50,7 +55,9 @@ def test_create_orientation_without_attachments_sends_data_only(dora_client):
         response = dora_client.create_orientation(payload)
 
     assert response == {"id": "orientation-1"}
-    assert b"di_service_id" in route.calls.last.request.content
+    request = route.calls.last.request
+    assert request.headers["content-type"].startswith("application/x-www-form-urlencoded")
+    assert b"di_service_id=soliguide--svc-1" in request.content
 
 
 def test_create_orientation_raises_on_http_error(dora_client):

--- a/tests/utils/test_phone.py
+++ b/tests/utils/test_phone.py
@@ -1,0 +1,20 @@
+import pytest
+
+from itou.utils.phone import normalize_phone_number
+
+
+@pytest.mark.parametrize(
+    "phone,expected",
+    [
+        ("", None),
+        ("0601901570", "0601901570"),
+        ("06 01 90 15 70", "0601901570"),
+        ("+33601901570", "0601901570"),
+        ("+33 6 01 90 15 70", "0601901570"),
+        ("0033601901570", "0601901570"),
+        ("123", None),
+        ("+336019015701", None),
+    ],
+)
+def test_normalize_phone_number(phone, expected):
+    assert normalize_phone_number(phone) == expected

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -40,7 +40,7 @@
                                           </i>
                                       </button>
                                       <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-service-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-service-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                                               <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                               </i>
                                               <span>
@@ -87,7 +87,7 @@
                           <p>
                               Ma structure de test
                           </p>
-                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structure/test-structure-uid/card" type="button">
+                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-uid/" type="button">
                               Voir la fiche structure
                           </a>
                       </div>
@@ -183,7 +183,7 @@
                                           </i>
                                       </button>
                                       <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-service-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-service-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                                               <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                               </i>
                                               <span>
@@ -230,7 +230,7 @@
                           <p>
                               Ma structure de test
                           </p>
-                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structure/test-structure-uid/card" type="button">
+                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-uid/" type="button">
                               Voir la fiche structure
                           </a>
                       </div>
@@ -318,7 +318,7 @@
                       </i>
                   </button>
                   <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-not-orientable-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-not-orientable-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                           <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                           </i>
                           <span>
@@ -352,7 +352,7 @@
                       </i>
                   </button>
                   <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-orientable-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                           <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                           </i>
                           <span>
@@ -413,7 +413,7 @@
                                           </i>
                                       </button>
                                       <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-service-full-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                                          <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-service-full-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                                               <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                                               </i>
                                               <span>
@@ -539,7 +539,7 @@
                           <p>
                               Structure complète
                           </p>
-                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structure/test-structure-full-uid/card" type="button">
+                          <a class="btn btn-secondary w-100" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-full-uid/" type="button">
                               Voir la fiche structure
                           </a>
                       </div>
@@ -612,7 +612,7 @@
                       </i>
                   </button>
                   <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/service/test-orientable-uid/card" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                           <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                           </i>
                           <span>

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -29,8 +29,10 @@
                           </h2>
                           <div class="form-row align-items-center gx-3">
                               <div class="form-group col-12 col-lg-auto">
-                                  <a class="btn btn-lg btn-white btn-block justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://dora.inclusion.gouv.fr/services/test-service-uid/orienter?mtm_campaign=lesemplois&mtm_kwd=service-professional" rel="noopener" target="_blank">
-                                      Orienter le bénéficiaire
+                                  <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="/insertion/orientations/test-service-uid/start/">
+                                      <span>
+                                          Orienter un bénéficiaire
+                                      </span>
                                   </a>
                               </div>
                               <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
@@ -172,8 +174,10 @@
                           </h2>
                           <div class="form-row align-items-center gx-3">
                               <div class="form-group col-12 col-lg-auto">
-                                  <a class="btn btn-lg btn-white btn-block justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://dora.inclusion.gouv.fr/services/di--test-service-uid/orienter?mtm_campaign=lesemplois&mtm_kwd=service-professional" rel="noopener" target="_blank">
-                                      Orienter le bénéficiaire
+                                  <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="/insertion/orientations/test-service-uid/start/">
+                                      <span>
+                                          Orienter un bénéficiaire
+                                      </span>
                                   </a>
                               </div>
                               <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
@@ -341,8 +345,10 @@
       </h2>
       <div class="form-row align-items-center gx-3">
           <div class="form-group col-12 col-lg-auto">
-              <a class="btn btn-lg btn-white btn-block justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://dora.inclusion.gouv.fr/services/di--test-orientable-uid/orienter?mtm_campaign=lesemplois&mtm_kwd=service-professional" rel="noopener" target="_blank">
-                  Orienter le bénéficiaire
+              <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="/insertion/orientations/test-orientable-uid/start/">
+                  <span>
+                      Orienter un bénéficiaire
+                  </span>
               </a>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
@@ -397,8 +403,10 @@
                           </h2>
                           <div class="form-row align-items-center gx-3">
                               <div class="form-group col-12 col-lg-auto">
-                                  <a class="btn btn-lg btn-white btn-block justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://dora.inclusion.gouv.fr/services/test/orienter?mtm_campaign=lesemplois&mtm_kwd=service-professional" rel="noopener" target="_blank">
-                                      Orienter le bénéficiaire
+                                  <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="/insertion/orientations/test-service-full-uid/start/">
+                                      <span>
+                                          Orienter un bénéficiaire
+                                      </span>
                                   </a>
                               </div>
                               <div class="form-group col-12 col-lg-auto">
@@ -601,8 +609,10 @@
       </h2>
       <div class="form-row align-items-center gx-3">
           <div class="form-group col-12 col-lg-auto">
-              <a class="btn btn-lg btn-white btn-block justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://test.example.com" rel="noopener" target="_blank">
-                  Orienter le bénéficiaire
+              <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://test.example.com" rel="noopener" target="_blank">
+                  <span>
+                      Test link
+                  </span>
               </a>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
@@ -612,7 +622,7 @@
                       </i>
                   </button>
                   <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
-                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-external-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
                           <i aria-hidden="true" class="ri-file-copy-line fw-normal">
                           </i>
                           <span>

--- a/tests/www/insertion_views/__snapshots__/test_wizard.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_wizard.ambr
@@ -1,0 +1,752 @@
+# serializer version: 1
+# name: test_conformity_step_blocks_when_beneficiary_info_is_incomplete
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12">
+                  <div class="c-stepper mb-3 mb-md-4">
+                      <div class="progress">
+                          <div aria-labelledby="currentProgressState" aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                          </div>
+                      </div>
+                      <p id="currentProgressState">
+                          <strong>
+                              Étape 1/3
+                          </strong>
+                          :
+          
+              Valider la conformité
+                      </p>
+                  </div>
+              </div>
+          </div>
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="alert alert-warning mb-3 mb-md-4" id="missing-beneficiary-infos-warning" role="status">
+                      <div class="row">
+                          <div class="col-auto pe-0">
+                              <i aria-hidden="true" class="ri-error-warning-line ri-xl text-warning">
+                              </i>
+                          </div>
+                          <div class="col">
+                              <p class="mb-2">
+                                  <strong>
+                                      Informations manquantes
+                                  </strong>
+                              </p>
+                              <p class="mb-0">
+                                  Les informations suivantes doivent être renseignées pour poursuivre l'orientation :
+                              </p>
+                              <ul class="mb-0">
+                                  <li>
+                                      <strong>
+                                          Prénom
+                                      </strong>
+                                  </li>
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+                  <div class="c-form mb-3 mb-md-4">
+                      <form class="js-prevent-multiple-submit" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <div class="alert alert-danger" data-emplois-give-focus-if-exist="" role="alert" tabindex="0">
+                              <p class="mb-2">
+                                  <strong>
+                                      Votre formulaire contient une erreur
+                                  </strong>
+                              </p>
+                              <ul class="mb-0">
+                                  <li>
+                                      Les informations du candidat sont incomplètes : Prénom.
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="alert alert-info mb-3 mb-md-4" role="status">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                                      </i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-0">
+                                          Veuillez vous assurer que les coordonnées de votre usager sont bien à jour
+                                      </p>
+                                  </div>
+                              </div>
+                          </div>
+                          <div class="c-box mb-3 mb-md-4 position-relative">
+                              <div class="position-absolute top-0 end-0 m-3">
+                                  <span class="btn btn-outline-primary w-100 w-md-auto disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
+                                      Modifier
+                                  </span>
+                              </div>
+                              <ul class="list-data mb-0 pe-md-5">
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          Adresse
+                                      </small>
+                                      <i class="text-disabled">
+                                          Non renseignée
+                                      </i>
+                                  </li>
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          N° de téléphone
+                                      </small>
+                                      <strong>
+                                          0… 0… 0… 0… 0…
+                                      </strong>
+                                  </li>
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          Adresse mail
+                                      </small>
+                                      <strong>
+                                          t…
+                                      </strong>
+                                  </li>
+                              </ul>
+                          </div>
+                          <hr class="my-3"/>
+                          <h2 class="h3">
+                              Conditions et critères requis
+                          </h2>
+                          <div class="form-group form-group-required-check form-group-required">
+                              <div class="form-check">
+                                  <input checked="" class="form-check-input is-valid" id="id_confirms_conditions" name="confirms_conditions" required="" type="checkbox"/>
+                                  <label class="form-check-label" for="id_confirms_conditions">
+                                      Je confirme que l'usager remplit au moins une condition et un critère requis.
+                                  </label>
+                              </div>
+                          </div>
+                          <div class="row">
+                              <div class="col-12">
+                                  <hr class="mb-3"/>
+                                  <small class="d-inline-block mb-3">
+                                      * champs obligatoires
+                                  </small>
+                                  <div class="form-row align-items-center justify-content-end gx-3">
+                                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                          <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/insertion/services/test-orientation-incomplete-uid/">
+                                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                                              </i>
+                                              <span>
+                                                  Annuler
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                          <button class="btn btn-block btn-primary disabled" type="button">
+                                              <span>
+                                                  Suivant
+                                              </span>
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </form>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-incomplete-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-incomplete-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation incomplete
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-incomplete-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-incomplete-uid/?back_url=/insertion/orientations/[UUID of session]/create/confirm/">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: test_orientation_wizard_happy_path[confirmation]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="c-form">
+                      <h2 class="h3">
+                          Votre demande a bien été transmise !
+                      </h2>
+                      <p>
+                          Le récapitulatif de la demande vous a été envoyé, ainsi qu'à l'adresse e-mail de
+                              Jane DOE :
+                              usager@example.org.
+                      </p>
+                      <a class="btn btn-primary" href="/dashboard/">
+                          Retour à l'accueil
+                      </a>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-wizard-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-wizard-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation wizard
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-wizard-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-wizard-uid/?back_url=/insertion/orientations/test-orientation-wizard-uid/confirmation/%3Fjob_seeker_public_id%3D7614fc4b-aef9-4694-ab17-12324300180a">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: test_orientation_wizard_happy_path[conformity]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12">
+                  <div class="c-stepper mb-3 mb-md-4">
+                      <div class="progress">
+                          <div aria-labelledby="currentProgressState" aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                          </div>
+                      </div>
+                      <p id="currentProgressState">
+                          <strong>
+                              Étape 1/3
+                          </strong>
+                          :
+          
+              Valider la conformité
+                      </p>
+                  </div>
+              </div>
+          </div>
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="c-form mb-3 mb-md-4">
+                      <form class="js-prevent-multiple-submit" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <div class="alert alert-info mb-3 mb-md-4" role="status">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                                      </i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-0">
+                                          Veuillez vous assurer que les coordonnées de votre usager sont bien à jour
+                                      </p>
+                                  </div>
+                              </div>
+                          </div>
+                          <div class="c-box mb-3 mb-md-4 position-relative">
+                              <div class="position-absolute top-0 end-0 m-3">
+                                  <a aria-label="Modifier les coordonnées de Jane DOE" class="btn btn-outline-primary w-100 w-md-auto" href="/dashboard/edit_job_seeker_info/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/insertion/orientations/[UUID of session]/create/confirm/">
+                                      Modifier
+                                  </a>
+                              </div>
+                              <ul class="list-data mb-0 pe-md-5">
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          Adresse
+                                      </small>
+                                      <strong>
+                                          9 Allée des Peupliers, 33000 Bordeaux
+                                      </strong>
+                                  </li>
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          N° de téléphone
+                                      </small>
+                                      <strong>
+                                          06 07 08 09 10
+                                      </strong>
+                                  </li>
+                                  <li class="has-forced-line-break">
+                                      <small>
+                                          Adresse mail
+                                      </small>
+                                      <strong>
+                                          usager@example.org
+                                      </strong>
+                                  </li>
+                              </ul>
+                          </div>
+                          <hr class="my-3"/>
+                          <h2 class="h3">
+                              Conditions et critères requis
+                          </h2>
+                          <div class="alert alert-info mb-3 mb-md-4" role="status">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                                      </i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-0">
+                                          Frais à la charge de l'usager : 20€
+                                          <i aria-label="adhésion annuelle de 10€ à la MJC Champ Libre + frais de location" class="ri-information-line ri-xl text-info" data-bs-title="adhésion annuelle de 10€ à la MJC Champ Libre + frais de location" data-bs-toggle="tooltip" role="button" tabindex="0">
+                                          </i>
+                                      </p>
+                                  </div>
+                              </div>
+                          </div>
+                          <p class="fw-bold mb-2">
+                              Publics concernés par ce service
+                          </p>
+                          <ul class="mb-3 mb-md-4">
+                              <li>
+                                  Demandeur d'emploi
+                              </li>
+                          </ul>
+                          <p class="fw-bold mb-2">
+                              Critères de condition d'accès
+                          </p>
+                          <ul class="mb-3 mb-md-4">
+                              <li>
+                                  Résident QPV / ZFRR
+                              </li>
+                          </ul>
+                          <div class="form-group form-group-required-check form-group-required">
+                              <div class="form-check">
+                                  <input class="form-check-input" id="id_confirms_conditions" name="confirms_conditions" required="" type="checkbox"/>
+                                  <label class="form-check-label" for="id_confirms_conditions">
+                                      Je confirme que l'usager remplit au moins une condition et un critère requis.
+                                  </label>
+                              </div>
+                          </div>
+                          <div class="row">
+                              <div class="col-12">
+                                  <hr class="mb-3"/>
+                                  <small class="d-inline-block mb-3">
+                                      * champs obligatoires
+                                  </small>
+                                  <div class="form-row align-items-center justify-content-end gx-3">
+                                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                          <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/insertion/services/test-orientation-wizard-uid/">
+                                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                                              </i>
+                                              <span>
+                                                  Annuler
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                          <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                                              <span>
+                                                  Suivant
+                                              </span>
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </form>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-wizard-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-wizard-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation wizard
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-wizard-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-wizard-uid/?back_url=/insertion/orientations/[UUID of session]/create/confirm/">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: test_orientation_wizard_happy_path[documents]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12">
+                  <div class="c-stepper mb-3 mb-md-4">
+                      <div class="progress">
+                          <div aria-labelledby="currentProgressState" aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="progress-bar progress-bar-100" role="progressbar">
+                          </div>
+                      </div>
+                      <p id="currentProgressState">
+                          <strong>
+                              Étape 3/3
+                          </strong>
+                          :
+          
+              Documents et justificatifs requis
+                      </p>
+                  </div>
+              </div>
+          </div>
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="c-form mb-3 mb-md-4">
+                      <form class="js-prevent-multiple-submit" enctype="multipart/form-data" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <h2 class="h3">
+                              Documents et justificatifs requis
+                          </h2>
+                          <div class="c-info mb-3 mb-md-4">
+                              <span class="c-info__summary">
+                                  Attention à ne télécharger que les pièces strictement nécessaires à la demande.
+                              </span>
+                              <div class="c-info__detail">
+                                  <p class="mb-0">
+                                      Pour des raisons de confidentialité, l'envoi de la carte vitale, des attestations
+                                              de droits santé/CPAM ou de tout autre document contenant le NIR (numéro de sécurité
+                                              sociale) n'est pas autorisé.
+                                  </p>
+                              </div>
+                          </div>
+                          <div class="form-group form-group-required">
+                              <div class="form-check">
+                                  <input class="form-check-input" id="id_gdpr_consent" name="gdpr_consent" required="" type="checkbox"/>
+                                  <label class="form-check-label" for="id_gdpr_consent">
+                                      Je m'engage en tant qu'accompagnateur, à informer la personne concernée du traitement de ses données personnelles dans le cadre de cette orientation.
+                                  </label>
+                              </div>
+                          </div>
+                          <div class="row">
+                              <div class="col-12">
+                                  <hr class="mb-3"/>
+                                  <small class="d-inline-block mb-3">
+                                      * champs obligatoires
+                                  </small>
+                                  <div class="form-row align-items-center justify-content-end gx-3">
+                                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                          <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/insertion/services/test-orientation-wizard-uid/">
+                                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                                              </i>
+                                              <span>
+                                                  Annuler
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-1 order-lg-2">
+                                          <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/insertion/orientations/[UUID of session]/create/fill/">
+                                              <span>
+                                                  Retour
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                          <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                                              <span>
+                                                  Suivant
+                                              </span>
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </form>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-wizard-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-wizard-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation wizard
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-wizard-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-wizard-uid/?back_url=/insertion/orientations/[UUID of session]/create/submit/">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: test_orientation_wizard_happy_path[referent]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12">
+                  <div class="c-stepper mb-3 mb-md-4">
+                      <div class="progress">
+                          <div aria-labelledby="currentProgressState" aria-valuemax="100" aria-valuemin="0" aria-valuenow="66" class="progress-bar progress-bar-66" role="progressbar">
+                          </div>
+                      </div>
+                      <p id="currentProgressState">
+                          <strong>
+                              Étape 2/3
+                          </strong>
+                          :
+          
+              Compléter la demande
+                      </p>
+                  </div>
+              </div>
+          </div>
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="c-form mb-3 mb-md-4">
+                      <form class="js-prevent-multiple-submit" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <fieldset>
+                              <legend class="mb-0">
+                                  Conseiller ou conseillère référent(e)
+                              </legend>
+                              <p class="fs-sm">
+                                  Personne en charge de l'accompagnement et du suivi professionnel de la situation
+                                          de l'usager. Si ce n'est pas vous, veuillez modifier les informations ci-dessous
+                              </p>
+                              <div class="form-group form-group-input-w-lg-66 form-group-required">
+                                  <label class="form-label" for="id_referent_last_name">
+                                      Nom
+                                  </label>
+                                  <input class="form-control" id="id_referent_last_name" name="referent_last_name" required="" type="text" value="Dupont"/>
+                              </div>
+                              <div class="form-group form-group-input-w-lg-66 form-group-required">
+                                  <label class="form-label" for="id_referent_first_name">
+                                      Prénom
+                                  </label>
+                                  <input class="form-control" id="id_referent_first_name" name="referent_first_name" required="" type="text" value="Pierre"/>
+                              </div>
+                              <div class="form-group form-group-input-w-lg-66 form-group-required">
+                                  <label class="form-label" for="id_referent_phone">
+                                      Téléphone
+                                  </label>
+                                  <input aria-describedby="id_referent_phone_helptext" class="form-control" id="id_referent_phone" name="referent_phone" required="" type="tel" value="0612345678"/>
+                                  <div class="form-text" id="id_referent_phone_helptext">
+                                      Ex : 0123456789
+                                  </div>
+                              </div>
+                              <div class="form-group form-group-input-w-lg-66 form-group-required">
+                                  <label class="form-label" for="id_referent_email">
+                                      Adresse e-mail
+                                  </label>
+                                  <input aria-describedby="id_referent_email_helptext" class="form-control" id="id_referent_email" maxlength="320" name="referent_email" required="" type="email" value="pierre.dupont@test.local"/>
+                                  <div class="form-text" id="id_referent_email_helptext">
+                                      Ex : mail@domaine.fr
+                                  </div>
+                              </div>
+                          </fieldset>
+                          <hr class="my-3"/>
+                          <fieldset>
+                              <legend>
+                                  Motif de l'orientation (facultatif)
+                              </legend>
+                              <div class="form-group">
+                                  <label class="form-label" for="id_orientation_reason">
+                                      Si besoin, détaillez ici le motif de l'orientation
+                                  </label>
+                                  <textarea aria-describedby="id_orientation_reason_helptext" class="form-control" cols="40" id="id_orientation_reason" name="orientation_reason" rows="4"></textarea>
+                                  <div class="form-text" id="id_orientation_reason_helptext">
+                                      Merci de ne pas fournir des informations considérées comme sensibles (situation personnelle ou professionnelle autre que celles cochées à l'étape 1 de la demande, etc.).
+                                  </div>
+                              </div>
+                          </fieldset>
+                          <div class="row">
+                              <div class="col-12">
+                                  <hr class="mb-3"/>
+                                  <small class="d-inline-block mb-3">
+                                      * champs obligatoires
+                                  </small>
+                                  <div class="form-row align-items-center justify-content-end gx-3">
+                                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                          <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/insertion/services/test-orientation-wizard-uid/">
+                                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                                              </i>
+                                              <span>
+                                                  Annuler
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-1 order-lg-2">
+                                          <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/insertion/orientations/[UUID of session]/create/confirm/">
+                                              <span>
+                                                  Retour
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                          <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                                              <span>
+                                                  Suivant
+                                              </span>
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </form>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-wizard-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-wizard-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation wizard
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-wizard-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-wizard-uid/?back_url=/insertion/orientations/[UUID of session]/create/fill/">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: test_orientation_wizard_happy_path[select-job-seeker]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                  <div class="c-form mb-5">
+                      <h2 class="h3">
+                          Rechercher un usager
+                      </h2>
+                      <p>
+                          Dans le menu déroulant ci-dessous, vous trouverez la liste de vos usagers.
+                      </p>
+                      <form class="c-form js-prevent-multiple-submit" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <div class="form-group form-group-input-w-lg-66 form-group-required">
+                              <label class="form-label" for="id_job_seeker">
+                                  Nom de l'usager
+                              </label>
+                              <select class="form-select django-select2" data-allow-clear="false" data-minimum-input-length="0" data-placeholder="Nom de l'usager" data-theme="bootstrap-5" id="id_job_seeker" lang="fr" name="job_seeker" required="">
+                                  <option selected="" value="">
+                                      ---------
+                                  </option>
+                                  <option value="7614fc4b-aef9-4694-ab17-12324300180a">
+                                      DOE Jane
+                                  </option>
+                              </select>
+                          </div>
+                          <div class="row">
+                              <div class="col-12">
+                                  <hr class="mb-3"/>
+                                  <small class="d-inline-block mb-3">
+                                      * champs obligatoires
+                                  </small>
+                                  <div class="form-row align-items-center justify-content-end gx-3">
+                                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                          <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/insertion/services/test-orientation-wizard-uid/">
+                                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                                              </i>
+                                              <span>
+                                                  Annuler
+                                              </span>
+                                          </a>
+                                      </div>
+                                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                          <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                                              <span>
+                                                  Suivant
+                                              </span>
+                                          </button>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </form>
+                  </div>
+                  <hr class="my-5" data-it-text="ou"/>
+                  <div class="text-center mb-3">
+                      Votre usager n'a pas encore de compte ?
+                      <a class="btn-link" data-matomo-action="clic" data-matomo-category="compte-candidat" data-matomo-event="true" data-matomo-option="creer-un-compte-candidat-orientation" href="/job-seekers/start?tunnel=orientation&from_url=%2Finsertion%2Fservices%2Ftest-orientation-wizard-uid%2F&service_uid=test-orientation-wizard-uid">
+                          Créer un compte usager
+                      </a>
+                  </div>
+              </div>
+              <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 d-flex flex-column">
+                  <div class="c-box c-box--organization mb-3 mb-md-4">
+                      <button aria-controls="collapseOrientationService-test-orientation-wizard-uid" aria-expanded="false" class="c-box--organization__summary w-100" data-bs-target="#collapseOrientationService-test-orientation-wizard-uid" data-bs-toggle="collapse" type="button">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <div>
+                              <span class="d-block h3">
+                                  Service orientation wizard
+                              </span>
+                          </div>
+                      </button>
+                      <div class="c-box--organization__detail collapse" id="collapseOrientationService-test-orientation-wizard-uid">
+                          <hr class="my-4"/>
+                          <p class="mb-0">
+                              Structure orientation wizard
+                          </p>
+                          <a class="btn btn-secondary btn-block mt-4" data-matomo-action="clic" data-matomo-category="orientation" data-matomo-event="true" data-matomo-option="voir-fiche-structure" href="/insertion/structures/test-structure-orientation-wizard-uid/?back_url=/insertion/orientations/test-orientation-wizard-uid/job-seeker/">
+                              Voir la fiche structure
+                          </a>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import pytest
 from django.conf import settings
 from django.urls import reverse
 from itoutils.django.testing import assertSnapshotQueries
@@ -8,7 +7,6 @@ from pytest_django.asserts import assertContains, assertNotContains, assertTempl
 
 from itou.insertion.models import SOURCE_DORA_VALUE, GenericReferenceItemKind, GenericReferenceItemSource
 from tests.insertion.factories import GenericReferenceItemFactory, ServiceFactory, StructureFactory
-from tests.prescribers.factories import PrescriberOrganizationFactory
 from tests.users.factories import PrescriberFactory
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
@@ -77,7 +75,7 @@ class TestStructures:
 
 class TestServices:
     LOGIN_URL = reverse("login:existing_user")
-    ORIENT_BTN_LABEL = "Orienter le bénéficiaire"
+    ORIENT_BTN_LABEL = "Orienter un bénéficiaire"
     DISPLAY_SERVICE_CONTACT_BTN = 'data-bs-target="#service-contact-modal"'
     FORMS_TO_FILL = "Documents à compléter"
 
@@ -206,19 +204,38 @@ class TestServices:
         user = PrescriberFactory(membership=True)
         test_link = "https://test.example.com"
         service = ServiceFactory(
-            uid="test-orientable-uid",
-            name="Service orientable",
+            uid="test-external-uid",
+            name="Service avec lien externe",
             updated_on="2025-01-15",
             is_orientable_with_form=False,
             mobilization_modes_professionals_external_form_link="https://test.example.com",
-            structure__uid="test-structure-orientable-uid",
+            mobilization_modes_professionals_external_form_link_text="Test link",
+            structure__uid="test-structure-external-uid",
             structure__updated_on="2025-01-15",
         )
         client.force_login(user)
         response = client.get(self.get_service_url(service))
-        assertContains(response, self.ORIENT_BTN_LABEL)
+        assertContains(response, "Test link")
         assertContains(response, f'href="{test_link}"')
         assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
+
+    def test_detail_orientable_with_external_link_prefers_wizard(self, client):
+        user = PrescriberFactory(membership=True)
+        external_link = "https://test.example.com"
+        service = ServiceFactory(
+            uid="test-orientable-ext-uid",
+            name="Service orientable avec lien externe",
+            updated_on="2025-01-15",
+            is_orientable_with_form=True,
+            mobilization_modes_professionals_external_form_link=external_link,
+            mobilization_modes_professionals_external_form_link_text="Lien externe",
+            structure__uid="test-structure-orientable-ext-uid",
+            structure__updated_on="2025-01-15",
+        )
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertContains(response, reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid}))
+        assertNotContains(response, f'href="{external_link}"')
 
     def test_detail_orientable_and_user_authenticated(self, client, snapshot):
         user = PrescriberFactory(membership=True)
@@ -346,46 +363,24 @@ class TestServices:
         response = client.get(self.get_service_url(service_no_link))
         assertNotContains(response, 'rel="canonical"')
 
-    @pytest.mark.parametrize("is_authorized", [True, False])
-    def test_detail_orientation_url_with_jwt_for_prescriber(self, client, is_authorized):
-        organization = PrescriberOrganizationFactory(authorized=is_authorized)
-        prescriber = PrescriberFactory(membership=True, membership__organization=organization)
+    def test_detail_orientation_url_points_to_wizard_start(self, client):
+        user = PrescriberFactory(membership=True)
         service = ServiceFactory(
-            uid="test-jwt-uid",
+            uid="test-wizard-uid",
             updated_on="2025-01-15",
             is_orientable_with_form=True,
-            structure__uid="test-structure-jwt-uid",
+            structure__uid="test-structure-wizard-uid",
             structure__updated_on="2025-01-15",
         )
-        client.force_login(prescriber)
+        client.force_login(user)
 
-        orientation_token = "jwt-token"
-
-        with patch("itou.www.insertion_views.views.get_orientation_jwt", return_value=orientation_token):
-            response = client.get(self.get_service_url(service))
+        response = client.get(self.get_service_url(service))
 
         assert response.status_code == 200
-
-        # Regular prescribers get direct DORA URL without nexus auto_login
-        regular_dora_url = (
-            f"https://dora.inclusion.gouv.fr/services/di--{service.uid}/orienter"
-            f"?mtm_campaign=lesemplois&amp;mtm_kwd=service-professional"
-        )
-        # Authorized ProConnect prescribers get orientation URL wrapped in nexus auto_login with JWT
-        authorized_dora_url = reverse(
-            "nexus:auto_login",
-            query={
-                "next_url": f"https://dora.inclusion.gouv.fr/services/di--{service.uid}/orienter"
-                f"?mtm_campaign=lesemplois&mtm_kwd=service-professional&op={orientation_token}"
-            },
-        )
-
-        if is_authorized:
-            assertContains(response, authorized_dora_url)
-        else:
-            assertNotContains(response, authorized_dora_url)
-            assertContains(response, regular_dora_url)
-            assertNotContains(response, "op=")
+        action_box = str(parse_response_to_soup(response, ".c-box--action"))
+        wizard_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+        assert wizard_url in action_box
+        assert reverse("nexus:auto_login") not in action_box
 
     def test_detail_credential_documents_empty(self, client):
         service = ServiceFactory(

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -1,0 +1,374 @@
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
+
+from itou.insertion.models import GenericReferenceItemKind
+from itou.utils.apis.dora import DoraAPIException
+from itou.www.insertion_views.views import OrientationStep, OrientationWizardView
+from tests.insertion.factories import GenericReferenceItemFactory, ServiceFactory
+from tests.prescribers.factories import PrescriberMembershipFactory
+from tests.users.factories import JobSeekerAssignmentFactory, JobSeekerFactory, PrescriberFactory
+from tests.utils.testing import get_session_name, parse_response_to_soup, pretty_indented
+
+
+def test_orientation_wizard_happy_path(client, snapshot, mocker):
+    prescriber = PrescriberMembershipFactory(
+        organization__authorized=True,
+        organization__for_snapshot=True,
+        user__for_snapshot=True,
+    ).user
+    job_seeker = JobSeekerFactory(
+        for_snapshot=True,
+        email="usager@example.org",
+        phone="0607080910",
+        address_line_1="9 Allée des Peupliers",
+        post_code="33000",
+        city="Bordeaux",
+    )
+    JobSeekerAssignmentFactory(job_seeker=job_seeker, professional=prescriber)
+    fee = GenericReferenceItemFactory(
+        kind=GenericReferenceItemKind.FEE,
+        value="payant",
+        label="20€",
+    )
+    public = GenericReferenceItemFactory(
+        kind=GenericReferenceItemKind.PUBLIC,
+        value="demandeur-emploi",
+        label="Demandeur d'emploi",
+    )
+    service = ServiceFactory(
+        uid="test-orientation-wizard-uid",
+        name="Service orientation wizard",
+        updated_on="2025-01-15",
+        is_orientable_with_form=True,
+        source__value="dora",
+        structure__uid="test-structure-orientation-wizard-uid",
+        structure__name="Structure orientation wizard",
+        structure__updated_on="2025-01-15",
+        fee=fee,
+        fee_details="adhésion annuelle de 10€ à la MJC Champ Libre + frais de location",
+        access_conditions_dora=["Résident QPV / ZFRR"],
+    )
+    service.publics.add(public)
+
+    select_job_seeker_url = reverse(
+        "insertion_views:orientation_select_job_seeker",
+        kwargs={"service_uid": service.uid},
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    response = client.get(start_url)
+    assertRedirects(response, select_job_seeker_url, fetch_redirect_response=False)
+
+    response = client.get(select_job_seeker_url)
+    assert pretty_indented(parse_response_to_soup(response, "#main .s-section")) == snapshot(name="select-job-seeker")
+
+    response = client.post(select_job_seeker_url, data={"job_seeker": job_seeker.public_id}, follow=True)
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+    assert response.request["PATH_INFO"] == conformity_url
+
+    replace_session_uuid = [("href", session_uuid, "[UUID of session]"), ("action", session_uuid, "[UUID of session]")]
+    response = client.get(conformity_url)
+    assert pretty_indented(
+        parse_response_to_soup(response, "#main .s-section", replace_in_attr=replace_session_uuid)
+    ) == snapshot(name="conformity")
+
+    response = client.post(conformity_url, {"confirms_conditions": "on"})
+    referent_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.REFERENT},
+    )
+    assertRedirects(response, referent_url, fetch_redirect_response=False)
+
+    response = client.get(referent_url)
+    assert pretty_indented(
+        parse_response_to_soup(response, "#main .s-section", replace_in_attr=replace_session_uuid)
+    ) == snapshot(name="referent")
+
+    response = client.post(
+        referent_url,
+        {
+            "referent_last_name": "Dupont",
+            "referent_first_name": "Jean",
+            "referent_phone": "0612345678",
+            "referent_email": "jean@example.com",
+        },
+    )
+    documents_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.DOCUMENTS},
+    )
+    assertRedirects(response, documents_url, fetch_redirect_response=False)
+
+    response = client.get(documents_url)
+    assert pretty_indented(
+        parse_response_to_soup(response, "#main .s-section", replace_in_attr=replace_session_uuid)
+    ) == snapshot(name="documents")
+
+    mock_dora = mocker.patch("itou.www.insertion_views.views.DoraAPIClient")
+    response = client.post(
+        documents_url,
+        {
+            "credentials_documents_files": SimpleUploadedFile("doc.pdf", b"x", content_type="application/pdf"),
+            "credentials_proof_files": SimpleUploadedFile("proof.pdf", b"y", content_type="application/pdf"),
+            "gdpr_consent": "on",
+        },
+    )
+    confirmation_url = reverse(
+        "insertion_views:orientation_confirmation",
+        kwargs={"service_uid": service.uid},
+        query={"job_seeker_public_id": job_seeker.public_id},
+    )
+    assertRedirects(response, confirmation_url, fetch_redirect_response=False)
+    mock_dora.return_value.create_orientation.assert_called_once()
+
+    response = client.get(confirmation_url)
+    assert pretty_indented(parse_response_to_soup(response, "#main .s-section")) == snapshot(name="confirmation")
+
+
+def test_documents_step_credential_documents(client):
+    prescriber = PrescriberFactory(membership=True)
+    job_seeker = JobSeekerFactory(phone="0606060606")
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        credentials_documents=[
+            "production/eed8a0d4-238d-4921-a133-f5895e79fafb/flyer_PACEA_2025.pdf",
+            "production/eed8a0d4-238d-4921-a133-f5895e79fafb/flyer_CEJ_2025.pdf",
+        ],
+        structure__name="Structure orientation wizard",
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    client.get(start_url + f"?job_seeker_public_id={job_seeker.public_id}")
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+    referent_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.REFERENT},
+    )
+    documents_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.DOCUMENTS},
+    )
+
+    client.post(conformity_url, {"confirms_conditions": "on"})
+    client.post(
+        referent_url,
+        {
+            "referent_last_name": "Dupont",
+            "referent_first_name": "Jean",
+            "referent_phone": "0612345678",
+            "referent_email": "jean@example.com",
+        },
+    )
+
+    s3_urls = [
+        "https://s3.example.com/flyer_PACEA_2025.pdf?token=aaa",
+        "https://s3.example.com/flyer_CEJ_2025.pdf?token=bbb",
+    ]
+    with patch(
+        "itou.insertion.models.generate_dora_storage_url",
+        side_effect=s3_urls,
+    ):
+        response = client.get(documents_url)
+
+    assert response.status_code == 200
+    assert response.context["credential_documents"] == [
+        ("flyer_PACEA_2025.pdf", "https://s3.example.com/flyer_PACEA_2025.pdf?token=aaa"),
+        ("flyer_CEJ_2025.pdf", "https://s3.example.com/flyer_CEJ_2025.pdf?token=bbb"),
+    ]
+    assertContains(response, "flyer_PACEA_2025.pdf")
+    assertContains(response, "flyer_CEJ_2025.pdf")
+    assertContains(response, "https://s3.example.com/flyer_PACEA_2025.pdf?token=aaa")
+    assertNotContains(response, "production/eed8a0d4-238d-4921-a133-f5895e79fafb")
+
+
+def test_start_requires_login(client):
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        structure__name="Structure orientation wizard",
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    response = client.get(start_url)
+
+    assert response.status_code == 302
+    assert "/accounts/login" in response.headers["Location"]
+
+
+def test_session_isolation_between_users(client):
+    prescriber = PrescriberFactory(membership=True)
+    job_seeker = JobSeekerFactory(phone="0606060606")
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        structure__name="Structure orientation wizard",
+    )
+    intruder = PrescriberFactory(membership=True)
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    client.get(start_url + f"?job_seeker_public_id={job_seeker.public_id}")
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+
+    client.force_login(intruder)
+    response = client.get(conformity_url)
+
+    assert response.status_code == 404
+
+
+def test_conformity_step_blocks_when_beneficiary_info_is_incomplete(client, snapshot):
+    prescriber = PrescriberFactory(membership=True)
+    job_seeker = JobSeekerFactory(first_name="", last_name="DUPONT", phone="0606060606", email="test@example.org")
+    service = ServiceFactory(
+        uid="test-orientation-incomplete-uid",
+        name="Service orientation incomplete",
+        updated_on="2025-01-15",
+        is_orientable_with_form=True,
+        structure__uid="test-structure-orientation-incomplete-uid",
+        structure__name="Structure orientation wizard",
+        structure__updated_on="2025-01-15",
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    client.get(start_url + f"?job_seeker_public_id={job_seeker.public_id}")
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+
+    response = client.post(conformity_url, {"confirms_conditions": "on"})
+
+    assert response.status_code == 200
+    assert (
+        pretty_indented(
+            parse_response_to_soup(
+                response,
+                "#main .s-section",
+                replace_in_attr=[
+                    ("href", session_uuid, "[UUID of session]"),
+                    ("action", session_uuid, "[UUID of session]"),
+                ],
+            )
+        )
+        == snapshot
+    )
+
+
+def test_documents_step_redirects_to_error_page_when_orientation_submission_fails(client, mocker):
+    prescriber = PrescriberFactory(membership=True)
+    job_seeker = JobSeekerFactory(phone="0606060606")
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        structure__name="Structure orientation wizard",
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    client.get(start_url + f"?job_seeker_public_id={job_seeker.public_id}")
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+    referent_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.REFERENT},
+    )
+    documents_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.DOCUMENTS},
+    )
+
+    client.post(conformity_url, {"confirms_conditions": "on"})
+    client.post(
+        referent_url,
+        {
+            "referent_last_name": "Dupont",
+            "referent_first_name": "Jean",
+            "referent_phone": "0612345678",
+            "referent_email": "jean@example.com",
+        },
+    )
+
+    mock_dora = mocker.patch("itou.www.insertion_views.views.DoraAPIClient")
+    mock_dora.return_value.create_orientation.side_effect = DoraAPIException
+
+    response = client.post(
+        documents_url,
+        {
+            "credentials_documents_files": SimpleUploadedFile("doc.pdf", b"x", content_type="application/pdf"),
+            "credentials_proof_files": SimpleUploadedFile("proof.pdf", b"y", content_type="application/pdf"),
+            "gdpr_consent": "on",
+        },
+    )
+    assert response.status_code == 200
+    assertContains(response, "problème technique")
+    assert get_session_name(client.session, OrientationWizardView.expected_session_kind) == session_uuid
+
+
+def test_documents_step_normalizes_beneficiary_phone_for_dora(client, mocker):
+    prescriber = PrescriberFactory(membership=True)
+    job_seeker = JobSeekerFactory(phone="+33601901570")
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        structure__name="Structure orientation wizard",
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    client.get(start_url + f"?job_seeker_public_id={job_seeker.public_id}")
+    session_uuid = get_session_name(client.session, OrientationWizardView.expected_session_kind)
+    conformity_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.CONFORMITY},
+    )
+    referent_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.REFERENT},
+    )
+    documents_url = reverse(
+        "insertion_views:orientation_steps",
+        kwargs={"session_uuid": session_uuid, "step": OrientationStep.DOCUMENTS},
+    )
+
+    client.post(conformity_url, {"confirms_conditions": "on"})
+    client.post(
+        referent_url,
+        {
+            "referent_last_name": "Dupont",
+            "referent_first_name": "Jean",
+            "referent_phone": "0612345678",
+            "referent_email": "jean@example.com",
+        },
+    )
+
+    mock_dora = mocker.patch("itou.www.insertion_views.views.DoraAPIClient")
+
+    client.post(
+        documents_url,
+        {
+            "credentials_documents_files": SimpleUploadedFile("doc.pdf", b"x", content_type="application/pdf"),
+            "credentials_proof_files": SimpleUploadedFile("proof.pdf", b"y", content_type="application/pdf"),
+            "gdpr_consent": "on",
+        },
+    )
+
+    payload, _ = mock_dora.return_value.create_orientation.call_args.args
+    assert payload["beneficiary_phone"] == "0601901570"

--- a/tests/www/search_views/__snapshots__/test_services.ambr
+++ b/tests/www/search_views/__snapshots__/test_services.ambr
@@ -2,24 +2,20 @@
 # name: test_api_error
   '''
   <div id="services-search-results">
-      <div class="c-box c-box--results mb-3 mb-md-4">
-          <div class="c-box--results__body">
-              <div class="alert alert-warning" role="status">
-                  <div class="row">
-                      <div class="col-auto pe-0">
-                          <i aria-hidden="true" class="ri-error-warning-line ri-xl text-warning">
-                          </i>
-                      </div>
-                      <div class="col">
-                          <p class="mb-0">
-                              Une erreur est survenue lors de l'appel à
-                              <a class="has-external-link" href="https://data.inclusion.gouv.fr/" rel="noopener" target="_blank">
-                                  data·inclusion
-                              </a>
-                              . Veuillez réessayer ultérieurement.
-                          </p>
-                      </div>
-                  </div>
+      <div class="alert alert-warning" role="status">
+          <div class="row">
+              <div class="col-auto pe-0">
+                  <i aria-hidden="true" class="ri-error-warning-line ri-xl text-warning">
+                  </i>
+              </div>
+              <div class="col">
+                  <p class="mb-0">
+                      Une erreur est survenue lors de l'appel à
+                      <a class="has-external-link" href="https://data.inclusion.gouv.fr/" rel="noopener" target="_blank">
+                          data·inclusion
+                      </a>
+                      . Veuillez réessayer ultérieurement.
+                  </p>
               </div>
           </div>
       </div>
@@ -75,14 +71,20 @@
               <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
                   <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                       <li>
+                          <i aria-hidden="true" class="ri-navigation-line fw-normal me-1">
+                          </i>
+                          à
+                          <strong class="text-info mx-1">
+                              0 km
+                          </strong>
+                          de votre lieu de recherche
+                      </li>
+                      <li>
                           <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-1">
                           </i>
                           <address class="m-0">
                               Une adresse en présentiel à Vannes, 56260 Vannes
                           </address>
-                          <span class="badge badge-xs rounded-pill bg-light text-primary ms-1">
-                              0 km
-                          </span>
                       </li>
                   </ul>
                   <div class="mt-md-1">
@@ -123,14 +125,20 @@
               <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
                   <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                       <li>
+                          <i aria-hidden="true" class="ri-navigation-line fw-normal me-1">
+                          </i>
+                          à
+                          <strong class="text-info mx-1">
+                              0 km
+                          </strong>
+                          de votre lieu de recherche
+                      </li>
+                      <li>
                           <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-1">
                           </i>
                           <address class="m-0">
                               56260 Vannes
                           </address>
-                          <span class="badge badge-xs rounded-pill bg-light text-primary ms-1">
-                              0 km
-                          </span>
                       </li>
                   </ul>
                   <div class="mt-md-1">
@@ -471,15 +479,23 @@
               <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
                   <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                       <li>
+                          <i aria-hidden="true" class="ri-navigation-line fw-normal me-1">
+                          </i>
+                          à
+                          <strong class="text-info mx-1">
+                              0 km
+                          </strong>
+                          de votre lieu de recherche
+                      </li>
+                      <li>
                           <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-1">
                           </i>
                           <address class="m-0">
                               44350 Guérande
                           </address>
-                          <span class="badge badge-xs rounded-pill bg-light text-primary ms-1">
-                              0 km
-                          </span>
-                          <span class="badge badge-xs rounded-pill bg-light text-primary">
+                      </li>
+                      <li>
+                          <span class="badge badge-sm rounded-pill bg-info text-white">
                               Également disponible à distance
                           </span>
                       </li>


### PR DESCRIPTION
## :thinking: Pourquoi ?
PARCE QUE c'est [NOTRE TICKEEEEET](https://www.notion.so/gip-inclusion/Formulaire-d-orientation-3265f321b60480289283d88ab5dda1ea?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link) 
[Figma](https://www.figma.com/design/xcU6Mp4qiijbpTdwV416ON/MER---Prescripteur?node-id=2187-5133&p=f&t=c9obndFWA5cLvO7u-0) 

## :cake: Comment ?
Design : on s'écarte volontairement du Figma sur le field d'upload, pour rester en phase avec ce qui existe coté emplois et ne pas introduire ni JS ni upload prématuré.

Pour les commits:
- Quelques mini commit cosmétiques proposent de spetites évolutions du File Picker sans changer sa logique générale, mais on accepte plus de fichiers et plus de types.
- On a le méga commit (~1000 lignes mais bcp de templates et tests) pour le tunnel d'orientation
- Un commit final à ignorer en relecture, il sert pour la recette (erreurs lisibles)

Fonctionne avec https://github.com/gip-inclusion/dora/pull/1056 pour la partie POST de l'orientation en fin de tunnel


## :desert_island: Comment tester ?
Pour Gael, il faut aller sur la recette jetable, choisir un service d'insertion, un compte prescripteur habilité de démo; j'ai déjà mis un bénéficiaire lié. On peut aussi en créer, des bénéficiaires.
Avec l'UID  du  service d'insertion aller sur sa fiche `service /insertion/service/<UID>/card` et dérouler.



## :computer: Captures d'écran
<img width="1954" height="1289" alt="Screenshot from 2026-05-28 11-17-54" src="https://github.com/user-attachments/assets/743d00a3-6c6c-4618-9940-1813e62cef77" />
<img width="1954" height="1289" alt="Screenshot from 2026-05-28 11-18-03" src="https://github.com/user-attachments/assets/13c832b0-b703-4a58-95c3-3bb6ca521da3" />
<img width="1954" height="1289" alt="Screenshot from 2026-05-28 11-18-13" src="https://github.com/user-attachments/assets/1c2d9c39-259a-4520-a177-421f8d542670" />
<img width="1954" height="1289" alt="Screenshot from 2026-05-28 11-18-31" src="https://github.com/user-attachments/assets/7cf28ea9-284f-45f6-ac8a-217aaab87a43" />
<img width="1954" height="1289" alt="Screenshot from 2026-05-28 11-18-52" src="https://github.com/user-attachments/assets/da454b7f-8d06-4b89-a470-833172d02d8a" />
<img width="1155" height="609" alt="Screenshot from 2026-05-28 11-19-04" src="https://github.com/user-attachments/assets/00e2bc0e-35ee-4f34-a209-b665cc01032b" />

# Catégories changelog
| Interface                | Orientation                       |


