### PR TITLE
GEIQ : Affichage du SIRET de la structure

### DIFF
--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -9,7 +9,7 @@ from itou.geiq_assessments.models import Assessment, Employee
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
 from itou.utils.constants import MB
-from itou.utils.templatetags.format_filters import format_int_euros
+from itou.utils.templatetags.format_filters import format_int_euros, format_siret
 from itou.utils.types import InclusiveDateRange
 from itou.utils.widgets import DuetDatePickerWidget
 
@@ -53,7 +53,17 @@ class CreateForm(forms.Form):
         required=False,
     )
 
-    def __init__(self, *args, geiq_name, antenna_names, existing_main_geiq, existing_antenna_ids, **kwargs):
+    def __init__(
+        self,
+        *args,
+        geiq_name,
+        geiq_siret=None,
+        antenna_names,
+        antenna_sirets=None,
+        existing_main_geiq,
+        existing_antenna_ids,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.antenna_names = antenna_names
         self.fields["ddets"].form_group_class = "form-group form-group-input-w-lg-66 ms-4 collapse ddets_group"
@@ -67,15 +77,20 @@ class CreateForm(forms.Form):
             self.fields["convention_with_dreets"].widget.attrs["aria-expanded"] = "true"
             self.fields["dreets"].form_group_class += " show"
 
-        self.fields["main_geiq"].label = geiq_name
+        self.fields["main_geiq"].label = (
+            f"{geiq_name} (SIRET : {format_siret(geiq_siret)})" if geiq_siret else geiq_name
+        )
         self.fields["main_geiq"].disabled = existing_main_geiq
 
         antenna_fields = []
+        antenna_sirets = antenna_sirets or {}
         for antenna_id, antenna_name in antenna_names.items():
             if antenna_id:  # Ignore main geiq with id 0
                 field_name = self.get_antenna_field(antenna_id)
+                antenna_siret = antenna_sirets.get(antenna_id)
+                label = f"{antenna_name} (SIRET : {format_siret(antenna_siret)})" if antenna_siret else antenna_name
                 self.fields[field_name] = forms.BooleanField(
-                    label=antenna_name, required=False, disabled=antenna_id in existing_antenna_ids
+                    label=label, required=False, disabled=antenna_id in existing_antenna_ids
                 )
                 antenna_fields.append(field_name)
         self.antenna_fields = antenna_fields

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -201,6 +201,7 @@ def create_assessment(request, template_name="geiq_assessments_views/create.html
         return render(request, template_name, context)
 
     antenna_names = {antenna_info["id"]: antenna_info["nom"] for antenna_info in geiq_info["antennes"]}
+    antenna_sirets = {antenna_info["id"]: antenna_info["siret"] for antenna_info in geiq_info["antennes"]}
     antenna_postcodes = {antenna_info["id"]: antenna_info["cp"] for antenna_info in geiq_info["antennes"]}
     campaign_qs = AssessmentCampaign.objects.filter(pk=campaign_label_infos.campaign_id)
     # Take a lock on the campaign to prevent concurrent creation
@@ -224,9 +225,11 @@ def create_assessment(request, template_name="geiq_assessments_views/create.html
 
     create_form = CreateForm(
         antenna_names=antenna_names,
+        antenna_sirets=antenna_sirets,
         existing_antenna_ids=existing_antenna_ids,
         existing_main_geiq=existing_main_geiq,
         geiq_name=geiq_info["nom"],
+        geiq_siret=geiq_info.get("siret"),
         data=request.POST or None,
     )
 

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -2736,7 +2736,7 @@
                       
                       
                   <ul class="mb-0">
-                      <li>Un Joli GEIQ</li><li>Une autre antenne</li>
+                      <li>Un Joli GEIQ (SIRET : 123 456 789 01234)</li><li>Une autre antenne</li>
                   </ul>
               
                   </div>
@@ -2783,7 +2783,7 @@
                                           <div class="form-group">
                                               <div class="form-check">
                                                   <input class="form-check-input" disabled="" id="id_main_geiq" name="main_geiq" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_main_geiq">Un Joli GEIQ</label>
+                                                  <label class="form-check-label" for="id_main_geiq">Un Joli GEIQ (SIRET : 123 456 789 01234)</label>
                                                   <i aria-label="Cette structure est déjà présente dans un autre bilan d’exécution." class="ri-error-warning-line text-info" data-bs-title="Cette structure est déjà présente dans un autre bilan d’exécution." data-bs-toggle="tooltip"></i>
                                               </div>
                                           </div>
@@ -2794,7 +2794,7 @@
                                               <div class="form-group">
                                                   <div class="form-check">
                                                       <input class="form-check-input" disabled="" id="id_antenna_2345" name="antenna_2345" type="checkbox"/>
-                                                      <label class="form-check-label" for="id_antenna_2345">Une antenne</label>
+                                                      <label class="form-check-label" for="id_antenna_2345">Une antenne (SIRET : 123 456 789 02345)</label>
                                                       <i aria-label="Cette structure est déjà présente dans un autre bilan d’exécution." class="ri-error-warning-line text-info" data-bs-title="Cette structure est déjà présente dans un autre bilan d’exécution." data-bs-toggle="tooltip"></i>
                                                   </div>
                                               </div>
@@ -2804,14 +2804,14 @@
                                               <div class="form-group">
                                                   <div class="form-check">
                                                       <input class="form-check-input" disabled="" id="id_antenna_3456" name="antenna_3456" type="checkbox"/>
-                                                      <label class="form-check-label" for="id_antenna_3456">Une autre antenne</label>
+                                                      <label class="form-check-label" for="id_antenna_3456">Une autre antenne (SIRET : 123 456 789 03456)</label>
                                                       <i aria-label="Cette structure est déjà présente dans un autre bilan d’exécution." class="ri-error-warning-line text-info" data-bs-title="Cette structure est déjà présente dans un autre bilan d’exécution." data-bs-toggle="tooltip"></i>
                                                   </div>
                                               </div>
                                           
                                       
                                           
-                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_4567" name="antenna_4567" type="checkbox"/><label class="form-check-label" for="id_antenna_4567">Une dernière antenne</label></div></div>
+                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_4567" name="antenna_4567" type="checkbox"/><label class="form-check-label" for="id_antenna_4567">Une dernière antenne (SIRET : 123 456 789 04567)</label></div></div>
                                           
                                       
                                   </fieldset>
@@ -2898,20 +2898,20 @@
                                       <legend class="h3">Quelles sont les structures concernées par cette convention ?</legend>
                                       <strong class="d-block">GEIQ principal:</strong>
                                       
-                                          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_main_geiq" name="main_geiq" type="checkbox"/><label class="form-check-label" for="id_main_geiq">Un Joli GEIQ</label></div></div>
+                                          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_main_geiq" name="main_geiq" type="checkbox"/><label class="form-check-label" for="id_main_geiq">Un Joli GEIQ (SIRET : 123 456 789 01234)</label></div></div>
                                       
                                       <strong class="d-block">Antennes:</strong>
                                       
                                           
-                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_2345" name="antenna_2345" type="checkbox"/><label class="form-check-label" for="id_antenna_2345">Une antenne</label></div></div>
+                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_2345" name="antenna_2345" type="checkbox"/><label class="form-check-label" for="id_antenna_2345">Une antenne (SIRET : 123 456 789 02345)</label></div></div>
                                           
                                       
                                           
-                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_3456" name="antenna_3456" type="checkbox"/><label class="form-check-label" for="id_antenna_3456">Une autre antenne</label></div></div>
+                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_3456" name="antenna_3456" type="checkbox"/><label class="form-check-label" for="id_antenna_3456">Une autre antenne (SIRET : 123 456 789 03456)</label></div></div>
                                           
                                       
                                           
-                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_4567" name="antenna_4567" type="checkbox"/><label class="form-check-label" for="id_antenna_4567">Une dernière antenne</label></div></div>
+                                              <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_antenna_4567" name="antenna_4567" type="checkbox"/><label class="form-check-label" for="id_antenna_4567">Une dernière antenne (SIRET : 123 456 789 04567)</label></div></div>
                                           
                                       
                                   </fieldset>
@@ -2993,7 +2993,7 @@
                       
                       
                   <ul class="mb-0">
-                      <li>Un Joli GEIQ</li>
+                      <li>Un Joli GEIQ (SIRET : 123 456 789 01234)</li>
                   </ul>
               
                   </div>
@@ -3037,7 +3037,7 @@
                                       <legend class="h3">Quelles sont les structures concernées par cette convention ?</legend>
                                       <strong class="d-block">GEIQ principal:</strong>
                                       
-                                          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_main_geiq" name="main_geiq" type="checkbox"/><label class="form-check-label" for="id_main_geiq">Un Joli GEIQ</label></div></div>
+                                          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_main_geiq" name="main_geiq" type="checkbox"/><label class="form-check-label" for="id_main_geiq">Un Joli GEIQ (SIRET : 123 456 789 01234)</label></div></div>
                                       
                                       <strong class="d-block">Antennes:</strong>
                                       


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lors de la sélection des structures concernée, ajout du SIRET comme détrompeur, cf. Zohra :
> Plusieurs geiq se plaignent de ne pas etre dans la bonne structure alors meme qu'ils ont créé le bilan qui va bien et que ça n'aura aucune incidence

## :cake: Comment ? <!-- optionnel -->

Modification du formulaire.

## :desert_island: Comment tester ?

N/A

## :computer: Captures d'écran <!-- optionnel -->

<img width="1804" height="1384" alt="image" src="https://github.com/user-attachments/assets/823d80f9-d9ed-4944-bd6b-5053eb1a85c6" />

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
