### PR TITLE
GEIQ : Passage de la vue du détail des contrats en CBV

### DIFF
--- a/itou/geiq_assessments/enums.py
+++ b/itou/geiq_assessments/enums.py
@@ -59,6 +59,17 @@ class AllowanceRefusalReason(models.TextChoices):
         return details.get(reason)
 
 
+class EmployerAction(enum.StrEnum):
+    REQUEST_ALLOWANCE = "request_allowance"
+    UNREQUEST_ALLOWANCE = "unrequest_allowance"
+
+    # Make the Enum work in Django's templates
+    # See :
+    # - https://docs.djangoproject.com/en/dev/ref/templates/api/#variables-and-lookups
+    # - https://github.com/django/django/pull/12304
+    do_not_call_in_templates = enum.nonmember(True)
+
+
 class InstitutionAction(enum.StrEnum):
     REVIEW = "review"
     ASK_FOR_INSTITUTION_FIX = "ask_for_institution_fix"

--- a/itou/geiq_assessments/enums.py
+++ b/itou/geiq_assessments/enums.py
@@ -62,6 +62,7 @@ class AllowanceRefusalReason(models.TextChoices):
 class EmployerAction(enum.StrEnum):
     REQUEST_ALLOWANCE = "request_allowance"
     UNREQUEST_ALLOWANCE = "unrequest_allowance"
+    ALLOWANCE_REQUEST_JUSTIFICATION = "allowance_request_justification"
 
     # Make the Enum work in Django's templates
     # See :

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -66,7 +66,7 @@
         {% elif request.from_institution and not contract.allowance_granted %}
             <li class="nav-item">
                 <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %} active{% endif %}"
-                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %}">{{ AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.label }}
+                   href="{% url "geiq_assessments_views:assessment_contracts_details_refusal_justification" contract_pk=contract.pk %}">{{ AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.label }}
                     {% if not contract.allowance_refusal_reason %}<i class="ri-error-warning-line ri-xl text-warning ms-2"></i>{% endif %}
                 </a>
             </li>

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -56,7 +56,7 @@
         {% if request.from_employer and contract.requires_justification %}
             <li class="nav-item">
                 <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %} active{% endif %}"
-                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}">
+                   href="{% url "geiq_assessments_views:assessment_contracts_details_request_justification" contract_pk=contract.pk %}">
                     <span>{{ AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.label }}</span>
                     {% if not contract.allowance_request_justification_reason %}
                         <i class="ri-error-warning-line text-warning ms-2"></i>

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -32,30 +32,45 @@
         {% endcomponent_alert %}
     {% endif %}
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
-        {% for tab in AssessmentContractDetailsTab %}
-            {% if tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION and tab != AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}
-                <li class="nav-item">
-                    {# FIXME(ewen): use span as below #}
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
-                    </a>
-                </li>
-            {% elif tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION and request.from_employer and contract.requires_justification %}
-                <li class="nav-item">
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">
-                        <span>{{ tab.label }}</span>
-                        {% if not contract.allowance_request_justification_reason %}
-                            <i class="ri-error-warning-line text-warning ms-2"></i>
-                        {% endif %}
-                    </a>
-                </li>
-            {% elif tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION and request.from_institution and not contract.allowance_granted %}
-                <li class="nav-item">
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
-                        {% if not contract.allowance_refusal_reason %}<i class="ri-error-warning-line ri-xl text-warning ms-2"></i>{% endif %}
-                    </a>
-                </li>
-            {% endif %}
-        {% endfor %}
+        <li class="nav-item">
+            <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.EMPLOYEE %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details_employee" contract_pk=contract.pk %}">
+                <span>{{ AssessmentContractDetailsTab.EMPLOYEE.label }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.CONTRACT %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details_contract" contract_pk=contract.pk %}">
+                <span>{{ AssessmentContractDetailsTab.CONTRACT.label }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.SUPPORT_AND_TRAINING %} active{% endif %}"
+               href="{% url "geiq_assessments_views:assessment_contracts_details_support_and_training" contract_pk=contract.pk %}">
+                <span>{{ AssessmentContractDetailsTab.SUPPORT_AND_TRAINING.label }}</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.EXIT %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details_exit" contract_pk=contract.pk %}">
+                <span>{{ AssessmentContractDetailsTab.EXIT.label }}</span>
+            </a>
+        </li>
+        {% if request.from_employer and contract.requires_justification %}
+            <li class="nav-item">
+                <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %} active{% endif %}"
+                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}">
+                    <span>{{ AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.label }}</span>
+                    {% if not contract.allowance_request_justification_reason %}
+                        <i class="ri-error-warning-line text-warning ms-2"></i>
+                    {% endif %}
+                </a>
+            </li>
+        {% elif request.from_institution and not contract.allowance_granted %}
+            <li class="nav-item">
+                <a class="nav-link{% if active_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %} active{% endif %}"
+                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %}">{{ AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.label }}
+                    {% if not contract.allowance_refusal_reason %}<i class="ri-error-warning-line ri-xl text-warning ms-2"></i>{% endif %}
+                </a>
+            </li>
+        {% endif %}
     </ul>
 {% endblock %}
 

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -208,7 +208,7 @@
                                                         {% else %}
                                                             Non
                                                             {% if request.from_institution and contract.allowance_request_justification_reason %}
-                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.CONTRACT %}"
+                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details_contract' contract_pk=contract.pk %}"
                                                                    class="text-info text-decoration-none lh-1"
                                                                    data-bs-toggle="tooltip"
                                                                    data-bs-title="Le GEIQ a motivé cette demande d’aide">

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -183,7 +183,7 @@
                                             {% for contract in contracts_page %}
                                                 <tr>
                                                     <td>
-                                                        <a class="btn-link" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.EMPLOYEE %}">{{ contract.employee.get_full_name }}</a>
+                                                        <a class="btn-link" href="{% url "geiq_assessments_views:assessment_contracts_details_employee" contract_pk=contract.pk %}">{{ contract.employee.get_full_name }}</a>
                                                         {% if contract.employee.allowance_granted_previous_year %}
                                                             <i class="ri-file-warning-line ri-lg text-warning"
                                                                aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière."

--- a/itou/templates/geiq_assessments_views/includes/allowance_request_justification_form.html
+++ b/itou/templates/geiq_assessments_views/includes/allowance_request_justification_form.html
@@ -1,10 +1,13 @@
 {% load buttons_form %}
 {% load django_bootstrap5 %}
+{% load enums %}
+{% enums "geiq_assessments" "EmployerAction" as EmployerAction %}
 <div class="c-form mb-3 mb-md-4">
     <form method="post">
         {% csrf_token %}
         {% bootstrap_form_errors form type="all" %}
         <h2 class="h3">{{ form.allowance_request_reason.label }} *</h2>
+        <input type="hidden" name="action" value="{{ EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION }}" />
         {% for choice in form.allowance_request_reason %}
             <div class="form-group">
                 <div class="form-check">

--- a/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
@@ -33,7 +33,7 @@
 
         {% if active_tab != active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
             <a class="btn btn-outline-primary btn-block btn-lg mb-2{% if disabled %} disabled{% endif %}"
-               href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}">
+               href="{% url "geiq_assessments_views:assessment_contracts_details_refusal_justification" contract_pk=contract.pk %}">
                 <span>{{ contract.allowance_refusal_reason|yesno:"Modifier le motif de refus,Justifier le refus" }}</span>
             </a>
         {% endif %}

--- a/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
@@ -1,8 +1,8 @@
 {% load enums %}
 <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
     {% if contract.allowance_requested %}
+        <h3>Aide sollicitée pour ce contrat</h3>
         {% if contract.requires_justification %}
-            <h3>Aide sollicitée pour ce contrat</h3>
             <p>
                 La durée du contrat est inférieure à {{ MIN_DAYS_IN_YEAR_FOR_ALLOWANCE }} jours sur l’année {{ contract.employee.assessment.campaign.year }}.
                 {% if contract.allowance_request_justification_reason %}
@@ -20,24 +20,16 @@
                     {{ contract.allowance_request_justification_reason|yesno:"Modifier votre justification,Justifier la demande d’aide" }}
                 </a>
             {% endif %}
-            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-ico btn-outline-primary bg-white w-100"{% if disabled %} disabled{% endif %}>
-                    <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
-                    <span>Ne plus solliciter l’aide</span>
-                </button>
-            </form>
         {% else %}
-            <h3>Aide sollicitée pour ce contrat</h3>
             <p>Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.</p>
-            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-ico btn-outline-primary bg-white w-100"{% if disabled %} disabled{% endif %}>
-                    <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
-                    <span>Ne plus solliciter l’aide</span>
-                </button>
-            </form>
         {% endif %}
+        <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-ico btn-outline-primary bg-white w-100"{% if disabled %} disabled{% endif %}>
+                <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
+                <span>Ne plus solliciter l’aide</span>
+            </button>
+        </form>
     {% else %}
         <h3>Aide non sollicitée pour ce contrat</h3>
         <p>Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.</p>

--- a/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
@@ -1,4 +1,5 @@
 {% load enums %}
+{% enums "geiq_assessments" "EmployerAction" as EmployerAction %}
 <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
     {% if contract.allowance_requested %}
         <h3>Aide sollicitée pour ce contrat</h3>
@@ -23,9 +24,9 @@
         {% else %}
             <p>Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.</p>
         {% endif %}
-        <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
+        <form method="post">
             {% csrf_token %}
-            <button type="submit" class="btn btn-ico btn-outline-primary bg-white w-100"{% if disabled %} disabled{% endif %}>
+            <button type="submit" class="btn btn-ico btn-outline-primary bg-white w-100" name="action" value="{{ EmployerAction.UNREQUEST_ALLOWANCE }}"{% if disabled %} disabled{% endif %}>
                 <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
                 <span>Ne plus solliciter l’aide</span>
             </button>
@@ -33,9 +34,11 @@
     {% else %}
         <h3>Aide non sollicitée pour ce contrat</h3>
         <p>Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.</p>
-        <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_include' contract_pk=contract.pk %}">
+        <form method="post">
             {% csrf_token %}
-            <button type="submit" class="btn btn-primary w-100"{% if disabled %} disabled{% endif %}>Solliciter l’aide</button>
+            <button type="submit" class="btn btn-primary w-100" name="action" value="{{ EmployerAction.REQUEST_ALLOWANCE }}"{% if disabled %} disabled{% endif %}>
+                Solliciter l’aide
+            </button>
         </form>
     {% endif %}
 </div>

--- a/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
@@ -15,9 +15,8 @@
             <p>Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».</p>
             {% if active_tab is not active_tab.ALLOWANCE_REQUEST_JUSTIFICATION %}
                 <a type="button"
-                   class="btn btn-primary w-100 mb-3"
-                   {% if disabled %}disabled{% endif %}
-                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REQUEST_JUSTIFICATION.value %}">
+                   class="btn btn-primary w-100 mb-3{% if disabled %} disabled{% endif %}"
+                   href="{% url "geiq_assessments_views:assessment_contracts_details_request_justification" contract_pk=contract.pk %}">
                     {{ contract.allowance_request_justification_reason|yesno:"Modifier votre justification,Justifier la demande d’aide" }}
                 </a>
             {% endif %}

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -46,14 +46,14 @@
         {% endif %}
     {% elif request.from_institution and not contract.allowance_granted %}
         {% if contract.allowance_refusal_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details_refusal_justification' contract_pk=contract.pk %}"
                class="text-success text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Voir le motif de refus pour contrat.">
                 <i class="ri-check-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details_refusal_justification' contract_pk=contract.pk %}"
                class="text-warning text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver le refus pour ce contrat.">

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -30,14 +30,14 @@
 
     {% if request.from_employer and contract.requires_justification %}
         {% if contract.allowance_request_justification_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details_request_justification' contract_pk=contract.pk %}"
                class="text-success text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous avez motivé la demande d’aide de ce contrat">
                 <i class="ri-check-line" aria-label="Vous avez motivé la demande d’aide de ce contrat" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details_request_justification' contract_pk=contract.pk %}"
                class="text-warning text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver la demande d’aide de ce contrat">

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -260,12 +260,12 @@ NAV_ENTRIES = {
             "geiq_assessments_views:upload_action_financial_assessment",
             "geiq_assessments_views:assessment_comment",
             "geiq_assessments_views:assessment_contracts_list",
-            "geiq_assessments_views:assessment_contracts_details",  # deprecated
             "geiq_assessments_views:assessment_contracts_details_employee",
             "geiq_assessments_views:assessment_contracts_details_contract",
             "geiq_assessments_views:assessment_contracts_details_support_and_training",
             "geiq_assessments_views:assessment_contracts_details_exit",
             "geiq_assessments_views:assessment_contracts_details_request_justification",
+            "geiq_assessments_views:assessment_contracts_details_refusal_justification",
         ],
         matomo_event_category="offcanvasNav",
         matomo_event_name="clic",

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -260,7 +260,11 @@ NAV_ENTRIES = {
             "geiq_assessments_views:upload_action_financial_assessment",
             "geiq_assessments_views:assessment_comment",
             "geiq_assessments_views:assessment_contracts_list",
-            "geiq_assessments_views:assessment_contracts_details",
+            "geiq_assessments_views:assessment_contracts_details",  # deprecated
+            "geiq_assessments_views:assessment_contracts_details_employee",
+            "geiq_assessments_views:assessment_contracts_details_contract",
+            "geiq_assessments_views:assessment_contracts_details_support_and_training",
+            "geiq_assessments_views:assessment_contracts_details_exit",
         ],
         matomo_event_category="offcanvasNav",
         matomo_event_name="clic",

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -265,6 +265,7 @@ NAV_ENTRIES = {
             "geiq_assessments_views:assessment_contracts_details_contract",
             "geiq_assessments_views:assessment_contracts_details_support_and_training",
             "geiq_assessments_views:assessment_contracts_details_exit",
+            "geiq_assessments_views:assessment_contracts_details_request_justification",
         ],
         matomo_event_category="offcanvasNav",
         matomo_event_name="clic",

--- a/itou/www/geiq_assessments_views/urls.py
+++ b/itou/www/geiq_assessments_views/urls.py
@@ -87,10 +87,30 @@ urlpatterns = [
         kwargs={"new_value": False},
     ),
     path(
+        "contracts/<uuid:contract_pk>/employee",
+        views.AssessmentContractDetailsEmployeeView.as_view(),
+        name="assessment_contracts_details_employee",
+    ),
+    path(
+        "contracts/<uuid:contract_pk>/contract",
+        views.AssessmentContractDetailsContractView.as_view(),
+        name="assessment_contracts_details_contract",
+    ),
+    path(
+        "contracts/<uuid:contract_pk>/support-and-training",
+        views.AssessmentContractDetailsSupportAndTrainingView.as_view(),
+        name="assessment_contracts_details_support_and_training",
+    ),
+    path(
+        "contracts/<uuid:contract_pk>/exit",
+        views.AssessmentContractDetailsExitView.as_view(),
+        name="assessment_contracts_details_exit",
+    ),
+    path(
         "contracts/<uuid:contract_pk>/<str:tab>",
         views.assessment_contracts_details,
         name="assessment_contracts_details",
-    ),
+    ),  # ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION
     # institution urls
     path("institution/list", views.list_for_institution, name="list_for_institution"),
     path("institution/<uuid:pk>", views.assessment_details_for_institution, name="details_for_institution"),

--- a/itou/www/geiq_assessments_views/urls.py
+++ b/itou/www/geiq_assessments_views/urls.py
@@ -107,15 +107,15 @@ urlpatterns = [
         name="assessment_contracts_details_exit",
     ),
     path(
+        "contracts/<uuid:contract_pk>/request-justification",
+        views.AssessmentContractDetailsRequestJustificationView.as_view(),
+        name="assessment_contracts_details_request_justification",
+    ),
+    path(
         "contracts/<uuid:contract_pk>/refusal-justification",
         views.AssessmentContractDetailsRefusalJustificationView.as_view(),
         name="assessment_contracts_details_refusal_justification",
     ),
-    path(
-        "contracts/<uuid:contract_pk>/<str:tab>",
-        views.assessment_contracts_details,
-        name="assessment_contracts_details",
-    ),  # ALLOWANCE_REQUEST_JUSTIFICATION
     # institution urls
     path("institution/list", views.list_for_institution, name="list_for_institution"),
     path("institution/<uuid:pk>", views.assessment_details_for_institution, name="details_for_institution"),

--- a/itou/www/geiq_assessments_views/urls.py
+++ b/itou/www/geiq_assessments_views/urls.py
@@ -107,10 +107,15 @@ urlpatterns = [
         name="assessment_contracts_details_exit",
     ),
     path(
+        "contracts/<uuid:contract_pk>/refusal-justification",
+        views.AssessmentContractDetailsRefusalJustificationView.as_view(),
+        name="assessment_contracts_details_refusal_justification",
+    ),
+    path(
         "contracts/<uuid:contract_pk>/<str:tab>",
         views.assessment_contracts_details,
         name="assessment_contracts_details",
-    ),  # ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION
+    ),  # ALLOWANCE_REQUEST_JUSTIFICATION
     # institution urls
     path("institution/list", views.list_for_institution, name="list_for_institution"),
     path("institution/<uuid:pk>", views.assessment_details_for_institution, name="details_for_institution"),

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -723,11 +723,8 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
 
                 if self.object.requires_justification and not self.object.allowance_request_justification_reason:
                     redirect_to_view = reverse(
-                        "geiq_assessments_views:assessment_contracts_details",
-                        kwargs={
-                            "contract_pk": self.object.pk,
-                            "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION,
-                        },
+                        "geiq_assessments_views:assessment_contracts_details_request_justification",
+                        kwargs={"contract_pk": self.object.pk},
                     )
                 else:
                     redirect_to_view = reverse(
@@ -846,6 +843,76 @@ class AssessmentContractDetailsExitView(AssessmentContractDetailsBaseView):
         self.tab = AssessmentContractDetailsTab.EXIT
 
 
+class AssessmentContractDetailsRequestJustificationView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return employer_has_access_to_assessments(self.request)
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.object.requires_justification:
+            raise Http404
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
+    def get_form(self):
+        form = AllowanceRequestJustificationForm(
+            data=self.request.POST
+            if self.request.POST.get("action") == EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION
+            else None,
+            initial={
+                "allowance_request_reason": self.object.allowance_request_justification_reason,
+                "allowance_request_details": self.object.allowance_request_justification_details,
+            },
+        )
+        if self.object.employee.assessment.contracts_selection_validated_at:
+            for fieldname in form.fields:
+                form.fields[fieldname].disabled = True
+        return form
+
+    def post_action(self, action):
+        if not self.object.requires_justification:
+            raise Http404
+
+        self.allowance_request_justification_form = self.get_form()
+        if action is EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION:
+            if self.allowance_request_justification_form.is_valid():
+                if self.object.employee.assessment.contracts_selection_validated_at:
+                    messages.error(
+                        self.request,
+                        "La sélection des contrats a déjà été validée : "
+                        "vous ne pouvez plus modifier le motif de sollicitation de l’aide pour ce contrat.",
+                    )
+                else:
+                    self.object.allowance_request_justification_reason = (
+                        self.allowance_request_justification_form.cleaned_data["allowance_request_reason"]
+                    )
+                    self.object.allowance_request_justification_details = (
+                        self.allowance_request_justification_form.cleaned_data["allowance_request_details"]
+                    )
+                    self.object.save(
+                        update_fields=(
+                            "allowance_request_justification_reason",
+                            "allowance_request_justification_details",
+                        )
+                    )
+                return HttpResponseRedirect(
+                    reverse(
+                        "geiq_assessments_views:assessment_contracts_details_contract",
+                        kwargs={"contract_pk": str(self.object.pk)},
+                    )
+                )
+            return self.render_to_response(self.get_context_data(object=self.object))
+
+        return super().post_action(action)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {"allowance_request_justification_form": self.get_form()}
+
+
 class AssessmentContractDetailsRefusalJustificationView(AssessmentContractDetailsBaseView):
     def test_func(self):
         return self.request.from_institution
@@ -903,175 +970,6 @@ class AssessmentContractDetailsRefusalJustificationView(AssessmentContractDetail
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {"allowance_refusal_justification_form": self.get_form()}
-
-
-# View only used for ALLOWANCE_REQUEST_JUSTIFICATION temporarily
-@check_request(lambda request: employer_has_access_to_assessments(request) or request.from_institution)
-def assessment_contracts_details(
-    request, contract_pk, tab, template_name="geiq_assessments_views/assessment_contracts_details.html"
-):
-    try:
-        details_tab = AssessmentContractDetailsTab(tab)
-    except ValueError:
-        raise Http404
-    if request.from_employer:
-        if tab not in AssessmentContractDetailsTab.get_employer_tabs():
-            raise Http404
-        filter_kwargs = {"employee__assessment__companies": request.current_organization}
-    elif request.from_institution:
-        if tab not in AssessmentContractDetailsTab.get_institution_tabs():
-            raise Http404
-        filter_kwargs = {
-            "employee__assessment__institutions": request.current_organization,
-            "employee__assessment__submitted_at__isnull": False,
-            "allowance_requested": True,
-        }
-    else:
-        raise Http404  # This should never happen thanks to check_request
-    contract_qs = EmployeeContract.objects.filter(**filter_kwargs).select_related("employee__assessment__campaign")
-    if details_tab == AssessmentContractDetailsTab.SUPPORT_AND_TRAINING:
-        contract_qs = contract_qs.prefetch_related("employee__prequalifications")
-    contract = get_object_or_404(contract_qs, pk=contract_pk)
-
-    editable = False
-    context = {}
-    if request.from_employer:
-        if not contract.employee.assessment.submitted_at:
-            editable = not contract.employee.assessment.contracts_selection_validated_at
-        if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION:
-            if not contract.requires_justification:
-                raise Http404  # Tab is displayed and accessible only if the contract requires justification.
-            allowance_request_justification_form = AllowanceRequestJustificationForm(
-                data=request.POST or None,
-                initial={
-                    "allowance_request_reason": contract.allowance_request_justification_reason,
-                    "allowance_request_details": contract.allowance_request_justification_details,
-                },
-            )
-            if contract.employee.assessment.contracts_selection_validated_at:
-                for fieldname in allowance_request_justification_form.fields:
-                    allowance_request_justification_form.fields[fieldname].disabled = True
-            context |= {"allowance_request_justification_form": allowance_request_justification_form}
-            if request.method == "POST":
-                if allowance_request_justification_form.is_valid():
-                    if contract.employee.assessment.contracts_selection_validated_at:
-                        messages.error(
-                            request,
-                            "La sélection des contrats a déjà été validée : "
-                            "vous ne pouvez plus modifier le motif de sollicitation de l’aide pour ce contrat.",
-                        )
-                    else:
-                        contract.allowance_request_justification_reason = (
-                            allowance_request_justification_form.cleaned_data["allowance_request_reason"]
-                        )
-                        contract.allowance_request_justification_details = (
-                            allowance_request_justification_form.cleaned_data["allowance_request_details"]
-                        )
-                        contract.save(
-                            update_fields=(
-                                "allowance_request_justification_reason",
-                                "allowance_request_justification_details",
-                            )
-                        )
-                    return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={
-                                "contract_pk": str(contract.pk),
-                                "tab": AssessmentContractDetailsTab.CONTRACT.value,
-                            },
-                        )
-                    )
-    elif request.from_institution:
-        if not contract.employee.assessment.reviewed_at:
-            editable = not contract.employee.assessment.grants_selection_validated_at
-        if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
-            if contract.allowance_granted:
-                raise Http404
-            allowance_refusal_justification_form = AllowanceRefusalJustificationForm(
-                data=request.POST
-                if request.POST.get("action") == InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION
-                else None,
-                initial={
-                    "allowance_refusal_reason": contract.allowance_refusal_reason,
-                    "allowance_refusal_details": contract.allowance_refusal_details,
-                },
-            )
-            if contract.employee.assessment.grants_selection_validated_at:
-                for fieldname in allowance_refusal_justification_form.fields:
-                    allowance_refusal_justification_form.fields[fieldname].disabled = True
-            context |= {"allowance_refusal_justification_form": allowance_refusal_justification_form}
-
-        if request.method == "POST":
-            try:
-                action = InstitutionAction(request.POST.get("action"))
-            except ValueError:
-                raise Http404
-
-            if action in [InstitutionAction.REFUSE_ALLOWANCE, InstitutionAction.GRANT_ALLOWANCE]:
-                redirect_to_tab = None
-                if contract.employee.assessment.grants_selection_validated_at:
-                    messages.error(
-                        request,
-                        "La sélection des contrats a déjà été validée : "
-                        "vous ne pouvez plus accorder ou refuser l’aide pour ce contrat.",
-                    )
-                elif action is InstitutionAction.REFUSE_ALLOWANCE:
-                    contract.allowance_granted = False
-                    contract.save(update_fields=("allowance_granted",))
-                    redirect_to_tab = AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value
-                elif action is InstitutionAction.GRANT_ALLOWANCE:
-                    contract.allowance_granted = True
-                    contract.allowance_refusal_reason = ""
-                    contract.allowance_refusal_details = ""
-                    contract.save(
-                        update_fields=(
-                            "allowance_granted",
-                            "allowance_refusal_reason",
-                            "allowance_refusal_details",
-                        )
-                    )
-                    if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
-                        redirect_to_tab = AssessmentContractDetailsTab.EMPLOYEE.value
-                if redirect_to_tab:
-                    return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
-                        )
-                    )
-
-            elif action is InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION:
-                if details_tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
-                    raise Http404
-                if allowance_refusal_justification_form.is_valid():
-                    if contract.employee.assessment.grants_selection_validated_at:
-                        messages.error(
-                            request,
-                            "La sélection des contrats a déjà été validée : "
-                            "vous ne pouvez plus modifier le motif de refus.",
-                        )
-                    else:
-                        contract.allowance_refusal_reason = allowance_refusal_justification_form.cleaned_data[
-                            "allowance_refusal_reason"
-                        ]
-                        contract.allowance_refusal_details = allowance_refusal_justification_form.cleaned_data[
-                            "allowance_refusal_details"
-                        ]
-                        contract.save(update_fields=("allowance_refusal_reason", "allowance_refusal_details"))
-
-    context |= {
-        "back_url": reverse(
-            "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
-        ),
-        "assessment": contract.employee.assessment,
-        "editable": editable,
-        "contract": contract,
-        "matomo_custom_title": f"Bilan d’exécution - page de detail d’un contrat - {tab}",
-        "active_tab": details_tab,
-        "MIN_DAYS_IN_YEAR_FOR_ALLOWANCE": MIN_DAYS_IN_YEAR_FOR_ALLOWANCE,
-    }
-    return render(request, template_name, context)
 
 
 @require_POST

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -6,6 +6,7 @@ from functools import partial
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.core.files.base import ContentFile
 from django.db import models
@@ -17,6 +18,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import content_disposition_header
 from django.views.decorators.http import require_POST, require_safe
+from django.views.generic import DetailView
 
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, REGIONS
 from itou.companies.enums import CompanyKind
@@ -663,6 +665,149 @@ def assessment_contracts_export(request, pk, include_unselected_by_geiq):
     )
 
 
+class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
+    model = EmployeeContract
+    template_name = "geiq_assessments_views/assessment_contracts_details.html"
+    context_object_name = "contract"
+    slug_field = "pk"
+    slug_url_kwarg = "contract_pk"
+
+    def test_func(self):
+        raise NotImplementedError
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.editable = False
+        self.tab = None
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+
+        if self.request.from_employer:
+            filter_kwargs = {"employee__assessment__companies": self.request.current_organization}
+        elif self.request.from_institution:
+            filter_kwargs = {
+                "employee__assessment__institutions": self.request.current_organization,
+                "employee__assessment__submitted_at__isnull": False,
+                "allowance_requested": True,
+            }
+        else:
+            raise Http404  # This should never happen thanks to UserPassesTestMixin
+
+        qs = qs.filter(**filter_kwargs).select_related("employee__assessment__campaign")
+
+        if self.tab == AssessmentContractDetailsTab.SUPPORT_AND_TRAINING:
+            qs = qs.prefetch_related("employee__prequalifications")
+
+        return qs
+
+    def post_action(self, action):
+        if self.request.from_institution:
+            if action in [InstitutionAction.REFUSE_ALLOWANCE, InstitutionAction.GRANT_ALLOWANCE]:
+                redirect_to_view = None
+                if self.object.employee.assessment.grants_selection_validated_at:
+                    messages.error(
+                        self.request,
+                        "La sélection des contrats a déjà été validée : "
+                        "vous ne pouvez plus accorder ou refuser l’aide pour ce contrat.",
+                    )
+                elif action is InstitutionAction.REFUSE_ALLOWANCE:
+                    self.object.allowance_granted = False
+                    self.object.save(update_fields=("allowance_granted",))
+                    redirect_to_view = reverse(
+                        "geiq_assessments_views:assessment_contracts_details",
+                        kwargs={
+                            "contract_pk": str(self.object.pk),
+                            "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
+                        },
+                    )
+                elif action is InstitutionAction.GRANT_ALLOWANCE:
+                    self.object.allowance_granted = True
+                    self.object.allowance_refusal_reason = ""
+                    self.object.allowance_refusal_details = ""
+                    self.object.save(
+                        update_fields=(
+                            "allowance_granted",
+                            "allowance_refusal_reason",
+                            "allowance_refusal_details",
+                        )
+                    )
+                if redirect_to_view:
+                    return HttpResponseRedirect(redirect_to_view)
+        return self.render_to_response(self.get_context_data(object=self.object))
+
+    def post(self, request, *args, **kwargs):
+        try:
+            action = InstitutionAction(request.POST.get("action"))
+        except ValueError:
+            raise Http404
+
+        self.object = self.get_object()
+
+        return self.post_action(action)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        if self.request.from_employer:
+            if not self.object.employee.assessment.submitted_at:
+                self.editable = not self.object.employee.assessment.contracts_selection_validated_at
+        elif self.request.from_institution:
+            if not self.object.employee.assessment.reviewed_at:
+                self.editable = not self.object.employee.assessment.grants_selection_validated_at
+
+        back_url = reverse(
+            "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": self.object.employee.assessment.pk}
+        )
+
+        context |= {
+            "back_url": back_url,
+            "assessment": self.object.employee.assessment,
+            "editable": self.editable,
+            "MIN_DAYS_IN_YEAR_FOR_ALLOWANCE": MIN_DAYS_IN_YEAR_FOR_ALLOWANCE,
+            "matomo_custom_title": f"Bilan d’exécution - page de detail d’un contrat - {self.tab}",
+            "active_tab": self.tab,
+        }
+        return context
+
+
+class AssessmentContractDetailsEmployeeView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return employer_has_access_to_assessments(self.request) or self.request.from_institution
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.EMPLOYEE
+
+
+class AssessmentContractDetailsContractView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return employer_has_access_to_assessments(self.request) or self.request.from_institution
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.CONTRACT
+
+
+class AssessmentContractDetailsSupportAndTrainingView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return employer_has_access_to_assessments(self.request) or self.request.from_institution
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.SUPPORT_AND_TRAINING
+
+
+class AssessmentContractDetailsExitView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return employer_has_access_to_assessments(self.request) or self.request.from_institution
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.EXIT
+
+
+# View only used for ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION, temporarily
 @check_request(lambda request: employer_has_access_to_assessments(request) or request.from_institution)
 def assessment_contracts_details(
     request, contract_pk, tab, template_name="geiq_assessments_views/assessment_contracts_details.html"

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -25,7 +25,12 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.files.models import save_file
 from itou.geiq_assessments import sync
-from itou.geiq_assessments.enums import AssessmentContractDetailsTab, AssessmentTransition, InstitutionAction
+from itou.geiq_assessments.enums import (
+    AssessmentContractDetailsTab,
+    AssessmentTransition,
+    EmployerAction,
+    InstitutionAction,
+)
 from itou.geiq_assessments.models import (
     MIN_DAYS_IN_YEAR_FOR_ALLOWANCE,
     Assessment,
@@ -702,6 +707,35 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
         return qs
 
     def post_action(self, action):
+        if self.request.from_employer:
+            if action in [EmployerAction.REQUEST_ALLOWANCE, EmployerAction.UNREQUEST_ALLOWANCE]:
+                if self.object.employee.assessment.contracts_selection_validated_at:
+                    messages.error(
+                        self.request,
+                        "La sélection des contrats a déjà été validée : "
+                        "vous ne pouvez plus modifier le statut de sollicitation de l’aide pour ce contrat.",
+                    )
+                elif action is EmployerAction.REQUEST_ALLOWANCE:
+                    self.object.allowance_requested = True
+                elif action is EmployerAction.UNREQUEST_ALLOWANCE:
+                    self.object.allowance_requested = False
+                self.object.save(update_fields=("allowance_requested",))
+
+                if self.object.requires_justification and not self.object.allowance_request_justification_reason:
+                    redirect_to_view = reverse(
+                        "geiq_assessments_views:assessment_contracts_details",
+                        kwargs={
+                            "contract_pk": self.object.pk,
+                            "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION,
+                        },
+                    )
+                else:
+                    redirect_to_view = reverse(
+                        "geiq_assessments_views:assessment_contracts_details_contract",
+                        kwargs={"contract_pk": self.object.pk},
+                    )
+                return HttpResponseRedirect(redirect_to_view)
+
         if self.request.from_institution:
             if action in [InstitutionAction.REFUSE_ALLOWANCE, InstitutionAction.GRANT_ALLOWANCE]:
                 redirect_to_view = None
@@ -740,7 +774,10 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
 
     def post(self, request, *args, **kwargs):
         try:
-            action = InstitutionAction(request.POST.get("action"))
+            if request.from_employer:
+                action = EmployerAction(request.POST.get("action"))
+            elif request.from_institution:
+                action = InstitutionAction(request.POST.get("action"))
         except ValueError:
             raise Http404
 
@@ -1081,24 +1118,6 @@ def assessment_contracts_toggle(
             updated_fields += ["allowance_refusal_reason", "allowance_refusal_details"]
         contract.save(update_fields=updated_fields)
     from_list = bool(request.GET.get("from_list"))
-
-    # For the buttons not relying on HTMX (i.e. cards/boxes inside contract details tabs).
-    if not request.htmx:
-        tab = AssessmentContractDetailsTab.CONTRACT
-        if contract.requires_justification and not contract.allowance_request_justification_reason:
-            tab = AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION
-        if contract.employee.assessment.contracts_selection_validated_at:
-            messages.error(
-                request,
-                "La sélection des contrats a déjà été validée : "
-                "vous ne pouvez plus modifier le statut de sollicitation de l’aide pour ce contrat.",
-            )
-        return HttpResponseRedirect(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_details",
-                kwargs={"contract_pk": contract.pk, "tab": tab.value},
-            )
-        )
 
     stats = None
     if from_list:

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -715,11 +715,8 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
                     self.object.allowance_granted = False
                     self.object.save(update_fields=("allowance_granted",))
                     redirect_to_view = reverse(
-                        "geiq_assessments_views:assessment_contracts_details",
-                        kwargs={
-                            "contract_pk": str(self.object.pk),
-                            "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
-                        },
+                        "geiq_assessments_views:assessment_contracts_details_refusal_justification",
+                        kwargs={"contract_pk": str(self.object.pk)},
                     )
                 elif action is InstitutionAction.GRANT_ALLOWANCE:
                     self.object.allowance_granted = True
@@ -732,6 +729,11 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
                             "allowance_refusal_details",
                         )
                     )
+                    if self.tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
+                        redirect_to_view = reverse(
+                            "geiq_assessments_views:assessment_contracts_details_employee",
+                            kwargs={"contract_pk": self.object.pk},
+                        )
                 if redirect_to_view:
                     return HttpResponseRedirect(redirect_to_view)
         return self.render_to_response(self.get_context_data(object=self.object))
@@ -807,7 +809,66 @@ class AssessmentContractDetailsExitView(AssessmentContractDetailsBaseView):
         self.tab = AssessmentContractDetailsTab.EXIT
 
 
-# View only used for ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION, temporarily
+class AssessmentContractDetailsRefusalJustificationView(AssessmentContractDetailsBaseView):
+    def test_func(self):
+        return self.request.from_institution
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.tab = AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if self.object.allowance_granted:
+            raise Http404
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
+    def get_form(self):
+        form = AllowanceRefusalJustificationForm(
+            data=self.request.POST
+            if self.request.POST.get("action") == InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION
+            else None,
+            initial={
+                "allowance_refusal_reason": self.object.allowance_refusal_reason,
+                "allowance_refusal_details": self.object.allowance_refusal_details,
+            },
+        )
+        if self.object.employee.assessment.grants_selection_validated_at:
+            for fieldname in form.fields:
+                form.fields[fieldname].disabled = True
+        return form
+
+    def post_action(self, action):
+        if self.object.allowance_granted:
+            raise Http404
+
+        self.allowance_refusal_justification_form = self.get_form()
+        if action is InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION:
+            if self.allowance_refusal_justification_form.is_valid():
+                if self.object.employee.assessment.grants_selection_validated_at:
+                    messages.error(
+                        self.request,
+                        "La sélection des contrats a déjà été validée : "
+                        "vous ne pouvez plus modifier le motif de refus.",
+                    )
+                else:
+                    self.object.allowance_refusal_reason = self.allowance_refusal_justification_form.cleaned_data[
+                        "allowance_refusal_reason"
+                    ]
+                    self.object.allowance_refusal_details = self.allowance_refusal_justification_form.cleaned_data[
+                        "allowance_refusal_details"
+                    ]
+                    self.object.save(update_fields=("allowance_refusal_reason", "allowance_refusal_details"))
+            return self.render_to_response(self.get_context_data(object=self.object))
+
+        return super().post_action(action)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {"allowance_refusal_justification_form": self.get_form()}
+
+
+# View only used for ALLOWANCE_REQUEST_JUSTIFICATION temporarily
 @check_request(lambda request: employer_has_access_to_assessments(request) or request.from_institution)
 def assessment_contracts_details(
     request, contract_pk, tab, template_name="geiq_assessments_views/assessment_contracts_details.html"

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -709,6 +709,7 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
     def post_action(self, action):
         if self.request.from_employer:
             if action in [EmployerAction.REQUEST_ALLOWANCE, EmployerAction.UNREQUEST_ALLOWANCE]:
+                redirect_to_view = None
                 if self.object.employee.assessment.contracts_selection_validated_at:
                     messages.error(
                         self.request,
@@ -717,21 +718,21 @@ class AssessmentContractDetailsBaseView(UserPassesTestMixin, DetailView):
                     )
                 elif action is EmployerAction.REQUEST_ALLOWANCE:
                     self.object.allowance_requested = True
+                    if self.object.requires_justification and not self.object.allowance_request_justification_reason:
+                        redirect_to_view = reverse(
+                            "geiq_assessments_views:assessment_contracts_details_request_justification",
+                            kwargs={"contract_pk": self.object.pk},
+                        )
                 elif action is EmployerAction.UNREQUEST_ALLOWANCE:
                     self.object.allowance_requested = False
+                    if self.tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION:
+                        redirect_to_view = reverse(
+                            "geiq_assessments_views:assessment_contracts_details_contract",
+                            kwargs={"contract_pk": self.object.pk},
+                        )
                 self.object.save(update_fields=("allowance_requested",))
-
-                if self.object.requires_justification and not self.object.allowance_request_justification_reason:
-                    redirect_to_view = reverse(
-                        "geiq_assessments_views:assessment_contracts_details_request_justification",
-                        kwargs={"contract_pk": self.object.pk},
-                    )
-                else:
-                    redirect_to_view = reverse(
-                        "geiq_assessments_views:assessment_contracts_details_contract",
-                        kwargs={"contract_pk": self.object.pk},
-                    )
-                return HttpResponseRedirect(redirect_to_view)
+                if redirect_to_view:
+                    return HttpResponseRedirect(redirect_to_view)
 
         if self.request.from_institution:
             if action in [InstitutionAction.REFUSE_ALLOWANCE, InstitutionAction.GRANT_ALLOWANCE]:
@@ -899,12 +900,6 @@ class AssessmentContractDetailsRequestJustificationView(AssessmentContractDetail
                             "allowance_request_justification_details",
                         )
                     )
-                return HttpResponseRedirect(
-                    reverse(
-                        "geiq_assessments_views:assessment_contracts_details_contract",
-                        kwargs={"contract_pk": str(self.object.pk)},
-                    )
-                )
             return self.render_to_response(self.get_context_data(object=self.object))
 
         return super().post_action(action)

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -656,8 +656,8 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsRequestJustificationView.get_object[<site-packages>/django/views/generic/detail.py]',
+          'AssessmentContractDetailsRequestJustificationView.get[www/geiq_assessments_views/views.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -733,12 +733,16 @@
       }),
       dict({
         'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -761,8 +765,6 @@
           'IncludeNode[layout/base.html]',
           'IfNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -780,12 +782,6 @@
                  AND "users_user"."id" = %s)
           LIMIT 1
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),
     ]),
   })
@@ -4315,7 +4311,7 @@
       <p>
           Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».
       </p>
-      <a class="btn btn-primary w-100 mb-3" disabled="" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification" type="button">
+      <a class="btn btn-primary w-100 mb-3 disabled" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification" type="button">
           Modifier votre justification
       </a>
       <form method="post">

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -4160,9 +4160,9 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-primary w-100" type="submit">
+          <button class="btn btn-primary w-100" name="action" type="submit" value="request_allowance">
               Solliciter l’aide
           </button>
       </form>
@@ -4189,9 +4189,9 @@
       <a class="btn btn-primary w-100 mb-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification" type="button">
           Modifier votre justification
       </a>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-ico btn-outline-primary bg-white w-100" type="submit">
+          <button class="btn btn-ico btn-outline-primary bg-white w-100" name="action" type="submit" value="unrequest_allowance">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
               </i>
               <span>
@@ -4224,9 +4224,9 @@
       <a class="btn btn-primary w-100 mb-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification" type="button">
           Justifier la demande d’aide
       </a>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-ico btn-outline-primary bg-white w-100" type="submit">
+          <button class="btn btn-ico btn-outline-primary bg-white w-100" name="action" type="submit" value="unrequest_allowance">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
               </i>
               <span>
@@ -4247,9 +4247,9 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-primary w-100" type="submit">
+          <button class="btn btn-primary w-100" name="action" type="submit" value="request_allowance">
               Solliciter l’aide
           </button>
       </form>
@@ -4266,9 +4266,9 @@
       <p>
           Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-ico btn-outline-primary bg-white w-100" type="submit">
+          <button class="btn btn-ico btn-outline-primary bg-white w-100" name="action" type="submit" value="unrequest_allowance">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
               </i>
               <span>
@@ -4289,9 +4289,9 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-primary w-100" disabled="" type="submit">
+          <button class="btn btn-primary w-100" disabled="" name="action" type="submit" value="request_allowance">
               Solliciter l’aide
           </button>
       </form>
@@ -4318,9 +4318,9 @@
       <a class="btn btn-primary w-100 mb-3" disabled="" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification" type="button">
           Modifier votre justification
       </a>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-ico btn-outline-primary bg-white w-100" disabled="" type="submit">
+          <button class="btn btn-ico btn-outline-primary bg-white w-100" disabled="" name="action" type="submit" value="unrequest_allowance">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
               </i>
               <span>
@@ -4341,9 +4341,9 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-primary w-100" disabled="" type="submit">
+          <button class="btn btn-primary w-100" disabled="" name="action" type="submit" value="request_allowance">
               Solliciter l’aide
           </button>
       </form>
@@ -4360,9 +4360,9 @@
       <p>
           Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-ico btn-outline-primary bg-white w-100" disabled="" type="submit">
+          <button class="btn btn-ico btn-outline-primary bg-white w-100" disabled="" name="action" type="submit" value="unrequest_allowance">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
               </i>
               <span>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -185,8 +185,8 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsRefusalJustificationView.get_object[<site-packages>/django/views/generic/detail.py]',
+          'AssessmentContractDetailsRefusalJustificationView.get[www/geiq_assessments_views/views.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -976,8 +976,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsContractView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -1447,8 +1446,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsContractView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -1524,12 +1522,16 @@
       }),
       dict({
         'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -1552,8 +1554,6 @@
           'IncludeNode[layout/base.html]',
           'IfNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -1571,12 +1571,6 @@
                  AND "users_user"."id" = %s)
           LIMIT 1
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),
     ]),
   })
@@ -1767,8 +1761,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsEmployeeView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -2238,8 +2231,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsEmployeeView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -2315,12 +2307,16 @@
       }),
       dict({
         'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -2343,8 +2339,6 @@
           'IncludeNode[layout/base.html]',
           'IfNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -2362,12 +2356,6 @@
                  AND "users_user"."id" = %s)
           LIMIT 1
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),
       dict({
         'origin': list([
@@ -2584,8 +2572,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsExitView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -3055,8 +3042,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsExitView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -3132,12 +3118,16 @@
       }),
       dict({
         'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -3160,8 +3150,6 @@
           'IncludeNode[layout/base.html]',
           'IfNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -3179,12 +3167,6 @@
                  AND "users_user"."id" = %s)
           LIMIT 1
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),
     ]),
   })
@@ -3375,8 +3357,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsSupportAndTrainingView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -3454,8 +3435,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsSupportAndTrainingView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeeprequalification"."id",
@@ -3863,8 +3843,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsSupportAndTrainingView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeecontract"."id",
@@ -3940,8 +3919,7 @@
       }),
       dict({
         'origin': list([
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
+          'AssessmentContractDetailsSupportAndTrainingView.get_object[<site-packages>/django/views/generic/detail.py]',
         ]),
         'sql': '''
           SELECT "geiq_assessments_employeeprequalification"."id",
@@ -3957,12 +3935,16 @@
       }),
       dict({
         'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -3985,8 +3967,6 @@
           'IncludeNode[layout/base.html]',
           'IfNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/assessment_contracts_details.html]',
-          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
           SELECT %s AS "a"
@@ -4004,12 +3984,6 @@
                  AND "users_user"."id" = %s)
           LIMIT 1
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),
     ]),
   })

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -707,17 +707,18 @@ class TestAssessmentContractsDetails:
                 return reverse(
                     "geiq_assessments_views:assessment_contracts_details_exit", kwargs={"contract_pk": contract_pk}
                 )
+            case AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_request_justification",
+                    kwargs={"contract_pk": contract_pk},
+                )
             case AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
                 return reverse(
                     "geiq_assessments_views:assessment_contracts_details_refusal_justification",
                     kwargs={"contract_pk": contract_pk},
                 )
             case _:
-                # FIXME: deprecated URL for ALLOWANCE_REQUEST_JUSTIFICATION
-                return reverse(
-                    "geiq_assessments_views:assessment_contracts_details",
-                    kwargs={"contract_pk": contract_pk, "tab": tab.value},
-                )
+                raise ValueError(f"Tab {tab} not found")
 
     @pytest.mark.parametrize("tab", AssessmentContractDetailsTab)
     def test_anonymous_access(self, client, tab):
@@ -749,7 +750,7 @@ class TestAssessmentContractsDetails:
             (PrescriberFactory(membership=True), 403),
             (EmployerFactory(membership=True, membership__company__not_geiq_kind=True), 403),
             (EmployerFactory(membership=True, membership__company__kind=CompanyKind.GEIQ), 404),
-            (LaborInspectorFactory(membership=True), 404),
+            (LaborInspectorFactory(membership=True), 403),
         ]:
             client.force_login(user)
             response = client.get(url)
@@ -875,7 +876,7 @@ class TestAssessmentContractsDetails:
         check_user_access_to_tabs(
             ddets_membership.user,
             tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION],
-            status_code=404,
+            status_code=403,
         )  # institution users still do not have access
 
         # Institution only tabs
@@ -990,9 +991,12 @@ class TestAssessmentContractsDetails:
             assertContains(response, JUSTIFICATION_TAB_WITH_ICON_LI, html=True)
 
             # User fills the form with invalid values
+            response = client.post(details_justification_url, data={"allowance_request_reason": ""})
+            assert response.status_code == 404  # no action given leads to 404
             response = client.post(
                 details_justification_url,
                 data={
+                    "action": EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION,
                     "allowance_request_reason": "inexistant",
                 },
             )
@@ -1002,7 +1006,7 @@ class TestAssessmentContractsDetails:
             assertContains(response, "<li>Ce champ est obligatoire.</li>", html=True, count=1)
             response = client.post(
                 details_justification_url,
-                data={"allowance_request_details": " "},
+                data={"action": EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION, "allowance_request_details": " "},
             )
             assertContains(
                 response, "<li>Ce champ est obligatoire.</li>", html=True, count=2
@@ -1012,6 +1016,7 @@ class TestAssessmentContractsDetails:
             response = client.post(
                 details_justification_url,
                 data={
+                    "action": EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION,
                     "allowance_request_reason": random.choice(AllowanceJustificationReason.choices)[0],
                     "allowance_request_details": "C’est un cas particulier…",
                 },
@@ -1145,6 +1150,7 @@ class TestAssessmentContractsDetails:
             response = client.post(
                 details_justification_url,
                 data={
+                    "action": EmployerAction.ALLOWANCE_REQUEST_JUSTIFICATION,
                     "allowance_request_reason": AllowanceJustificationReason.OTHER.value,
                     "allowance_request_details": "Nouveaux détails",
                 },

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -686,23 +686,44 @@ class TestAssessmentContractsListAndToggle:
 
 
 class TestAssessmentContractsDetails:
+    @staticmethod
+    def get_tab_url(tab, contract_pk):
+        match tab:
+            case AssessmentContractDetailsTab.EMPLOYEE:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_employee", kwargs={"contract_pk": contract_pk}
+                )
+            case AssessmentContractDetailsTab.CONTRACT:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_contract", kwargs={"contract_pk": contract_pk}
+                )
+            case AssessmentContractDetailsTab.SUPPORT_AND_TRAINING:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_support_and_training",
+                    kwargs={"contract_pk": contract_pk},
+                )
+            case AssessmentContractDetailsTab.EXIT:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_exit", kwargs={"contract_pk": contract_pk}
+                )
+            case _:
+                # FIXME: deprecated URL for ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details",
+                    kwargs={"contract_pk": contract_pk, "tab": tab.value},
+                )
+
     @pytest.mark.parametrize("tab", AssessmentContractDetailsTab)
     def test_anonymous_access(self, client, tab):
         contract = EmployeeContractFactory()
-        url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": tab.value},
-        )
+        url = self.get_tab_url(tab, contract.pk)
         response = client.get(url)
         assertRedirects(response, reverse("account_login") + f"?next={url}")
 
     @pytest.mark.parametrize("tab", AssessmentContractDetailsTab)
     def test_unauthorized_access(self, client, tab):
         contract = EmployeeContractFactory()
-        url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": tab.value},
-        )
+        url = self.get_tab_url(tab, contract.pk)
         for user, expected_status in [
             (JobSeekerFactory(), 403),
             (PrescriberFactory(membership=True), 403),
@@ -762,10 +783,7 @@ class TestAssessmentContractsDetails:
                 user_label = "DDETS"
                 viewable_tabs_for_user = AssessmentContractDetailsTab.get_institution_tabs()
             for tab in tabs:
-                tab_url = reverse(
-                    "geiq_assessments_views:assessment_contracts_details",
-                    kwargs={"contract_pk": str(contract.pk), "tab": tab.value},
-                )
+                tab_url = self.get_tab_url(tab, contract.pk)
                 if access and tab in viewable_tabs_for_user:
                     with assertSnapshotQueries(snapshot(name=f"SQL queries for {tab=} as {user_label}")):
                         response = client.get(tab_url)
@@ -854,24 +872,14 @@ class TestAssessmentContractsDetails:
             allowance_requested=False,
             nb_days_in_campaign_year=89 if short_contract else 90,
         )
-        details_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                # all common tabs should behave the same
-                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
-            },
+        details_url = self.get_tab_url(
+            # all common tabs should behave the same
+            random.choice(AssessmentContractDetailsTab.get_common_tabs()),
+            contract.pk,
         )
-        details_contract_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": AssessmentContractDetailsTab.CONTRACT},
-        )
-        details_justification_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.value,
-            },
+        details_contract_url = self.get_tab_url(AssessmentContractDetailsTab.CONTRACT, contract.pk)
+        details_justification_url = self.get_tab_url(
+            AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION, contract.pk
         )
         JUSTIFICATION_TAB_LI = f"""
         <li class="nav-item">
@@ -999,8 +1007,7 @@ class TestAssessmentContractsDetails:
         assertRedirects(
             response,
             reverse(
-                "geiq_assessments_views:assessment_contracts_details",
-                kwargs={"contract_pk": contract.pk, "tab": AssessmentContractDetailsTab.CONTRACT},
+                "geiq_assessments_views:assessment_contracts_details_contract", kwargs={"contract_pk": contract.pk}
             ),
         )
         if short_contract:
@@ -1023,24 +1030,10 @@ class TestAssessmentContractsDetails:
             allowance_requested=False,
             nb_days_in_campaign_year=89 if short_contract else 90,
         )
-        details_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                # all common tabs should behave the same
-                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
-            },
-        )
-        details_contract_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": AssessmentContractDetailsTab.CONTRACT},
-        )
-        details_justification_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.value,
-            },
+        details_url = self.get_tab_url(random.choice(AssessmentContractDetailsTab.get_common_tabs()), contract.pk)
+        details_contract_url = self.get_tab_url(AssessmentContractDetailsTab.CONTRACT, contract.pk)
+        details_justification_url = self.get_tab_url(
+            AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION, contract.pk
         )
 
         client.force_login(geiq_membership.user)
@@ -1169,20 +1162,13 @@ class TestAssessmentContractsDetails:
         contract = EmployeeContractFactory(
             employee__assessment=assessment, allowance_requested=True, allowance_granted=True
         )
-        details_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                # all common tabs should behave the same
-                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
-            },
+        details_url = self.get_tab_url(
+            # all common tabs should behave the same
+            random.choice(AssessmentContractDetailsTab.get_common_tabs()),
+            contract.pk,
         )
-        details_justification_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
-            },
+        details_justification_url = self.get_tab_url(
+            AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION, contract.pk
         )
         JUSTIFICATION_TAB_LI = f"""
         <li class="nav-item">
@@ -1278,13 +1264,7 @@ class TestAssessmentContractsDetails:
 
         # User grants the allowance and gets redirected to employee tab
         response = client.post(details_justification_url, data={"action": InstitutionAction.GRANT_ALLOWANCE})
-        assertRedirects(
-            response,
-            reverse(
-                "geiq_assessments_views:assessment_contracts_details",
-                kwargs={"contract_pk": contract.pk, "tab": AssessmentContractDetailsTab.EMPLOYEE},
-            ),
-        )
+        assertRedirects(response, self.get_tab_url(AssessmentContractDetailsTab.EMPLOYEE, contract.pk))
         contract.refresh_from_db()
         assert contract.allowance_granted is True
         assert contract.allowance_refusal_reason == ""
@@ -1315,20 +1295,9 @@ class TestAssessmentContractsDetails:
             allowance_refusal_reason=AllowanceRefusalReason.UNCONFIRMED_ELIGIBILITY,
             allowance_refusal_details="Incorrect.",
         )
-        details_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                # all common tabs should behave the same
-                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
-            },
-        )
-        details_justification_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={
-                "contract_pk": str(contract.pk),
-                "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
-            },
+        details_url = self.get_tab_url(random.choice(AssessmentContractDetailsTab.get_common_tabs()), contract.pk)
+        details_justification_url = self.get_tab_url(
+            AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION, contract.pk
         )
 
         client.force_login(ddets_membership.user)
@@ -1414,14 +1383,8 @@ class TestAssessmentContractsDetails:
         )
         common_tabs_except_contract = AssessmentContractDetailsTab.get_common_tabs()
         common_tabs_except_contract.remove(AssessmentContractDetailsTab.CONTRACT)
-        details_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": random.choice(common_tabs_except_contract)},
-        )
-        details_contract_url = reverse(
-            "geiq_assessments_views:assessment_contracts_details",
-            kwargs={"contract_pk": str(contract.pk), "tab": AssessmentContractDetailsTab.CONTRACT.value},
-        )
+        details_url = self.get_tab_url(random.choice(common_tabs_except_contract), contract.pk)
+        details_contract_url = self.get_tab_url(AssessmentContractDetailsTab.CONTRACT, contract.pk)
         client.force_login(ddets_membership.user)
 
         # Never display justification on tabs other than CONTRACT

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -16,6 +16,7 @@ from itou.geiq_assessments.enums import (
     AllowanceJustificationReason,
     AllowanceRefusalReason,
     AssessmentContractDetailsTab,
+    EmployerAction,
     InstitutionAction,
 )
 from itou.geiq_assessments.models import AssessmentInstitutionLink
@@ -953,12 +954,7 @@ class TestAssessmentContractsDetails:
         ) == snapshot(name="allowance request box with allowance not requested")
 
         # User requests the allowance
-        response = client.post(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_include",
-                kwargs={"contract_pk": str(contract.pk)},
-            ),
-        )
+        response = client.post(details_url, data={"action": EmployerAction.REQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is True
 
@@ -1040,12 +1036,7 @@ class TestAssessmentContractsDetails:
             assertNotContains(response, JUSTIFICATION_TAB_WITH_ICON_LI, html=True)
 
         # User unrequests the allowance and gets redirected to contract tab
-        response = client.post(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_exclude",
-                kwargs={"contract_pk": str(contract.pk)},
-            ),
-        )
+        response = client.post(details_url, data={"action": EmployerAction.UNREQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is False
         assertRedirects(
@@ -1091,12 +1082,7 @@ class TestAssessmentContractsDetails:
         ) == snapshot(name="allowance request box with allowance not requested after contract selection")
 
         # User tries to request the allowance
-        response = client.post(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_include",
-                kwargs={"contract_pk": str(contract.pk)},
-            ),
-        )
+        response = client.post(details_url, data={"action": EmployerAction.REQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is False
         assertRedirects(response, details_contract_url)
@@ -1128,12 +1114,7 @@ class TestAssessmentContractsDetails:
             contract.allowance_request_justification_reason = AllowanceJustificationReason.OTHER_REFERENCE_PERIOD
             contract.allowance_request_justification_details = "Détails."
         contract.save()
-        response = client.post(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_exclude",
-                kwargs={"contract_pk": str(contract.pk)},
-            ),
-        )
+        response = client.post(details_url, data={"action": EmployerAction.UNREQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is True
         assertRedirects(response, details_contract_url)

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -923,7 +923,6 @@ class TestAssessmentContractsDetails:
             random.choice(AssessmentContractDetailsTab.get_common_tabs()),
             contract.pk,
         )
-        details_contract_url = self.get_tab_url(AssessmentContractDetailsTab.CONTRACT, contract.pk)
         details_justification_url = self.get_tab_url(
             AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION, contract.pk
         )
@@ -960,7 +959,7 @@ class TestAssessmentContractsDetails:
         assert contract.allowance_requested is True
 
         if not short_contract:
-            assertRedirects(response, details_contract_url)
+            assert response.status_code == 200
             response = client.get(details_url)
             assert pretty_indented(
                 parse_response_to_soup(
@@ -1021,7 +1020,7 @@ class TestAssessmentContractsDetails:
                     "allowance_request_details": "C’est un cas particulier…",
                 },
             )
-            assertRedirects(response, details_contract_url)
+            assert response.status_code == 200
             contract.refresh_from_db()
             assert contract.allowance_requested is True
             assert contract.allowance_request_justification_reason is not None
@@ -1044,12 +1043,7 @@ class TestAssessmentContractsDetails:
         response = client.post(details_url, data={"action": EmployerAction.UNREQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is False
-        assertRedirects(
-            response,
-            reverse(
-                "geiq_assessments_views:assessment_contracts_details_contract", kwargs={"contract_pk": contract.pk}
-            ),
-        )
+        assert response.status_code == 200
         if short_contract:
             # The reason and details are not deleted
             assert contract.allowance_request_justification_reason is not None
@@ -1090,7 +1084,7 @@ class TestAssessmentContractsDetails:
         response = client.post(details_url, data={"action": EmployerAction.REQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is False
-        assertRedirects(response, details_contract_url)
+        assert response.status_code == 200
         assertMessages(
             response,
             [
@@ -1122,7 +1116,7 @@ class TestAssessmentContractsDetails:
         response = client.post(details_url, data={"action": EmployerAction.UNREQUEST_ALLOWANCE})
         contract.refresh_from_db()
         assert contract.allowance_requested is True
-        assertRedirects(response, details_contract_url)
+        assert response.status_code == 200
         assertMessages(
             response,
             [
@@ -1155,7 +1149,7 @@ class TestAssessmentContractsDetails:
                     "allowance_request_details": "Nouveaux détails",
                 },
             )
-            assertRedirects(response, details_contract_url)
+            assert response.status_code == 200
             assertMessages(
                 response,
                 [

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -706,8 +706,13 @@ class TestAssessmentContractsDetails:
                 return reverse(
                     "geiq_assessments_views:assessment_contracts_details_exit", kwargs={"contract_pk": contract_pk}
                 )
+            case AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
+                return reverse(
+                    "geiq_assessments_views:assessment_contracts_details_refusal_justification",
+                    kwargs={"contract_pk": contract_pk},
+                )
             case _:
-                # FIXME: deprecated URL for ALLOWANCE_REQUEST_JUSTIFICATION and ALLOWANCE_REFUSAL_JUSTIFICATION
+                # FIXME: deprecated URL for ALLOWANCE_REQUEST_JUSTIFICATION
                 return reverse(
                     "geiq_assessments_views:assessment_contracts_details",
                     kwargs={"contract_pk": contract_pk, "tab": tab.value},
@@ -720,8 +725,8 @@ class TestAssessmentContractsDetails:
         response = client.get(url)
         assertRedirects(response, reverse("account_login") + f"?next={url}")
 
-    @pytest.mark.parametrize("tab", AssessmentContractDetailsTab)
-    def test_unauthorized_access(self, client, tab):
+    @pytest.mark.parametrize("tab", AssessmentContractDetailsTab.get_common_tabs())
+    def test_unauthorized_access_common_tabs(self, client, tab):
         contract = EmployeeContractFactory()
         url = self.get_tab_url(tab, contract.pk)
         for user, expected_status in [
@@ -729,6 +734,34 @@ class TestAssessmentContractsDetails:
             (PrescriberFactory(membership=True), 403),
             (EmployerFactory(membership=True, membership__company__not_geiq_kind=True), 403),
             (EmployerFactory(membership=True, membership__company__kind=CompanyKind.GEIQ), 404),
+            (LaborInspectorFactory(membership=True), 404),
+        ]:
+            client.force_login(user)
+            response = client.get(url)
+            assert response.status_code == expected_status
+
+    def test_unauthorized_access_employer_tabs(self, client):
+        contract = EmployeeContractFactory()
+        url = self.get_tab_url(AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION, contract.pk)
+        for user, expected_status in [
+            (JobSeekerFactory(), 403),
+            (PrescriberFactory(membership=True), 403),
+            (EmployerFactory(membership=True, membership__company__not_geiq_kind=True), 403),
+            (EmployerFactory(membership=True, membership__company__kind=CompanyKind.GEIQ), 404),
+            (LaborInspectorFactory(membership=True), 404),
+        ]:
+            client.force_login(user)
+            response = client.get(url)
+            assert response.status_code == expected_status
+
+    def test_unauthorized_access_institution_tabs(self, client):
+        contract = EmployeeContractFactory()
+        url = self.get_tab_url(AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION, contract.pk)
+        for user, expected_status in [
+            (JobSeekerFactory(), 403),
+            (PrescriberFactory(membership=True), 403),
+            (EmployerFactory(membership=True, membership__company__not_geiq_kind=True), 403),
+            (EmployerFactory(membership=True, membership__company__kind=CompanyKind.GEIQ), 403),
             (LaborInspectorFactory(membership=True), 404),
         ]:
             client.force_login(user)
@@ -824,7 +857,6 @@ class TestAssessmentContractsDetails:
         # GEIQ only tabs
         # --------------------------------------------------------------------
         # Justification tab is not available for contracts >90 days with allowance_requested=True
-        contract.allowance_requested = True
         contract.save()
         assert not contract.requires_justification
         check_user_access_to_tabs(
@@ -858,14 +890,14 @@ class TestAssessmentContractsDetails:
         contract.save()
         # Justification tab is not available when allowance_granted=True
         check_user_access_to_tabs(
-            geiq_membership.user,
+            ddets_membership.user,
             tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION],
             status_code=404,
         )
         check_user_access_to_tabs(
-            ddets_membership.user,
+            geiq_membership.user,
             tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION],
-            status_code=404,
+            status_code=403,
         )  # GEIQ users do not have access
 
     @pytest.mark.parametrize("short_contract", [True, False], ids=["contract < 90 days", "contract >= 90 days"])

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -773,7 +773,7 @@ class TestAssessmentContractsDetails:
         )
 
         def check_user_access_to_tabs(
-            user, *, access, tabs=AssessmentContractDetailsTab.get_common_tabs(), with_previous_year_warning=False
+            user, *, status_code, tabs=AssessmentContractDetailsTab.get_common_tabs(), with_previous_year_warning=False
         ):
             client.force_login(user)
             if user == geiq_membership.user:
@@ -784,7 +784,7 @@ class TestAssessmentContractsDetails:
                 viewable_tabs_for_user = AssessmentContractDetailsTab.get_institution_tabs()
             for tab in tabs:
                 tab_url = self.get_tab_url(tab, contract.pk)
-                if access and tab in viewable_tabs_for_user:
+                if status_code == 200 and tab in viewable_tabs_for_user:
                     with assertSnapshotQueries(snapshot(name=f"SQL queries for {tab=} as {user_label}")):
                         response = client.get(tab_url)
                     assertContains(response, "DUPONT Jean")
@@ -794,22 +794,32 @@ class TestAssessmentContractsDetails:
                         assertNotContains(response, PREVIOUS_YEAR_WARNING)
                 else:
                     response = client.get(tab_url)
-                    assert response.status_code == 404
+                    assert response.status_code == status_code
 
-        check_user_access_to_tabs(geiq_membership.user, access=True)
+        check_user_access_to_tabs(geiq_membership.user, status_code=200)
 
         # DDETS user should not access the contract details before submission
-        check_user_access_to_tabs(ddets_membership.user, access=False)
+        check_user_access_to_tabs(ddets_membership.user, status_code=404)
 
         # Submit the assessment
         assessment.submit(user=geiq_membership.user)
-        check_user_access_to_tabs(ddets_membership.user, access=True)
+        check_user_access_to_tabs(ddets_membership.user, status_code=200)
 
         # Now for contract without allowance requested
         contract.allowance_requested = False
         contract.save()
-        check_user_access_to_tabs(geiq_membership.user, access=True)
-        check_user_access_to_tabs(ddets_membership.user, access=False)
+        check_user_access_to_tabs(geiq_membership.user, status_code=200)
+        check_user_access_to_tabs(ddets_membership.user, status_code=404)
+
+        # Now for contract with previous year info
+        contract.employee.allowance_granted_previous_year = True
+        contract.employee.save()
+        contract.allowance_requested = True
+        contract.save()
+        check_user_access_to_tabs(ddets_membership.user, status_code=200, with_previous_year_warning=True)
+        check_user_access_to_tabs(geiq_membership.user, status_code=200, with_previous_year_warning=True)
+        contract.employee.allowance_granted_previous_year = False
+        contract.employee.save()
 
         # GEIQ only tabs
         # --------------------------------------------------------------------
@@ -818,17 +828,21 @@ class TestAssessmentContractsDetails:
         contract.save()
         assert not contract.requires_justification
         check_user_access_to_tabs(
-            geiq_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION], access=False
+            geiq_membership.user,
+            tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION],
+            status_code=404,
         )
         # Justification tab is available for contract <90 days with allowance_requested=True
         contract.nb_days_in_campaign_year = 1
         contract.save()
         assert contract.requires_justification
         check_user_access_to_tabs(
-            geiq_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION], access=True
+            geiq_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION], status_code=200
         )
         check_user_access_to_tabs(
-            ddets_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION], access=False
+            ddets_membership.user,
+            tabs=[AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION],
+            status_code=404,
         )  # institution users still do not have access
 
         # Institution only tabs
@@ -836,25 +850,23 @@ class TestAssessmentContractsDetails:
         # Justification tab is available when allowance_granted=False
         assert contract.allowance_granted is False
         check_user_access_to_tabs(
-            ddets_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION], access=True
+            ddets_membership.user,
+            tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION],
+            status_code=200,
         )
         contract.allowance_granted = True
         contract.save()
         # Justification tab is not available when allowance_granted=True
         check_user_access_to_tabs(
-            geiq_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION], access=False
+            geiq_membership.user,
+            tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION],
+            status_code=404,
         )
         check_user_access_to_tabs(
-            ddets_membership.user, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION], access=False
+            ddets_membership.user,
+            tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION],
+            status_code=404,
         )  # GEIQ users do not have access
-
-        # Now for contract with previous year info
-        contract.employee.allowance_granted_previous_year = True
-        contract.employee.save()
-        contract.allowance_requested = True
-        contract.save()
-        check_user_access_to_tabs(ddets_membership.user, access=True, with_previous_year_warning=True)
-        check_user_access_to_tabs(geiq_membership.user, access=True, with_previous_year_warning=True)
 
     @pytest.mark.parametrize("short_contract", [True, False], ids=["contract < 90 days", "contract >= 90 days"])
     def test_contract_request_allowance_as_geiq(self, client, snapshot, short_contract):


### PR DESCRIPTION
## :thinking: Pourquoi ?

On a dû aller vite pour le lancement de la campagne des bilans d’exécution, on rationalise un peu le code maintenant.

Contenu de la PR :
- on passe les onglets communs de la vue détails en class-based views, puis les onglets spécifiques aux institutions puis GEIQ, en plusieurs étapes
- on en profite pour harmoniser le fonctionnement des deux onglets de justification
  - comme pour les institutions, la sélection/désélection du contrat côté GEIQ se passe dans la même vue
  - on redirige seulement quand il y a besoin

Preneur de retours :) 
