### PR TITLE
Interface: Augmenter le nombre d'usagers affichés par page dans les accompagnements à 50

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -325,7 +325,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         )
     )
 
-    page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_SMALL)
+    page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_LARGE)
     for job_seeker in page_obj:
         job_seeker.user_can_view_personal_information = can_view_personal_information(request, job_seeker)
         job_seeker.show_more_actions = (

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -323,7 +323,7 @@ def test_multiple(client, snapshot):
     assert_contains_button_apply_for(response, job_app5.job_seeker, with_city=False, with_personal_information=False)
 
 
-@override_settings(PAGE_SIZE_SMALL=1)
+@override_settings(PAGE_SIZE_LARGE=1)
 def test_pagination(client):
     url = reverse("job_seekers_views:list")
     organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte Notion](https://app.notion.com/p/gip-inclusion/Augmenter-le-nombre-de-r-sultats-par-page-36e5f321b6048070a273c6704a56da6c?v=2845f321b60480bd9ef6000c92a2d6ab&source=copy_link)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->


