### PR TITLE
Tech: Correction du template tag "buttons_form" en cas d'absence de `reset_url`

### DIFF
--- a/itou/templates/components/demo_buttons_form.html
+++ b/itou/templates/components/demo_buttons_form.html
@@ -1,0 +1,32 @@
+{% extends "layout/base.html" %}
+{% load buttons_form %}
+{% load components %}
+{% load enums %}
+{% load matomo %}
+{% load static %}
+{% load support %}
+{% load theme_inclusion %}
+
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+
+                <h1>
+                    itou_buttons_form
+                    {% if reset_url %}
+                        avec
+                    {% else %}
+                        sans
+                    {% endif %}
+                    reset_url
+                </h1>
+                <div>gna gna gna un autre formulaire ici</div>
+                {% itou_buttons_form primary_label="Terminer" secondary_label="Revenir à l’étape précédente" secondary_url="/secondary" reset_url=reset_url|default:None %}
+
+            </div>
+        </div>
+    </section>
+
+{% endblock content %}

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -6,7 +6,7 @@
         {% if show_mandatory_fields_mention %}<small class="d-inline-block mb-3">* champs obligatoires</small>{% endif %}
         <div class="form-row align-items-center justify-content-end gx-3">
             <div class="form-group col-12 col-lg order-3 order-lg-1">
-                {% if secondary_name and secondary_value or secondary_url %}
+                {% if ask_confirmation_before_reset %}
                     {# If there is a previous step - which is what most secondaries link to - we want a confirmation before resetting everything #}
                     <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
                         <i class="ri-close-line ri-lg" aria-hidden="true"></i>
@@ -58,7 +58,7 @@
     </div>
 </div>
 
-{% if secondary_name and secondary_value or secondary_url %}
+{% if ask_confirmation_before_reset %}
     <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
@@ -72,9 +72,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                    {% if reset_url is not None %}
-                        <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                    {% endif %}
+                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
                 </div>
             </div>
         </div>

--- a/itou/utils/templatetags/buttons_form.py
+++ b/itou/utils/templatetags/buttons_form.py
@@ -95,8 +95,11 @@ def itou_buttons_form(
     if secondary_name and secondary_url:
         raise ValueError("secondary_url cannot be used with secondary_name/value")
 
+    ask_confirmation_before_reset = reset_url and (secondary_name and secondary_value or secondary_url)
+
     return {
         "show_mandatory_fields_mention": show_mandatory_fields_mention,
+        "ask_confirmation_before_reset": ask_confirmation_before_reset,
         "primary_aria_label": primary_aria_label,
         "primary_disabled": primary_disabled,
         "primary_label": primary_label,

--- a/itou/www/components/urls.py
+++ b/itou/www/components/urls.py
@@ -10,6 +10,5 @@ app_name = "components"
 urlpatterns = []
 
 if settings.ITOU_ENVIRONMENT != ItouEnvironment.PROD:
-    urlpatterns.append(
-        path("", views.show_components, name="index"),
-    )
+    urlpatterns.append(path("", views.show_components, name="index"))
+    urlpatterns.append(path("demo_buttons_form", views.demo_buttons_form, name="demo_buttons_form"))

--- a/itou/www/components/views.py
+++ b/itou/www/components/views.py
@@ -13,3 +13,9 @@ def show_components(request):
         },
     }
     return render(request, "components/index.html", context)
+
+
+@login_not_required
+def demo_buttons_form(request):
+    context = {"reset_url": request.GET.get("reset_url")}
+    return render(request, "components/demo_buttons_form.html", context)

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -502,6 +502,71 @@
   
   '''
 # ---
+# name: TestButtonsForm.test_itou_buttons_with_secondary_name_and_value_without_reset_url[with_secondary_name_and_value_without_reset_url]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="row">
+              <div class="col-12">
+                  <hr class="mb-3"/>
+                  <small class="d-inline-block mb-3">
+                      * champs obligatoires
+                  </small>
+                  <div class="form-row align-items-center justify-content-end gx-3">
+                      <div class="form-group col-12 col-lg order-3 order-lg-1">
+                          <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                              <i aria-hidden="true" class="ri-close-line ri-lg">
+                              </i>
+                              <span>
+                                  Annuler
+                              </span>
+                          </button>
+                      </div>
+                      <div class="form-group col col-lg-auto order-1 order-lg-2">
+                          <button aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" name="name" type="submit" value="1">
+                              <span>
+                                  Retour
+                              </span>
+                          </button>
+                      </div>
+                      <div class="form-group col col-lg-auto order-2 order-lg-3">
+                          <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                              <span>
+                                  Suivant
+                              </span>
+                          </button>
+                      </div>
+                  </div>
+              </div>
+          </div>
+          <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+              <div class="modal-dialog modal-dialog-centered">
+                  <div class="modal-content">
+                      <div class="modal-header">
+                          <h3 class="modal-title">
+                              Êtes-vous sûr de vouloir annuler ?
+                          </h3>
+                      </div>
+                      <div class="modal-body">
+                          Les informations renseignées ne seront pas enregistrées.
+                          <br/>
+                          Cette action est irréversible.
+                      </div>
+                      <div class="modal-footer">
+                          <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">
+                              Retour
+                          </button>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
 # name: TestButtonsForm.test_itou_buttons_with_secondary_url[no_form_title]
   '''
   <html>

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -516,13 +516,6 @@
                   </small>
                   <div class="form-row align-items-center justify-content-end gx-3">
                       <div class="form-group col-12 col-lg order-3 order-lg-1">
-                          <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
-                              <i aria-hidden="true" class="ri-close-line ri-lg">
-                              </i>
-                              <span>
-                                  Annuler
-                              </span>
-                          </button>
                       </div>
                       <div class="form-group col col-lg-auto order-1 order-lg-2">
                           <button aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" name="name" type="submit" value="1">
@@ -536,27 +529,6 @@
                               <span>
                                   Suivant
                               </span>
-                          </button>
-                      </div>
-                  </div>
-              </div>
-          </div>
-          <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-              <div class="modal-dialog modal-dialog-centered">
-                  <div class="modal-content">
-                      <div class="modal-header">
-                          <h3 class="modal-title">
-                              Êtes-vous sûr de vouloir annuler ?
-                          </h3>
-                      </div>
-                      <div class="modal-body">
-                          Les informations renseignées ne seront pas enregistrées.
-                          <br/>
-                          Cette action est irréversible.
-                      </div>
-                      <div class="modal-footer">
-                          <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">
-                              Retour
                           </button>
                       </div>
                   </div>

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -95,6 +95,14 @@ class TestButtonsForm:
         template = Template('{% load buttons_form %}{% itou_buttons_form secondary_name="name" secondary_value="1" %}')
         assert pretty_indented(template.render(Context({}))) == snapshot(name="with_secondary_name_and_value")
 
+    def test_itou_buttons_with_secondary_name_and_value_without_reset_url(self, snapshot):
+        template = Template(
+            '{% load buttons_form %}{% itou_buttons_form secondary_name="name" secondary_value="1" reset_url=None %}'
+        )
+        assert pretty_indented(template.render(Context({}))) == snapshot(
+            name="with_secondary_name_and_value_without_reset_url"
+        )
+
     def test_itou_buttons_matomo_event(self, snapshot):
         template = Template(
             "{% load buttons_form %}"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le template tag `buttons_form` affiche des boutons de formulaire : validation, éventuellement "étape précédente", éventuellement "annuler".

Quand on veut un bouton "étape précédente", mais pas de bouton "annuler", il y a un bug : le template tag affiche un bouton "Annuler" qui ouvre une modale de confirmation... dont le seul bouton ne permet que de clore la modale : 

<img width="1012" height="286" alt="Capture d’écran du 2026-06-01 18-10-59" src="https://github.com/user-attachments/assets/d1793935-595a-47d9-9d3a-548c5b473f3f" />

Version corrigée (sans `reset_url`) : 

<img width="2038" height="926" alt="image" src="https://github.com/user-attachments/assets/ae29d844-dd97-405d-b548-e4d7e0d48e75" />

## :desert_island: Comment relire ?

Ne relire que le 2ème commit. Le premier ajoute une vue+template de démo et sera supprimé.

## :desert_island: Comment tester ?

Cette PR contient une page de démo : http://localhost:8000/components/demo_buttons_form?reset_url= 
