### PR TITLE
GEIQ: Maj du texte dans certaines mentions

### DIFF
--- a/itou/templates/geiq_assessments/email/assessment_review_for_geiq_body.txt
+++ b/itou/templates/geiq_assessments/email/assessment_review_for_geiq_body.txt
@@ -18,7 +18,7 @@ Références du dossier :
 Vous trouverez ci-dessous le récapitulatif de la décision enregistrée par la {{ assessment.reviewed_by_institution.name }}.
 
 IMPORTANT : Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
-Seul le courrier officiel émis par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
+Seule la décision officielle émise par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
 
 Montant total accordé : {{ assessment.granted_amount|format_int_euros }}
 Montant du premier versement déjà réalisé : {{ assessment.advance_amount|format_int_euros }}

--- a/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
+++ b/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
@@ -313,7 +313,7 @@
                         </p>
                         <p class="mb-0">
                             Le GEIQ sera informé que la décision concernant le montant total accordé reste soumise à validation financière.
-                            <strong>Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé.</strong>
+                            <strong>Seule la décision officielle émise par vos services pourra confirmer de manière définitive le montant accordé.</strong>
                         </p>
                     </div>
                     <div class="modal-footer">

--- a/itou/templates/geiq_assessments_views/assessment_print.html
+++ b/itou/templates/geiq_assessments_views/assessment_print.html
@@ -55,7 +55,7 @@
             </dl>
             <p class="fs-sm">Ces données ont été calculées suite à la sélection que vous avez effectuée.</p>
             <p class="fs-sm">
-                Le GEIQ est informé que la décision concernant le montant total accordé reste soumise à validation financière. <strong>Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé</strong>.
+                Le GEIQ est informé que la décision concernant le montant total accordé reste soumise à validation financière. <strong>Seule la décision officielle émise par vos services pourra confirmer de manière définitive le montant accordé</strong>.
             </p>
         </section>
 

--- a/itou/templates/geiq_assessments_views/assessment_result.html
+++ b/itou/templates/geiq_assessments_views/assessment_result.html
@@ -13,7 +13,7 @@
                         {% fragment as content %}
                             <p class="mb-0">
                                 Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
-                                Seul le courrier officiel émis par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
+                                Seule la décision officielle émise par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
                             </p>
                         {% endfragment %}
                     {% endcomponent_alert %}

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1809,7 +1809,7 @@
               
                               <p class="mb-0">
                                   Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
-                                  Seul le courrier officiel émis par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
+                                  Seule la décision officielle émise par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
                               </p>
                           
           
@@ -1947,7 +1947,7 @@
               
                               <p class="mb-0">
                                   Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
-                                  Seul le courrier officiel émis par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
+                                  Seule la décision officielle émise par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
                               </p>
                           
           

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -64,7 +64,7 @@
   Vous trouverez ci-dessous le récapitulatif de la décision enregistrée par la DDETS 29.
   
   IMPORTANT : Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
-  Seul le courrier officiel émis par la DDETS 29 pourra confirmer de manière définitive le montant accordé.
+  Seule la décision officielle émise par la DDETS 29 pourra confirmer de manière définitive le montant accordé.
   
   Montant total accordé : 80 000 €
   Montant du premier versement déjà réalisé : 50 000 €
@@ -2447,7 +2447,7 @@
               <p class="fs-sm">
                   Le GEIQ est informé que la décision concernant le montant total accordé reste soumise à validation financière.
                   <strong>
-                      Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé
+                      Seule la décision officielle émise par vos services pourra confirmer de manière définitive le montant accordé
                   </strong>
                   .
               </p>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Changement de texte pour remplacer les mentions qui font référence à “un courrier officiel”
https://app.notion.com/p/gip-inclusion/BOOST-Changement-de-texte-pour-remplacer-les-mentions-qui-font-r-f-rence-un-courrier-officiel-36e5f321b60480d59919c1da6cc44f98

