### PR TITLE
Tech: suppression de données personnelles de logs

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -335,10 +335,12 @@ class CancelledApproval(PENotificationMixin, CommonApprovalMixin):
             ]
         ):
             self.pe_log_err(
-                "had an invalid user_first_name={} user_last_name={} nir={}",
-                self.user_first_name,
-                self.user_last_name,
-                self.user_nir,
+                "approval is missing information in fields: %s",
+                [
+                    f
+                    for f in ("user_first_name", "user_last_name", "user_nir", "user_birthdate")
+                    if not getattr(self, f)
+                ],
             )
             # we save those as pending since the cron will ignore those cases anyway and thus has
             # no chance to block itself.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on ne souhaite pas avoir de données personnelles dans nos logs.

A priori, ce log n'a jamais été émis car on vérifie ces champs avant d'essayer l'envoi du PASS annulé à France Travail

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
