### PR TITLE
GEIQ : Tri amélioré des bilans GEIQ côté institutions

### DIFF
--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -9,7 +9,8 @@ from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.core.files.base import ContentFile
 from django.db import models
-from django.db.models import Case, Count, F, Prefetch, Q, Sum, When
+from django.db.models import Case, Count, F, IntegerField, Prefetch, Q, Sum, Value, When
+from django.db.models.functions import Greatest
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -27,6 +28,7 @@ from itou.geiq_assessments.models import (
     Assessment,
     AssessmentCampaign,
     AssessmentInstitutionLink,
+    AssessmentState,
     EmployeeContract,
     LabelInfos,
 )
@@ -812,8 +814,23 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
         .prefetch_related("institution_links__institution")
         .annotate(
             contracts_nb=Count("employees__contracts", filter=Q(employees__contracts__allowance_requested=True)),
+            state_order=Case(
+                When(state=AssessmentState.REVIEWED, then=Value(0)),
+                When(state=AssessmentState.SUBMITTED, then=Value(1)),
+                When(state=AssessmentState.NEW, then=Value(2)),
+                When(state=AssessmentState.FINAL_REVIEWED, then=Value(3)),
+                default=Value(0),
+                output_field=IntegerField(),
+            ),
+            last_updated_at=Greatest(
+                "created_at",
+                "decision_validated_at",
+                "grants_selection_validated_at",
+                "reviewed_at",
+                "final_reviewed_at",
+            ),
         )
-        .order_by("submitted_at", "created_at")
+        .order_by("state_order", "-last_updated_at")
     )
     context = {
         "assessments": assessments,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2815,6 +2815,14 @@
                  "geiq_assessments_assessment"."final_reviewed_by_institution_id",
                  COUNT("geiq_assessments_employeecontract"."id") FILTER (
                                                                          WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
                  "geiq_assessments_assessmentcampaign"."id",
                  "geiq_assessments_assessmentcampaign"."year",
                  "geiq_assessments_assessmentcampaign"."opening_date",
@@ -2827,9 +2835,11 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
                    "geiq_assessments_assessmentcampaign"."id"
-          ORDER BY "geiq_assessments_assessment"."submitted_at" ASC,
-                   "geiq_assessments_assessment"."created_at" ASC
+          ORDER BY 34 ASC,
+                   35 DESC
         ''',
       }),
       dict({
@@ -2847,6 +2857,7 @@
                  "geiq_assessments_assessmentinstitutionlink"."with_convention"
           FROM "geiq_assessments_assessmentinstitutionlink"
           WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
                                                                                  %s,
                                                                                  %s,
                                                                                  %s)
@@ -2926,7 +2937,7 @@
           <div class="row">
               <div class="col-12">
                   <p>
-                      4 résultats
+                      5 résultats
                   </p>
                   <div class="table-responsive mt-3 mt-md-4">
                       <table class="table table-hover">
@@ -2967,43 +2978,6 @@
                           <tbody>
                               <tr>
                                   <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Un Beau GEIQ
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (23)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
-                                          À contrôler
-                                      </span>
-                                  </td>
-                                  <td>
-                                      0
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
                                       <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
                                       </a>
                                   </td>
@@ -3042,13 +3016,14 @@
                               </tr>
                               <tr>
                                   <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                      <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          Un Beau GEIQ
                                       </a>
                                   </td>
                                   <td>
                                       <ul class="mb-0">
                                           <li>
-                                              Un Superbe GEIQ (12)
+                                              Siège (23)
                                           </li>
                                       </ul>
                                   </td>
@@ -3059,23 +3034,21 @@
                                       Un DREETS GEIQ
                                   </td>
                                   <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
-                                          Validé
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                          À contrôler
                                       </span>
                                   </td>
                                   <td>
                                       0
                                   </td>
                                   <td>
-                                      80 000 €
+                                      -
                                   </td>
                                   <td>
-                                      100 000 €
+                                      -
                                   </td>
                                   <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
-                                          80 %
-                                      </span>
+                                      -
                                   </td>
                               </tr>
                               <tr>
@@ -3116,6 +3089,82 @@
                                   </td>
                                   <td>
                                       -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                          <li>
+                                              Un Superbe GEIQ (12)
+                                          </li>
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                      Un DREETS GEIQ
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                          Validé
+                                      </span>
+                                  </td>
+                                  <td>
+                                      0
+                                  </td>
+                                  <td>
+                                      90 000 €
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                          90 %
+                                      </span>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/44444444-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                          <li>
+                                              Un Superbe GEIQ (12)
+                                          </li>
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                      Un DREETS GEIQ
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                          Validé
+                                      </span>
+                                  </td>
+                                  <td>
+                                      0
+                                  </td>
+                                  <td>
+                                      80 000 €
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                          80 %
+                                      </span>
                                   </td>
                               </tr>
                           </tbody>

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -168,7 +168,7 @@ class TestListAssessmentsView:
             assessment=reviewed_assessment, institution=membership.institution, with_convention=True
         )
         final_reviewed_assessment = AssessmentFactory(
-            id=uuid.UUID("33333333-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            id=uuid.UUID("44444444-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
             created_by__first_name="Marie",
             created_by__last_name="Curie",
@@ -192,6 +192,31 @@ class TestListAssessmentsView:
         AssessmentInstitutionLink.objects.create(
             assessment=final_reviewed_assessment, institution=membership.institution, with_convention=True
         )
+        later_final_reviewed_assessment = AssessmentFactory(
+            id=uuid.UUID("33333333-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            created_by__first_name="Marie",
+            created_by__last_name="Curie",
+            label_antennas=[{"id": 1, "name": "Un Superbe GEIQ", "post_code": "12345"}],
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            reviewed_by=membership.user,
+            reviewed_by_institution=membership.institution,
+            review_comment="Bravo !",
+            final_reviewed_at=timezone.now() + datetime.timedelta(hours=8),
+            final_reviewed_by=membership.user,
+            final_reviewed_by_institution=membership.institution,
+            convention_amount=100_000,
+            advance_amount=60_000,
+            granted_amount=90_000,
+        )  # Assessment has been finally reviewed (i.e. updated) later than previous one: it must appear before.
+        AssessmentInstitutionLink.objects.create(
+            assessment=later_final_reviewed_assessment, institution=membership.institution, with_convention=True
+        )
         AssessmentFactory(campaign=campaign)  # Another assessment not linked to the institution
 
         with assertSnapshotQueries(snapshot(name="SQL queries")):
@@ -201,7 +226,13 @@ class TestListAssessmentsView:
         )
         assertQuerySetEqual(
             response.context["assessments"],
-            [submitted_assessment, reviewed_assessment, final_reviewed_assessment, new_assessment],
+            [
+                reviewed_assessment,
+                submitted_assessment,
+                new_assessment,
+                later_final_reviewed_assessment,
+                final_reviewed_assessment,
+            ],
         )
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

[[Carte Notion](https://www.notion.so/gip-inclusion/Trier-les-bilans-par-statut-et-du-r-cent-au-ancien-36f5f321b604802c93fec19cd5aa021e?source=copy_link)]

Modification du tri des bilans GEIQ lorsqu'ils sont affichés aux utilisateurs institutionels (FFGEIQ/DGEFP/DDETS/DREETS) : on cherche à mettre davantage en avant les bilans qui nécessitent une action de validation ou de contrôle.

## :cake: Comment ? <!-- optionnel -->

Ajout d'annoations au QuerySet `assessment` de la vue `list_for_institution` et notamment une date `last_updated_at` virtuelle qui est le maximum des autres dates du bilan.

Test `test_complex_list` légèrement modifié.

## :desert_island: Comment tester ?

N/A (?)

## :computer: Captures d'écran <!-- optionnel -->

N/A