### PR TITLE
Tech: ajout d'un filtre `strong_or_disabled_non_filled` pour faciliter l'affichage d'un champs optionnel

### DIFF
--- a/itou/templates/apply/includes/accept_confirmation.html
+++ b/itou/templates/apply/includes/accept_confirmation.html
@@ -1,6 +1,7 @@
 {% load buttons_form %}
 {% load components %}
 {% load enums %}
+{% load format_filters %}
 {% load str_filters %}
 
 {% enums "companies" "ContractType" as ContractType %}
@@ -62,11 +63,7 @@
         </li>
         <li>
             <small>Date prévisionnelle de fin du contrat</small>
-            {% if form_accept.cleaned_data.hiring_end_at %}
-                <strong>{{ form_accept.cleaned_data.hiring_end_at|date:"d/m/Y" }}</strong>
-            {% else %}
-                <i class="text-disabled">Non renseigné</i>
-            {% endif %}
+            {{ form_accept.cleaned_data.hiring_end_at|date:"d/m/Y"|strong_or_disabled_non_filled }}
         </li>
         <li>
             <small>Accompagnateur au sein de la structure</small>

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -64,11 +64,7 @@
         </li>
         <li>
             <small>Date de naissance</small>
-            {% if job_seeker.jobseeker_profile.birthdate %}
-                <strong>{{ job_seeker.jobseeker_profile.birthdate|date:"d/m/Y" }}</strong>
-            {% else %}
-                <i class="text-disabled">Non renseignée</i>
-            {% endif %}
+            {{ job_seeker.jobseeker_profile.birthdate|date:"d/m/Y"|strong_or_disabled_non_filled:"Non renseignée" }}
         </li>
         <li>
             <small>Adresse</small>

--- a/itou/templates/apply/includes/profile_infos.html
+++ b/itou/templates/apply/includes/profile_infos.html
@@ -105,11 +105,7 @@
     <ul class="list-data mb-4">
         <li>
             <small>Inscrit à France Travail depuis</small>
-            {% if profile.pole_emploi_since %}
-                <strong>{{ profile.get_pole_emploi_since_display|lower }}</strong>
-            {% else %}
-                <i class="text-disabled">Non renseigné</i>
-            {% endif %}
+            {{ profile.get_pole_emploi_since_display|lower|strong_or_disabled_non_filled }}
         </li>
         <li>
             <small>Identifiant France Travail</small>
@@ -122,11 +118,7 @@
         </li>
         <li>
             <small>Niveau de formation</small>
-            {% if profile.education_level %}
-                <strong>{{ profile.get_education_level_display }}</strong>
-            {% else %}
-                <i class="text-disabled">Non renseigné</i>
-            {% endif %}
+            {{ profile.get_education_level_display|strong_or_disabled_non_filled }}
         </li>
         <li>
             <small>Autres</small>

--- a/itou/templates/apply/includes/siae_hiring_details.html
+++ b/itou/templates/apply/includes/siae_hiring_details.html
@@ -25,19 +25,11 @@
             </li>
             <li>
                 <small>Début</small>
-                {% if job_application.hiring_start_at %}
-                    <strong>{{ job_application.hiring_start_at|date:"d F Y" }}</strong>
-                {% else %}
-                    <i class="text-disabled">Non renseigné</i>
-                {% endif %}
+                {{ job_application.hiring_start_at|date:"d F Y"|strong_or_disabled_non_filled }}
             </li>
             <li>
                 <small>Fin</small>
-                {% if job_application.hiring_end_at %}
-                    <strong>{{ job_application.hiring_end_at|date:"d F Y" }}</strong>
-                {% else %}
-                    <i class="text-disabled">Non renseigné</i>
-                {% endif %}
+                {{ job_application.hiring_end_at|date:"d F Y"|strong_or_disabled_non_filled }}
             </li>
         </ul>
 

--- a/itou/templates/employee_record/includes/employee_record_summary.html
+++ b/itou/templates/employee_record/includes/employee_record_summary.html
@@ -43,11 +43,7 @@
             {% if display_ntt %}
                 <li>
                     <small>Numéro technique temporaire</small>
-                    {% if employee_record.ntt %}
-                        <strong>{{ employee_record.ntt }}</strong>
-                    {% else %}
-                        <i class="text-disabled">Non renseigné</i>
-                    {% endif %}
+                    {{ employee_record.ntt|strong_or_disabled_non_filled }}
                 </li>
             {% endif %}
         </ul>

--- a/itou/templates/gps/group_beneficiary.html
+++ b/itou/templates/gps/group_beneficiary.html
@@ -34,11 +34,7 @@
                                 {% if can_view_personal_information %}
                                     <li>
                                         <small>Date de naissance</small>
-                                        {% if group.beneficiary.jobseeker_profile.birthdate %}
-                                            <strong>{{ group.beneficiary.jobseeker_profile.birthdate|date:"d/m/Y" }}</strong>
-                                        {% else %}
-                                            <i class="text-disabled">Non renseignée</i>
-                                        {% endif %}
+                                        {{ group.beneficiary.jobseeker_profile.birthdate|date:"d/m/Y"|strong_or_disabled_non_filled }}
                                     </li>
                                 {% endif %}
                             </ul>
@@ -87,11 +83,7 @@
                                 <ul class="list-data">
                                     <li>
                                         <small>Niveau de formation</small>
-                                        {% if group.beneficiary.jobseeker_profile.get_education_level_display %}
-                                            <strong>{{ group.beneficiary.jobseeker_profile.get_education_level_display }}</strong>
-                                        {% else %}
-                                            <i class="text-disabled">Non renseigné</i>
-                                        {% endif %}
+                                        {{ group.beneficiary.jobseeker_profile.get_education_level_display|strong_or_disabled_non_filled }}
                                     </li>
                                     {% if group.beneficiary.jobseeker_profile.pole_emploi_since %}
                                         <li>

--- a/itou/templates/gps/group_contribution.html
+++ b/itou/templates/gps/group_contribution.html
@@ -1,4 +1,5 @@
 {% extends "gps/group_details_base.html" %}
+{% load format_filters %}
 
 {% block content %}
     <section class="s-section">
@@ -28,11 +29,7 @@
                             </li>
                             <li>
                                 <small>Date de fin</small>
-                                {% if membership.ended_at %}
-                                    <strong>{{ membership.ended_at|date:"F Y" }}</strong>
-                                {% else %}
-                                    <i class="text-disabled">(accompagnement en cours)</i>
-                                {% endif %}
+                                {{ membership.ended_at|date:"F Y"|strong_or_disabled_non_filled:"(accompagnement en cours)" }}
                             </li>
                         </ul>
                     </div>
@@ -41,11 +38,7 @@
                         <ul class="list-data">
                             <li>
                                 <small>Motif</small>
-                                {% if membership.reason %}
-                                    <strong>{{ membership.reason }}</strong>
-                                {% else %}
-                                    <i class="text-disabled">Non renseigné</i>
-                                {% endif %}
+                                {{ membership.reason|strong_or_disabled_non_filled }}
                             </li>
                         </ul>
                     </div>

--- a/itou/templates/gps/group_memberships.html
+++ b/itou/templates/gps/group_memberships.html
@@ -70,11 +70,7 @@
                                 <ul class="list-data">
                                     <li>
                                         <small>Motif de l’accompagnement</small>
-                                        {% if membership.reason %}
-                                            <strong>{{ membership.reason }}</strong>
-                                        {% else %}
-                                            <i class="text-disabled">Non renseigné</i>
-                                        {% endif %}
+                                        {{ membership.reason|strong_or_disabled_non_filled }}
                                     </li>
                                     <li>
                                         <small>Adresse e-mail</small>

--- a/itou/templates/gps/includes/membership_referent.html
+++ b/itou/templates/gps/includes/membership_referent.html
@@ -1,4 +1,5 @@
 {% load components %}
+{% load format_filters %}
 {% load matomo %}
 {% load str_filters %}
 
@@ -52,11 +53,7 @@
                     </li>
                     <li>
                         <small>Motif de l’accompagnement</small>
-                        {% if membership.reason %}
-                            <strong>{{ membership.reason }}</strong>
-                        {% else %}
-                            <i class="text-disabled">Non renseigné</i>
-                        {% endif %}
+                        {{ membership.reason|strong_or_disabled_non_filled }}
                     </li>
                     <li>
                         <small>Téléphone</small>

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -8,7 +8,7 @@ from textwrap import wrap
 
 from django import template
 from django.template.defaultfilters import floatformat, stringfilter
-from django.utils.html import conditional_escape
+from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 
 
@@ -130,3 +130,14 @@ def label_object_format(data):
         other_data_str = ", ".join(f"{k}: {v}" for k, v in other_data.items())
         return f"{data['nom']} - [{other_data_str}]"
     return str(data)
+
+
+@register.filter
+def strong_or_disabled_non_filled(value, non_filled_text="Non renseigné"):
+    # Handle "" or None as missing value but not the number 0
+    if value == "":
+        value = None
+    if value is not None:
+        return format_html("<strong>{}</strong>", value)
+    else:
+        return format_html('<i class="text-disabled">{}</i>', non_filled_text)

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -932,6 +932,22 @@ class TestUtilsTemplateFilters:
             with subtests.test(number):
                 assert format_filters.format_approval_number(number) == expected
 
+    @pytest.mark.parametrize(
+        "value,non_filled_text,expected",
+        [
+            (42, None, "<strong>42</strong>"),
+            ("Martine", None, "<strong>Martine</strong>"),
+            ("", None, '<i class="text-disabled">Non renseigné</i>'),
+            (None, None, '<i class="text-disabled">Non renseigné</i>'),
+            (0, None, "<strong>0</strong>"),
+            ("", "Non disponible", '<i class="text-disabled">Non disponible</i>'),
+            (None, "Non disponible", '<i class="text-disabled">Non disponible</i>'),
+        ],
+    )
+    def test_strong_or_disabled_non_filled(self, value, non_filled_text, expected):
+        kwargs = {"non_filled_text": non_filled_text} if non_filled_text is not None else {}
+        assert format_filters.strong_or_disabled_non_filled(value, **kwargs) == expected
+
 
 class TestUtilsUrls:
     def test_get_safe_url(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on répète très souvent ce:

```
{% if truc %}
   <strong>{{ truc }}</strong>
{% else %}
    <i class="text-disabled">Non renseigné</i>
{% endif %}
```

## :cake: Comment ? <!-- optionnel -->

Avec un nouveau filtre Django qui fait exactement cela.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
