### PR TITLE
Tech : correction du test bagottant `test_throttling`

### DIFF
--- a/tests/www/test_throttling.py
+++ b/tests/www/test_throttling.py
@@ -2,7 +2,6 @@ from functools import partial
 
 import pytest
 from django.urls import reverse
-from freezegun import freeze_time
 from pytest_django.asserts import assertContains
 
 from tests.users.factories import PrescriberFactory
@@ -14,7 +13,6 @@ def one_request_per_minute(mocker):
     mocker.patch("itou.utils.throttling.FailSafeUserRateThrottle.rate", "1/minute")
 
 
-@freeze_time()
 @pytest.mark.parametrize("user_factory", [None, partial(PrescriberFactory, membership=True)])
 def test_throttling(client, user_factory, one_request_per_minute):
     if user_factory is not None:
@@ -28,6 +26,6 @@ def test_throttling(client, user_factory, one_request_per_minute):
     response = client.get(url)
     assertContains(
         response,
-        "<p>Vous avez effectué trop de requêtes. Réessayez dans 60 secondes.</p>",
+        "<p>Vous avez effectué trop de requêtes. Réessayez dans",
         status_code=429,
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le test `test_throttling` échouait de manière intermittente car il vérifiait le message exact `"Réessayez dans 60 secondes."`.

Le décorateur `@freeze_time()` était censé geler le temps et pallier ce problème. Cependant, la classe `SimpleRateThrottle` de DRF a l'attribut `timer = time.time` résolu au chargement du module qui n'est visiblement pas patché par `freezegun`. Cela ouvrait la porte à un delta de temps réel écoulé entre 2 requêtes qui fait que le résultat est parfois 59 secondes au lieu de 60 (et donc le test était _flaky_).

## :cake: Comment ?

- Suppression de `@freeze_time()`, qui ne résolvait pas le problème,
- `assert` ne vérifie plus le nombre de secondes exact, mais uniquement le début du message (`"Réessayez dans"`), qui est la partie fonctionnellement significative.