### PR TITLE
Interface: Suppression de l'affichage en liste des résultats

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -221,9 +221,9 @@
                                                     <td>{{ contract.employee.allowance_amount|format_int_euros }}</td>
                                                     <td>
                                                         {% if request.from_employer %}
-                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_requested csrf_token=csrf_token from_list=True editable=can_validate request=request disable_stats_oob=True only %}
+                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_requested csrf_token=csrf_token editable=can_validate request=request disable_stats_oob=True only %}
                                                         {% elif request.from_institution %}
-                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_granted csrf_token=csrf_token from_list=True editable=can_validate request=request disable_stats_oob=True only %}
+                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_granted csrf_token=csrf_token editable=can_validate request=request disable_stats_oob=True only %}
                                                         {% endif %}
                                                     </td>
                                                 </tr>

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -8,16 +8,12 @@
 {% endif %}
 
 <div class="d-flex align-items-start" id="toggle_allowance_for_contract_{{ contract.pk }}">
-    <form hx-post="{{ post_url }}{% if from_list %}?from_list=1{% endif %}"
-          hx-trigger="change"
-          hx-target="#toggle_allowance_for_contract_{{ contract.pk }}"
-          hx-swap="outerHTML"
-          class="js-prevent-multiple-submit">
+    <form hx-post="{{ post_url }}" hx-trigger="change" hx-target="#toggle_allowance_for_contract_{{ contract.pk }}" hx-swap="outerHTML" class="js-prevent-multiple-submit">
         {% csrf_token %}
-        <div class="form-check form-switch mb-0{% if not from_list %} form-switch-lg{% endif %}">
+        <div class="form-check form-switch mb-0">
             <input type="checkbox" class="form-check-input" name="allowance" id="allowance_for_contract_{{ contract.pk }}" {% if value %}checked{% endif %} {% if not editable %}disabled{% endif %} />
             <label class="form-check-label" for="allowance_for_contract_{{ contract.pk }}">
-                <span {% if from_list %}class="visually-hidden"{% endif %}>
+                <span class="visually-hidden">
                     {% if request.from_employer %}
                         Obtenir l’aide
                     {% elif request.from_institution %}
@@ -63,7 +59,7 @@
     {% endif %}
 </div>
 {% with disable_oob=disable_stats_oob|default:False %}
-    {% if from_list and request.htmx and not disable_oob %}
+    {% if request.htmx and not disable_oob %}
         {% include "geiq_assessments_views/includes/contracts_list_stats.html" with stats=stats hx_swap_oob=True request=request only %}
         {% include "geiq_assessments_views/includes/contracts_list_validate_button_form.html" with ContractsAction=ContractsAction back_url=back_url contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb csrf_token=csrf_token request=request hx_swap_oob=True only %}
         {% include "geiq_assessments_views/includes/contracts_list_justification_alert.html" with contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb assessment=assessment request=request hx_swap_oob=True only %}

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -872,7 +872,6 @@ def assessment_contracts_toggle(
             contract.allowance_refusal_details = ""
             updated_fields += ["allowance_refusal_reason", "allowance_refusal_details"]
         contract.save(update_fields=updated_fields)
-    from_list = bool(request.GET.get("from_list"))
 
     # For the buttons not relying on HTMX (i.e. cards/boxes inside contract details tabs).
     if not request.htmx:
@@ -893,18 +892,16 @@ def assessment_contracts_toggle(
         )
 
     stats = None
-    if from_list:
-        if request.from_employer:
-            stats = get_allowance_stats_for_geiq(assessment, for_assessment_details=False)
-            back_url = reverse("geiq_assessments_views:details_for_geiq", kwargs={"pk": assessment.pk})
-        elif request.from_institution:
-            stats = get_allowance_stats_for_institution(assessment, for_assessment_details=False)
-            back_url = reverse("geiq_assessments_views:details_for_institution", kwargs={"pk": assessment.pk})
+    if request.from_employer:
+        stats = get_allowance_stats_for_geiq(assessment, for_assessment_details=False)
+        back_url = reverse("geiq_assessments_views:details_for_geiq", kwargs={"pk": assessment.pk})
+    elif request.from_institution:
+        stats = get_allowance_stats_for_institution(assessment, for_assessment_details=False)
+        back_url = reverse("geiq_assessments_views:details_for_institution", kwargs={"pk": assessment.pk})
 
     context = {
         "assessment": assessment,
         "contract": contract,
-        "from_list": from_list,
         "editable": True,
         "value": new_value,
         "stats": stats,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5980,7 +5980,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6014,7 +6014,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6048,7 +6048,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6253,7 +6253,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6287,7 +6287,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6321,7 +6321,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6575,7 +6575,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6609,7 +6609,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -6643,7 +6643,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7405,7 +7405,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7443,7 +7443,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7481,7 +7481,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7663,7 +7663,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7701,7 +7701,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7739,7 +7739,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -7970,7 +7970,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -8008,7 +8008,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
@@ -8046,7 +8046,7 @@
                                       </td>
                                       <td>
                                           <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
                                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                                   <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -457,8 +457,7 @@ class TestAssessmentContractsListAndToggle:
             reverse(
                 "geiq_assessments_views:assessment_contracts_exclude",
                 kwargs={"contract_pk": str(contract_1.pk)},
-            )
-            + "?from_list=1",
+            ),
             headers={"HX-Request": "true"},
         )
         update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk} > form", response)
@@ -472,8 +471,7 @@ class TestAssessmentContractsListAndToggle:
             reverse(
                 "geiq_assessments_views:assessment_contracts_include",
                 kwargs={"contract_pk": str(contract_2.pk)},
-            )
-            + "?from_list=1",
+            ),
             headers={"HX-Request": "true"},
         )
         update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk} > form", response)
@@ -555,8 +553,7 @@ class TestAssessmentContractsListAndToggle:
             reverse(
                 "geiq_assessments_views:assessment_contracts_exclude",
                 kwargs={"contract_pk": str(contract_1.pk)},
-            )
-            + "?from_list=1",
+            ),
             headers={"HX-Request": "true"},
         )
         update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk} > form", response)
@@ -569,8 +566,7 @@ class TestAssessmentContractsListAndToggle:
             reverse(
                 "geiq_assessments_views:assessment_contracts_include",
                 kwargs={"contract_pk": str(contract_2.pk)},
-            )
-            + "?from_list=1",
+            ),
             headers={"HX-Request": "true"},
         )
         update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk} > form", response)
@@ -658,8 +654,7 @@ class TestAssessmentContractsListAndToggle:
             reverse(
                 "geiq_assessments_views:assessment_contracts_exclude",
                 kwargs={"contract_pk": str(contract_1.pk)},
-            )
-            + "?from_list=1",
+            ),
             headers={"HX-Request": "true"},
         )
         contract_1.refresh_from_db()


### PR DESCRIPTION
⚠️ **Énorme ratage** : mauvais commit dans cette PR (qui reprend le commit de https://github.com/gip-inclusion/les-emplois/pull/8245, qui a déjà été intégrée). La _nouvelle_ bonne PR est : https://github.com/gip-inclusion/les-emplois/pull/8325

## :thinking: Pourquoi ?

[[Carte Notion](https://www.notion.so/gip-inclusion/Supprimer-la-vue-liste-3655f321b604802a83c3c0c1d29408db?source=copy_link)]

> On ne souhaite pas maintenir une vue liste dans la mesure où elle n’est pas utilisée par nos utilisateurs et elle nous oblige à toujours prévoir une version pour ce mode d’affichage.
> Seules les fiches salariés continueront d’être affichées sous forme de “cartes” (vue liste) car elles peuvent contenir des messages d’erreur.

## :cake: Comment ? <!-- optionnel -->

Élimination de la variable `display_kind`.

## :desert_island: Comment tester ?

.

## :computer: Captures d'écran <!-- optionnel -->

AVANT :
<img width="1920" height="1426" alt="image" src="https://github.com/user-attachments/assets/148c0541-36a1-4ebb-b91d-fd5a93d4e4be" />

APRÈS :
<img width="1920" height="1492" alt="image" src="https://github.com/user-attachments/assets/3825a1db-b62e-446d-9e52-614b13197fc1" />
<img width="1920" height="1096" alt="image" src="https://github.com/user-attachments/assets/0244e2a0-3532-4bd8-b40f-c8bc5f9ed8f3" />
