### PR TITLE
Tableau de bord: éviter que les structures se retrouvent sans admin

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -40,6 +40,7 @@
   "30 6 * * * $ROOT/clevercloud/run_management_command.sh check_inconsistencies",
   "0 7 * * * $ROOT/clevercloud/run_management_command.sh archive_accepted_evaluated_siae --wet-run",
   "0 9 * * * $ROOT/clevercloud/run_management_command.sh send_check_authorized_members_email",
+  "30 9 * * * $ROOT/clevercloud/run_management_command.sh auto_attribute_company_admins",
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "30 20 * * * $ROOT/clevercloud/run_management_command.sh populate_metabase_emplois --mode all",
   "5 23 * * * $ROOT/clevercloud/run_management_command.sh archive_employee_records --wet-run",

--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -218,6 +218,17 @@ class OrganizationAbstract(models.Model):
 
         return get_email_message(to, context, subject, body)
 
+    def auto_admin_attribution_email(self, user):
+        """
+        Tell a member he has been automatically assigned the admin role
+        because the organization had no active administrator.
+        """
+        to = [user.email]
+        context = {"structure": self, "user": user, "documentation_link": self.get_documentation_link()}
+        subject = "common/emails/auto_admin_attribution_email_subject.txt"
+        body = "common/emails/auto_admin_attribution_email_body.txt"
+        return get_email_message(to, context, subject, body)
+
     def remove_admin_email(self, user):
         """
         Tell a member he is no longer an administrator.

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -34,7 +34,7 @@ from itou.companies.enums import (
 )
 from itou.utils.emails import get_email_message
 from itou.utils.models import AbstractFieldsHistoryModel
-from itou.utils.tokens import company_signup_token_generator
+from itou.utils.tokens import admin_request_token_generator, company_signup_token_generator
 from itou.utils.urls import get_absolute_url, get_tally_form_url
 from itou.utils.validators import validate_af_number, validate_naf, validate_siret
 
@@ -486,6 +486,28 @@ class Company(AddressMixin, OrganizationAbstract, AbstractFieldsHistoryModel):
         subject = "companies/email/new_signup_activation_email_to_official_contact_subject.txt"
         body = "companies/email/new_signup_activation_email_to_official_contact_body.txt"
         return get_email_message(to, context, subject, body)
+
+    def admin_request_email(self, requesting_user, confirm_url):
+        """
+        Send an email to auth_email asking to confirm the admin role request
+        made by requesting_user.
+        """
+        to = [self.auth_email]
+        context = {
+            "structure": self,
+            "requesting_user": requesting_user,
+            "confirm_url": confirm_url,
+            "documentation_link": self.get_documentation_link(),
+        }
+        subject = "companies/email/admin_request_email_subject.txt"
+        body = "companies/email/admin_request_email_body.txt"
+        return get_email_message(to, context, subject, body)
+
+    def get_admin_request_token(self, user):
+        return admin_request_token_generator.make_token(self, user)
+
+    def check_admin_request_token(self, user, token):
+        return admin_request_token_generator.check_token(token, company=self, user=user)
 
     def activate_your_account_email(self):
         if self.has_members or not self.auth_email:

--- a/itou/templates/common/emails/auto_admin_attribution_email_body.txt
+++ b/itou/templates/common/emails/auto_admin_attribution_email_body.txt
@@ -1,0 +1,16 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+
+Bonjour {{ user.get_full_name }}
+
+L'espace de travail de votre structure {{ structure.name }} ({{ structure.kind }}) sur les emplois de l'inclusion ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
+
+{% if documentation_link %}
+Ce statut vous permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : {{ documentation_link }}.
+{% else %}
+Ce statut vous permet de gérer la liste des membres de votre organisation (retirer un collaborateur qui ne travaille plus dans votre organisation, nommer un autre collaborateur en tant qu’administrateur)
+{% endif %}
+
+Si vous ne souhaitez plus assumer le rôle d'administrateur, vous devez désigner un autre administrateur, qui se chargera de vous retirer ce statut.
+
+{% endblock body %}

--- a/itou/templates/common/emails/auto_admin_attribution_email_subject.txt
+++ b/itou/templates/common/emails/auto_admin_attribution_email_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Vous êtes désormais administrateur de l'espace {{ structure.name }}
+{% endblock %}

--- a/itou/templates/companies/email/admin_request_email_body.txt
+++ b/itou/templates/companies/email/admin_request_email_body.txt
@@ -1,0 +1,19 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+
+Bonjour,
+
+{{ requesting_user.get_full_name }} identifié avec l'adresse email {{ requesting_user.email }} souhaite devenir administrateur de la structure {{ structure.name }} ({{ structure.kind }}).
+
+{% if documentation_link %}
+Ce statut permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : {{ documentation_link }}.
+
+{% endif %}
+Pour des raisons de sécurité nous vous invitons à vérifier que cette demande émane bien de {{ requesting_user.get_full_name }}.
+
+Cliquez sur le lien suivant pour attribuer le statut d'administrateur à {{ requesting_user.get_full_name }} - {{ requesting_user.email }} :
+{{ confirm_url }}
+
+Si vous ne souhaitez pas donner suite à cette demande, merci de ne pas prendre en compte ce message.
+
+{% endblock body %}

--- a/itou/templates/companies/email/admin_request_email_subject.txt
+++ b/itou/templates/companies/email/admin_request_email_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Demande d'attribution du statut d'administrateur
+{% endblock %}

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -39,6 +39,28 @@
 {% endblock %}
 
 {% block content %}
+    {% if show_admin_request_banner %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        {% component_alert content=content variant="warning" title="Votre organisation ne compte actuellement aucun administrateur" %}
+                            {% fragment as content %}
+                                <p>
+                                    Si vous estimez devoir assumer ce rôle, veuillez en faire la demande en cliquant sur ce lien :
+                                    un e-mail sera envoyé à l'adresse d'authentification de l'entreprise.
+                                </p>
+                                <form method="post" action="{% url 'companies_views:request_admin_role' %}">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-warning btn-sm">Demander le statut d'administrateur</button>
+                                </form>
+                            {% endfragment %}
+                        {% endcomponent_alert %}
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
     {% include "includes/members_list.html" %}
 {% endblock %}
 

--- a/itou/users/management/commands/auto_attribute_company_admins.py
+++ b/itou/users/management/commands/auto_attribute_company_admins.py
@@ -1,0 +1,59 @@
+from django.db import transaction
+from django.db.models import Exists, OuterRef, Prefetch
+
+from itou.companies.models import Company, CompanyMembership
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Automatically assign admin role to the 2 most-recently-logged-in active members
+    of companies that have no active administrator and no auth_email.
+
+    Companies with an auth_email are excluded because they have a dedicated flow
+    allowing members to request the admin role through that address.
+
+    Members who have never logged in are excluded from promotion.
+    """
+
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
+    def handle(self, *args, **options):
+        logged_in_members = CompanyMembership.objects.filter(
+            company=OuterRef("pk"),
+            user__last_login__isnull=False,
+        )
+        active_admins = CompanyMembership.objects.filter(company=OuterRef("pk"), is_admin=True)
+
+        companies = (
+            Company.objects.active()
+            .filter(auth_email="")
+            .filter(Exists(logged_in_members), ~Exists(active_admins))
+            .prefetch_related(
+                Prefetch(
+                    "memberships",
+                    queryset=CompanyMembership.objects.filter(user__last_login__isnull=False)
+                    .select_related("user")
+                    .order_by("-user__last_login"),
+                    to_attr="candidate_memberships",
+                )
+            )
+            .order_by("pk")
+        )
+
+        self.logger.info("Processing %d companies", len(companies))
+
+        for company in companies:
+            to_promote = company.candidate_memberships[:2]
+            with transaction.atomic():
+                for membership in to_promote:
+                    membership.is_admin = True
+                CompanyMembership.objects.bulk_update(to_promote, ["is_admin", "updated_at"])
+                for membership in to_promote:
+                    company.auto_admin_attribution_email(membership.user).send()
+                    self.logger.info(
+                        "Promoted user %d to admin of company %d",
+                        membership.user_id,
+                        company.pk,
+                    )

--- a/itou/utils/tokens.py
+++ b/itou/utils/tokens.py
@@ -5,10 +5,53 @@ from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.http import base36_to_int, int_to_base36
 
 
-COMPANY_SIGNUP_MAGIC_LINK_TIMEOUT = 2 * 7 * 24 * 3600
+class TokenGenerator:
+    """
+    Base mixin for time-limited HMAC token generators.
+
+    Subclasses must define:
+    - key_salt (str)
+    - timeout (int, seconds)
+    - _make_hash_value(self, timestamp, **kwargs) -> str
+    """
+
+    secret = settings.SECRET_KEY
+
+    def make_token(self, **kwargs):
+        return self._make_token_with_timestamp(self._num_seconds(self._now()), **kwargs)
+
+    def check_token(self, token, **kwargs):
+        if not (token and all(kwargs.values())):
+            return False
+        try:
+            timestamp_b36, _ = token.split("-")
+        except ValueError:
+            return False
+        try:
+            timestamp = base36_to_int(timestamp_b36)
+        except ValueError:
+            return False
+        if not constant_time_compare(self._make_token_with_timestamp(timestamp, **kwargs), token):
+            return False
+        if (self._num_seconds(self._now()) - timestamp) > self.timeout:
+            return False
+        return True
+
+    def _make_token_with_timestamp(self, timestamp, **kwargs):
+        timestamp_b36 = int_to_base36(timestamp)
+        hash_string = salted_hmac(
+            self.key_salt, self._make_hash_value(timestamp, **kwargs), secret=self.secret
+        ).hexdigest()[::2]
+        return f"{timestamp_b36}-{hash_string}"
+
+    def _num_seconds(self, dt):
+        return int((dt - datetime(2001, 1, 1)).total_seconds())
+
+    def _now(self):
+        return datetime.now()
 
 
-class CompanySignupTokenGenerator:
+class CompanySignupTokenGenerator(TokenGenerator):
     """
     Strategy object used to generate and check tokens for the secure
     company signup mechanism.
@@ -17,52 +60,12 @@ class CompanySignupTokenGenerator:
     """
 
     key_salt = "itou.utils.tokens.SiaeSignupTokenGenerator"
-    secret = settings.SECRET_KEY
+    timeout = 2 * 7 * 24 * 3600
 
     def make_token(self, company):
-        """
-        Return a token that can be used once to do a signup
-        for the given company and is valid only for a limited time.
-        """
-        return self._make_token_with_timestamp(company, self._num_seconds(self._now()))
+        return super().make_token(company=company)
 
-    def check_token(self, company, token):
-        """
-        Check that a company signup token is correct for a given company.
-        """
-        if not (company and token):
-            return False
-        # Parse the token
-        try:
-            timestamp_b36, _ = token.split("-")
-        except ValueError:
-            return False
-
-        try:
-            timestamp = base36_to_int(timestamp_b36)
-        except ValueError:
-            return False
-
-        # Check that the timestamp/uid has not been tampered with
-        if not constant_time_compare(self._make_token_with_timestamp(company, timestamp), token):
-            return False
-
-        # Check the timestamp is within limit.
-        if (self._num_seconds(self._now()) - timestamp) > COMPANY_SIGNUP_MAGIC_LINK_TIMEOUT:
-            return False
-
-        return True
-
-    def _make_token_with_timestamp(self, company, timestamp):
-        # timestamp is number of seconds since 2001-1-1. Converted to base 36,
-        # this gives us a 6 digit string until about 2069.
-        timestamp_b36 = int_to_base36(timestamp)
-        hash_string = salted_hmac(
-            self.key_salt, self._make_hash_value(company, timestamp), secret=self.secret
-        ).hexdigest()[::2]  # Limit to 20 characters to shorten the URL.
-        return f"{timestamp_b36}-{hash_string}"
-
-    def _make_hash_value(self, company, timestamp):
+    def _make_hash_value(self, timestamp, company):
         """
         Hash the company's primary key and some company state (its number of members)
         that's sure to change after a signup to produce a token that is invalidated
@@ -72,12 +75,31 @@ class CompanySignupTokenGenerator:
         """
         return str(company.pk) + str(company.members.count()) + str(timestamp)
 
-    def _num_seconds(self, dt):
-        return int((dt - datetime(2001, 1, 1)).total_seconds())
-
-    def _now(self):
-        # Used for mocking in tests
-        return datetime.now()
-
 
 company_signup_token_generator = CompanySignupTokenGenerator()
+
+
+class AdminRequestTokenGenerator(TokenGenerator):
+    """
+    Token generator for the admin role request mechanism.
+
+    A member of a company with an auth_email can request the admin role.
+    A token is generated and sent to auth_email. When the link is clicked,
+    the token is validated and the member is promoted to admin.
+
+    The token includes membership.is_admin in its hash so it is automatically
+    invalidated once the promotion has been applied.
+    """
+
+    key_salt = "itou.utils.tokens.AdminRequestTokenGenerator"
+    timeout = 2 * 7 * 24 * 3600
+
+    def make_token(self, company, user):
+        return super().make_token(company=company, user=user)
+
+    def _make_hash_value(self, timestamp, company, user):
+        membership = company.memberships.get(user=user)
+        return f"{company.pk}{user.pk}{membership.is_admin}{timestamp}"
+
+
+admin_request_token_generator = AdminRequestTokenGenerator()

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -68,4 +68,10 @@ urlpatterns = [
     path("colleagues", views.MemberList.as_view(), name="members"),
     path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
     path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
+    path("request_admin_role", views.request_admin_role, name="request_admin_role"),
+    path(
+        "confirm_admin_role/<int:company_pk>/<str:token>",
+        views.confirm_admin_role,
+        name="confirm_admin_role",
+    ),
 ]

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -670,6 +670,9 @@ class MemberList(BaseMemberList):
         context = super().get_context_data(**kwargs)
         context["can_show_financial_annexes"] = self.organization.convention_can_be_accessed_by(self.request.user)
         context["base_url"] = "companies_views"
+        context["show_admin_request_banner"] = bool(
+            self.organization.auth_email and not self.organization.active_admin_members.exists()
+        )
         return context
 
 
@@ -698,3 +701,70 @@ def update_admin_role(request, action, public_id, template_name="companies/updat
         success_url=reverse("companies_views:members"),
         template_name=template_name,
     )
+
+
+@check_request(lambda request: request.from_employer)
+@require_POST
+def request_admin_role(request):
+    """
+    A member of a company with an auth_email (and no active admin) can submit
+    this view to trigger an email to auth_email asking to confirm their promotion.
+    """
+    company = request.current_organization
+    if not company.auth_email:
+        raise PermissionDenied
+    if company.active_admin_members.exists():
+        raise PermissionDenied
+
+    token = company.get_admin_request_token(request.user)
+    confirm_url = get_absolute_url(
+        reverse(
+            "companies_views:confirm_admin_role",
+            kwargs={"company_pk": company.pk, "token": token},
+        )
+    )
+    company.admin_request_email(request.user, confirm_url).send()
+    messages.success(
+        request,
+        f"Nous venons d'envoyer un e-mail à l'adresse {company.auth_email} afin de vérifier votre demande "
+        "d'attribution du statut d'administrateur. Nous vous invitons à consulter votre boîte de réception.",
+    )
+    return HttpResponseRedirect(reverse("companies_views:members"))
+
+
+def confirm_admin_role(request, company_pk, token):
+    """
+    Linked from the email sent to auth_email.
+    Validates the token and promotes the requesting user to admin.
+    The requesting user must be logged in since the token is tied to their account.
+    """
+    company = get_object_or_404(Company.objects.active(), pk=company_pk)
+
+    if not company.check_admin_request_token(request.user, token):
+        messages.error(
+            request,
+            "Ce lien est invalide ou a expiré. Veuillez demander un nouveau lien depuis la page collaborateurs.",
+        )
+        return HttpResponseRedirect(reverse("dashboard:index"))
+
+    existing_admins = company.active_admin_members.exclude(pk=request.user.pk)
+    if existing_admins.exists():
+        admin_names = ", ".join(u.get_full_name() for u in existing_admins)
+        messages.error(
+            request,
+            f"Votre demande ne peut plus être traitée car {company.name} dispose déjà d'un ou plusieurs "
+            f"administrateurs ({admin_names}). Veuillez les contacter directement.",
+        )
+        return HttpResponseRedirect(reverse("dashboard:index"))
+
+    membership = get_object_or_404(company.memberships, user=request.user, is_active=True)
+    membership.is_admin = True
+    membership.updated_by = request.user
+    membership.save(update_fields=["is_admin", "updated_by", "updated_at"])
+    company.add_admin_email(request.user).send()
+
+    messages.success(
+        request,
+        f"{request.user.get_full_name()} est désormais administrateur de {company.name}.",
+    )
+    return HttpResponseRedirect(reverse("dashboard:index"))

--- a/tests/users/__snapshots__/test_management_commands.ambr
+++ b/tests/users/__snapshots__/test_management_commands.ambr
@@ -1,4 +1,23 @@
 # serializer version: 1
+# name: TestAutoAttributeCompanyAdmins.test_email_content[auto_admin_attribution email body]
+  '''
+  Bonjour John DOE
+  
+  L'espace de travail de votre structure ACME Inc. (EI) sur les emplois de l'inclusion ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
+  
+  Ce statut vous permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738355467409.
+  
+  Si vous ne souhaitez plus assumer le rôle d'administrateur, vous devez désigner un autre administrateur, qui se chargera de vous retirer ce statut.
+  
+  ---
+  [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
+  Les emplois de l'inclusion
+  http://localhost:8000/
+  '''
+# ---
+# name: TestAutoAttributeCompanyAdmins.test_email_content[auto_admin_attribution email subject]
+  "[TEST] Vous êtes désormais administrateur de l'espace ACME Inc."
+# ---
 # name: TestCommandSendUsersToBrevo.test_wet_run_batch[send_users_to_brevo_batch]
   list([
     tuple(

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -1413,3 +1413,168 @@ def test_delete_old_nir_modification_requests(is_after_cutoff, caplog):
     call_command("delete_old_nir_modification_requests", wet_run=True)
     assert caplog.messages[4] == f"Deleted {del_count} NIR modification request{pluralize(del_count)}"
     assert NirModificationRequest.objects.count() == 1 - del_count
+
+
+class TestAutoAttributeCompanyAdmins:
+    def test_no_member(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        CompanyFactory(auth_email="")
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+        assert "Processing 0 companies" in caplog.messages
+        assert mailoutbox == []
+
+    def test_already_has_admin(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        CompanyMembershipFactory(company__auth_email="", is_admin=True)
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+        assert "Processing 0 companies" in caplog.messages
+        assert mailoutbox == []
+
+    def test_skips_company_with_auth_email(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        CompanyMembershipFactory(company__auth_email="contact@example.com", is_admin=False)
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+        assert "Processing 0 companies" in caplog.messages
+        assert mailoutbox == []
+
+    def test_skips_inactive_company(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        membership = CompanyMembershipFactory(
+            company__auth_email="",
+            company__subject_to_iae_rules=True,
+            company__convention__after_grace_period=True,
+            is_admin=False,
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        membership.refresh_from_db()
+        assert not membership.is_admin
+        assert mailoutbox == []
+
+    def test_promotes_single_member(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        membership = CompanyMembershipFactory(
+            company__auth_email="",
+            is_admin=False,
+            user__last_login=timezone.now(),
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        membership.refresh_from_db()
+        assert membership.is_admin
+        assert len(mailoutbox) == 1
+        assert membership.user.email in mailoutbox[0].to
+        assert membership.company.name in mailoutbox[0].subject
+
+    def test_promotes_two_most_recently_logged_in(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        company = CompanyFactory(auth_email="")
+        now = timezone.now()
+
+        oldest = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=now - datetime.timedelta(days=30),
+        )
+        recent = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=now - datetime.timedelta(days=1),
+        )
+        most_recent = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=now,
+        )
+
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        oldest.refresh_from_db()
+        recent.refresh_from_db()
+        most_recent.refresh_from_db()
+
+        assert not oldest.is_admin
+        assert recent.is_admin
+        assert most_recent.is_admin
+        assert len(mailoutbox) == 2
+        promoted_emails = {m.to[0] for m in mailoutbox}
+        assert recent.user.email in promoted_emails
+        assert most_recent.user.email in promoted_emails
+
+    def test_idempotent(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        CompanyMembershipFactory(
+            company__auth_email="",
+            is_admin=False,
+            user__last_login=timezone.now(),
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+        assert len(mailoutbox) == 1
+
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+        assert len(mailoutbox) == 1
+
+    def test_null_last_login_members_are_excluded(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        company = CompanyFactory(auth_email="")
+        now = timezone.now()
+
+        no_login = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=None,
+        )
+        recent = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=now - datetime.timedelta(days=1),
+        )
+        most_recent = CompanyMembershipFactory(
+            company=company,
+            is_admin=False,
+            user__last_login=now,
+        )
+
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        no_login.refresh_from_db()
+        recent.refresh_from_db()
+        most_recent.refresh_from_db()
+
+        assert not no_login.is_admin
+        assert recent.is_admin
+        assert most_recent.is_admin
+        assert len(mailoutbox) == 2
+        assert mailoutbox[0].to == [most_recent.user.email]
+        assert mailoutbox[1].to == [recent.user.email]
+
+    def test_skips_members_without_last_login(self, django_capture_on_commit_callbacks, mailoutbox, caplog):
+        membership = CompanyMembershipFactory(
+            company__auth_email="",
+            is_admin=False,
+            user__last_login=None,
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        membership.refresh_from_db()
+        assert not membership.is_admin
+        assert "Processing 0 companies" in caplog.messages
+        assert mailoutbox == []
+
+    def test_email_content(self, django_capture_on_commit_callbacks, mailoutbox, snapshot):
+        CompanyMembershipFactory(
+            company__for_snapshot=True,
+            company__auth_email="",
+            user__for_snapshot=True,
+            user__last_login=timezone.now(),
+            is_admin=False,
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command("auto_attribute_company_admins")
+
+        assert len(mailoutbox) == 1
+        email = mailoutbox[0]
+        assert email.subject == snapshot(name="auto_admin_attribution email subject")
+        assert email.body == snapshot(name="auto_admin_attribution email body")

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -51,7 +51,7 @@ from itou.utils.perms.middleware import ItouCurrentOrganizationMiddleware
 from itou.utils.sync import DiffItem, DiffItemKind, yield_sync_diff
 from itou.utils.templatetags import badges, dict_filters, format_filters, job_seekers
 from itou.utils.templatetags.datetime_filters import duration, naturaldate
-from itou.utils.tokens import COMPANY_SIGNUP_MAGIC_LINK_TIMEOUT, CompanySignupTokenGenerator
+from itou.utils.tokens import CompanySignupTokenGenerator
 from itou.utils.urls import (
     get_absolute_url,
     get_external_link_markup,
@@ -1052,7 +1052,7 @@ class TestCompanySignupTokenGenerator:
         company = CompanyFactory()
         p0 = CompanySignupTokenGenerator()
         tk1 = p0.make_token(company)
-        assert p0.check_token(company, tk1) is True
+        assert p0.check_token(tk1, company=company) is True
 
     def test_10265(self):
         """
@@ -1074,21 +1074,21 @@ class TestCompanySignupTokenGenerator:
         p0 = CompanySignupTokenGenerator()
         tk1 = p0.make_token(company)
         p1 = MockedCompanySignupTokenGenerator(
-            datetime.datetime.now() + datetime.timedelta(seconds=(COMPANY_SIGNUP_MAGIC_LINK_TIMEOUT - 1))
+            datetime.datetime.now() + datetime.timedelta(seconds=(CompanySignupTokenGenerator.timeout - 1))
         )
-        assert p1.check_token(company, tk1) is True
+        assert p1.check_token(tk1, company=company) is True
         p2 = MockedCompanySignupTokenGenerator(
-            datetime.datetime.now() + datetime.timedelta(seconds=(COMPANY_SIGNUP_MAGIC_LINK_TIMEOUT + 1))
+            datetime.datetime.now() + datetime.timedelta(seconds=(CompanySignupTokenGenerator.timeout + 1))
         )
-        assert p2.check_token(company, tk1) is False
+        assert p2.check_token(tk1, company=company) is False
 
     def test_check_token_with_nonexistent_token_and_user(self):
         company = CompanyFactory()
         p0 = CompanySignupTokenGenerator()
         tk1 = p0.make_token(company)
-        assert p0.check_token(None, tk1) is False
-        assert p0.check_token(company, None) is False
-        assert p0.check_token(company, tk1) is True
+        assert p0.check_token(tk1, company=None) is False
+        assert p0.check_token(None, company=company) is False
+        assert p0.check_token(tk1, company=company) is True
 
     def test_any_new_signup_invalidates_past_token(self):
         """
@@ -1098,14 +1098,14 @@ class TestCompanySignupTokenGenerator:
         company = CompanyFactory()
         p0 = CompanySignupTokenGenerator()
         tk1 = p0.make_token(company)
-        assert p0.check_token(company, tk1) is True
+        assert p0.check_token(tk1, company=company) is True
         user = User(kind=UserKind.PROFESSIONAL)
         user.save()
         membership = CompanyMembership()
         membership.user = user
         membership.company = company
         membership.save()
-        assert p0.check_token(company, tk1) is False
+        assert p0.check_token(tk1, company=company) is False
 
 
 class TestCnilCompositionPasswordValidator:

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -1,4 +1,23 @@
 # serializer version: 1
+# name: TestConfirmAdminRole.test_promotes_user_to_admin[add_admin email body]
+  '''
+  Bonjour John DOE
+  
+  Vous avez désormais le statut d’administrateur sur l’espace professionnel de votre organisation ACME Inc. (EI) sur les emplois de l’inclusion.
+  
+  Ce statut vous permet d’avoir accès à certaines fonctionnalités, la liste complète est disponible ici : https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738355467409.
+  
+  Pour des raisons de gestion et de sécurité, nous vous invitons à nommer plusieurs administrateurs au sein de votre organisation.
+  
+  ---
+  [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
+  Les emplois de l'inclusion
+  http://localhost:8000/
+  '''
+# ---
+# name: TestConfirmAdminRole.test_promotes_user_to_admin[add_admin email subject]
+  '[TEST] Votre rôle d’administrateur'
+# ---
 # name: TestMembers.test_members
   '''
   <main class="s-main" id="main" role="main">
@@ -148,6 +167,30 @@
   </main>
   
   '''
+# ---
+# name: TestRequestAdminRole.test_post_sends_email_to_auth_email[admin_request email body]
+  '''
+  Bonjour,
+  
+  John DOE identifié avec l'adresse email john.doe@test.local souhaite devenir administrateur de la structure ACME Inc. (EI).
+  
+  Ce statut permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738355467409.
+  
+  Pour des raisons de sécurité nous vous invitons à vérifier que cette demande émane bien de John DOE.
+  
+  Cliquez sur le lien suivant pour attribuer le statut d'administrateur à John DOE - john.doe@test.local :
+  http://localhost:8000/company/confirm_admin_role/1000/d2f6o0-d1d01e00e170c0d5fd20
+  
+  Si vous ne souhaitez pas donner suite à cette demande, merci de ne pas prendre en compte ce message.
+  
+  ---
+  [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
+  Les emplois de l'inclusion
+  http://localhost:8000/
+  '''
+# ---
+# name: TestRequestAdminRole.test_post_sends_email_to_auth_email[admin_request email subject]
+  "[TEST] Demande d'attribution du statut d'administrateur"
 # ---
 # name: TestUserMembershipDeactivation.test_deactivate_user
   '''

--- a/tests/www/companies_views/test_members_views.py
+++ b/tests/www/companies_views/test_members_views.py
@@ -7,6 +7,7 @@ from pytest_django.asserts import assertContains, assertNotContains, assertRedir
 
 from itou.common_apps.organizations.views import BaseMemberList
 from itou.companies.enums import CompanyKind
+from itou.utils.tokens import admin_request_token_generator
 from tests.common_apps.organizations.tests import assert_set_admin_role_creation, assert_set_admin_role_removal
 from tests.companies.factories import (
     CompanyFactory,
@@ -446,3 +447,167 @@ class TestCompanyAdminMembersManagement:
             )
         )
         assert response.status_code == 400
+
+
+class TestRequestAdminRole:
+    URL = reverse("companies_views:request_admin_role")
+
+    def test_banner_shown_when_no_admin_and_auth_email(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        response = client.get(reverse("companies_views:members"))
+        assertContains(response, "aucun administrateur")
+        assertContains(response, self.URL)
+
+    def test_banner_not_shown_when_admin_exists(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=True,
+        )
+        client.force_login(membership.user)
+        response = client.get(reverse("companies_views:members"))
+        assertNotContains(response, self.URL)
+
+    def test_banner_not_shown_without_auth_email(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        response = client.get(reverse("companies_views:members"))
+        assertNotContains(response, self.URL)
+
+    @freeze_time("2026-01-15")
+    def test_post_sends_email_to_auth_email(self, client, mailoutbox, snapshot):
+        membership = CompanyMembershipFactory(
+            company__for_snapshot=True,
+            company__pk=1000,
+            user__for_snapshot=True,
+            user__pk=1000,
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        response = client.post(self.URL)
+        assertRedirects(response, reverse("companies_views:members"), fetch_redirect_response=False)
+        assert len(mailoutbox) == 1
+        [admin_request_email] = mailoutbox
+        assert admin_request_email.subject == snapshot(name="admin_request email subject")
+        assert admin_request_email.body == snapshot(name="admin_request email body")
+
+    def test_post_forbidden_if_no_auth_email(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        response = client.post(self.URL)
+        assert response.status_code == 403
+
+    def test_post_forbidden_if_admin_already_exists(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=True,
+        )
+        client.force_login(membership.user)
+        response = client.post(self.URL)
+        assert response.status_code == 403
+
+    def test_post_requires_employer(self, client):
+        user = PrescriberFactory(membership=True)
+        client.force_login(user)
+        response = client.post(self.URL)
+        assert response.status_code == 403
+
+
+class TestConfirmAdminRole:
+    def _get_url(self, company, user):
+        token = admin_request_token_generator.make_token(company, user)
+        return reverse(
+            "companies_views:confirm_admin_role",
+            kwargs={"company_pk": company.pk, "token": token},
+        )
+
+    @freeze_time("2026-01-15")
+    def test_promotes_user_to_admin(self, client, mailoutbox, snapshot):
+        membership = CompanyMembershipFactory(
+            company__for_snapshot=True,
+            company__pk=1000,
+            user__for_snapshot=True,
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        url = self._get_url(membership.company, membership.user)
+        response = client.get(url)
+        assertRedirects(response, reverse("dashboard:index"), fetch_redirect_response=False)
+        membership.refresh_from_db()
+        assert membership.is_admin
+        assert len(mailoutbox) == 1
+        [add_admin_email] = mailoutbox
+        assert add_admin_email.subject == snapshot(name="add_admin email subject")
+        assert add_admin_email.body == snapshot(name="add_admin email body")
+
+    def test_invalid_token_rejected(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        url = reverse(
+            "companies_views:confirm_admin_role",
+            kwargs={"company_pk": membership.company.pk, "token": "bad-token"},
+        )
+        response = client.get(url)
+        assertRedirects(response, reverse("dashboard:index"), fetch_redirect_response=False)
+        membership.refresh_from_db()
+        assert not membership.is_admin
+
+    def test_token_invalidated_after_use(self, client, mailoutbox):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        url = self._get_url(membership.company, membership.user)
+
+        client.get(url)
+        membership.refresh_from_db()
+        assert membership.is_admin
+        email_count_after_first = len(mailoutbox)
+
+        # Second use of the same token: already admin, token hash changes → rejected
+        response = client.get(url)
+        assertRedirects(response, reverse("dashboard:index"), fetch_redirect_response=False)
+        assert len(mailoutbox) == email_count_after_first  # no additional email
+
+    def test_unknown_company_returns_404(self, client):
+        membership = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=False,
+        )
+        client.force_login(membership.user)
+        url = reverse(
+            "companies_views:confirm_admin_role",
+            kwargs={"company_pk": 99999999, "token": "any-token"},
+        )
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_rejected_if_admin_already_exists(self, client, mailoutbox):
+        existing_admin = CompanyMembershipFactory(
+            company__auth_email="contact@example.com",
+            is_admin=True,
+        )
+        requester = CompanyMembershipFactory(
+            company=existing_admin.company,
+            is_admin=False,
+        )
+        url = self._get_url(requester.company, requester.user)
+        client.force_login(requester.user)
+        response = client.get(url)
+        assertRedirects(response, reverse("dashboard:index"), fetch_redirect_response=False)
+        requester.refresh_from_db()
+        assert not requester.is_admin
+        assert len(mailoutbox) == 0


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://app.notion.com/p/gip-inclusion/Eviter-que-des-structures-se-retrouvent-sans-admin-3415f321b604809c8122dfa3c6a11391

## :cake: Comment ? <!-- optionnel -->

Légèrement Inspiré de https://github.com/gip-inclusion/les-emplois/pull/4015 pour la requête principale.
Pour le `AdminRequestTokenGenerator` , c'est Claude qui m'a soufflé de copier le `CompanySignupTokenGenerator`, lui-même copié du `PasswordResetGenerator` de Django. 

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<img width="1532" height="673" alt="Capture d’écran 2026-06-05 à 11 36 41" src="https://github.com/user-attachments/assets/177dd8aa-b435-4332-950f-c5a071d8c51c" />

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche p

rescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
