### PR TITLE
GEIQ: autoriser la suppression des bilans non transmis dans l'admin 

### DIFF
--- a/itou/geiq_assessments/admin.py
+++ b/itou/geiq_assessments/admin.py
@@ -116,7 +116,7 @@ class TransitionLogInline(ReadonlyMixin, ItouTabularInline):
 
 
 @admin.register(models.Assessment)
-class AssessmentAdmin(ReadonlyMixin, ItouModelAdmin):
+class AssessmentAdmin(ItouModelAdmin):
     list_display = [
         "label_geiq_name",
         "campaign",
@@ -193,6 +193,29 @@ class AssessmentAdmin(ReadonlyMixin, ItouModelAdmin):
             },
         ),
     )
+
+    def has_add_permission(self, *args, **kwargs):
+        return False
+
+    def has_change_permission(self, *args, **kwargs):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        # One can only delete "new" assessments (with the matching permission)
+        if obj and obj.submitted_at:
+            return False
+        return super().has_delete_permission(request, obj)
+
+    def get_deleted_objects(self, objs, request):
+        to_delete, model_count, perms_needed, protected = super().get_deleted_objects(objs, request)
+        # Don't block Assessment deletion for those objects
+        for model in [
+            models.Employee,
+            models.EmployeeContract,
+            models.EmployeePrequalification,
+        ]:
+            perms_needed.discard(model._meta.verbose_name)
+        return to_delete, model_count, perms_needed, protected
 
 
 class EmployeeContractInline(ReadonlyMixin, ItouTabularInline):

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -87,7 +87,7 @@ def get_permissions_dict():
         files_models.File: PERMS_READ,
         geo_models.QPV: PERMS_READ,
         geo_models.ZRR: PERMS_READ,
-        geiq_assessments_models.AssessmentCampaign: PERMS_ADD,
+        geiq_assessments_models.AssessmentCampaign: PERMS_READ,
         geiq_assessments_models.Assessment: PERMS_READ,
         geiq_assessments_models.Employee: PERMS_READ,
         geiq_assessments_models.EmployeeContract: PERMS_READ,
@@ -177,6 +177,9 @@ def get_permissions_dict():
             siae_evaluations_models.EvaluatedJobApplicationSanction: PERMS_ALL,
             siae_evaluations_models.EvaluatedAdministrativeCriteria: PERMS_ALL,
             siae_evaluations_models.Sanctions: PERMS_ALL,
+        },
+        "geiq-assessments": {
+            geiq_assessments_models.AssessmentCampaign: PERMS_ADD,
         },
     }
 

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -180,6 +180,7 @@ def get_permissions_dict():
         },
         "geiq-assessments": {
             geiq_assessments_models.AssessmentCampaign: PERMS_ADD,
+            geiq_assessments_models.Assessment: PERMS_DELETE,
         },
     }
 

--- a/tests/geiq_assessments/test_admin.py
+++ b/tests/geiq_assessments/test_admin.py
@@ -5,10 +5,16 @@ from django.urls import reverse
 from pytest_django.asserts import assertMessages
 
 from itou.companies.enums import CompanyKind
+from itou.geiq_assessments.models import Assessment
 from itou.utils.apis import geiq_label
 from tests.companies.factories import CompanyFactory
 from tests.geiq.factories import GeiqLabelDataFactory
-from tests.geiq_assessments.factories import AssessmentCampaignFactory
+from tests.geiq_assessments.factories import (
+    AssessmentCampaignFactory,
+    AssessmentFactory,
+    EmployeeContractFactory,
+    EmployeePrequalificationFactory,
+)
 
 
 def test_sync_assessments_without_conf(admin_client, settings):
@@ -88,3 +94,28 @@ def test_sync_assessments_all_good(admin_client, label_settings, mocker):
     assert campaign.label_infos
     assert len(campaign.label_infos.data) == 1
     assert campaign.label_infos.data[0]["siret"] == geiq.siret
+
+
+@pytest.mark.parametrize("submitted", [True, False])
+def test_delete_assessment(admin_client, submitted):
+    assessment = AssessmentFactory(with_submission_requirements=True)
+    if submitted:
+        assessment.submit(user=assessment.created_by)
+        # Since a submitted assessment cannot be deleted, don't bother with extra objects
+    else:
+        EmployeeContractFactory(employee__assessment=assessment)
+        EmployeePrequalificationFactory(employee__assessment=assessment)
+    response = admin_client.post(
+        reverse("admin:geiq_assessments_assessment_changelist"),
+        {
+            "action": "delete_selected",
+            "post": "yes",
+            "_selected_action": str(assessment.pk),
+        },
+    )
+    if submitted:
+        assert response.status_code == 403
+        assert Assessment.objects.filter(pk=assessment.pk).exists()
+    else:
+        assert response.status_code == 302
+        assert not Assessment.objects.filter(pk=assessment.pk).exists()

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -1,6 +1,8 @@
 # serializer version: 1
 # name: test_command[geiq-assessments]
   list([
+    'delete_assessment',
+    'view_assessment',
     'add_assessmentcampaign',
     'change_assessmentcampaign',
     'view_assessmentcampaign',
@@ -300,6 +302,8 @@
     'group name=geiq-assessments created',
     'group name=geiq-assessments, permission add_assessmentcampaign added',
     'group name=geiq-assessments, permission change_assessmentcampaign added',
+    'group name=geiq-assessments, permission delete_assessment added',
+    'group name=geiq-assessments, permission view_assessment added',
     'group name=geiq-assessments, permission view_assessmentcampaign added',
     'group name=gps-admin created',
     'group name=gps-admin, permission add_followupgroup added',

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -1,4 +1,11 @@
 # serializer version: 1
+# name: test_command[geiq-assessments]
+  list([
+    'add_assessmentcampaign',
+    'change_assessmentcampaign',
+    'view_assessmentcampaign',
+  ])
+# ---
 # name: test_command[gps-admin-readonly]
   list([
     'view_company',
@@ -181,8 +188,6 @@
     'view_employeerecordupdatenotification',
     'view_file',
     'view_assessment',
-    'add_assessmentcampaign',
-    'change_assessmentcampaign',
     'view_assessmentcampaign',
     'view_employee',
     'view_employeecontract',
@@ -292,6 +297,10 @@
 # ---
 # name: test_command[logs]
   list([
+    'group name=geiq-assessments created',
+    'group name=geiq-assessments, permission add_assessmentcampaign added',
+    'group name=geiq-assessments, permission change_assessmentcampaign added',
+    'group name=geiq-assessments, permission view_assessmentcampaign added',
     'group name=gps-admin created',
     'group name=gps-admin, permission add_followupgroup added',
     'group name=gps-admin, permission add_followupgroupmembership added',
@@ -327,7 +336,6 @@
     'group name=itou-admin created',
     'group name=itou-admin, permission add_announcementcampaign added',
     'group name=itou-admin, permission add_announcementitem added',
-    'group name=itou-admin, permission add_assessmentcampaign added',
     'group name=itou-admin, permission add_company added',
     'group name=itou-admin, permission add_companymembership added',
     'group name=itou-admin, permission add_eligibilitydiagnosis added',
@@ -349,7 +357,6 @@
     'group name=itou-admin, permission change_announcementcampaign added',
     'group name=itou-admin, permission change_announcementitem added',
     'group name=itou-admin, permission change_approval added',
-    'group name=itou-admin, permission change_assessmentcampaign added',
     'group name=itou-admin, permission change_company added',
     'group name=itou-admin, permission change_companymembership added',
     'group name=itou-admin, permission change_eligibilitydiagnosis added',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un certain nombre de bilans vont nécessiter d'être supprimés puis recréés, donc autant que le métier soit autonome.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
