### PR TITLE
GEIQ: Ajout du “Montant potentiel” sur la liste des bilans d'exécutions

### DIFF
--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -72,21 +72,21 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                {% if assessment.decision_validated_at %}
+                                                {% if assessment.can_view_amounts %}
                                                     {{ assessment.granted_amount|format_int_euros }}
                                                 {% else %}
                                                     -
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                {% if assessment.decision_validated_at %}
+                                                {% if assessment.can_view_amounts %}
                                                     {{ assessment.convention_amount|format_int_euros }}
                                                 {% else %}
                                                     -
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                {% if assessment.decision_validated_at and assessment.convention_amount %}
+                                                {% if assessment.can_view_amounts %}
                                                     {% grant_percentage_badge assessment %}
                                                 {% else %}
                                                     -

--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -32,8 +32,9 @@
                                         <th scope="col">Structures</th>
                                         <th scope="col">Campagne</th>
                                         <th scope="col">Référent</th>
-                                        <th scope="col">Statut du bilan</th>
+                                        <th scope="col" aria-label="Statut du bilan">Statut</th>
                                         <th scope="col">Nombre de contrats</th>
+                                        <th scope="col">Montant potentiel</th>
                                         <th scope="col">Montant accordé</th>
                                         <th scope="col">Montant conventionné</th>
                                         <th scope="col">Taux de réalisation</th>
@@ -67,6 +68,13 @@
                                             <td>
                                                 {% if assessment.submitted_at %}
                                                     {{ assessment.contracts_nb }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if assessment.can_view_amounts %}
+                                                    {{ assessment.potential_allowance_amount|format_int_euros }}
                                                 {% else %}
                                                     -
                                                 {% endif %}

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -982,8 +982,10 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
         raise Http404
     if organization_kind in (InstitutionKind.DGEFP_GEIQ, InstitutionKind.FFGEIQ):
         filters = {}  # can list all assessments
+        annotate_kwargs = {"can_view_amounts": Q(final_reviewed_at__isnull=False)}
     else:
         filters = {"institutions": request.current_organization}
+        annotate_kwargs = {"can_view_amounts": Q(reviewed_at__isnull=False)}
     assessments = (
         Assessment.objects.filter(**filters)
         .select_related("campaign")
@@ -1005,6 +1007,7 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
                 "reviewed_at",
                 "final_reviewed_at",
             ),
+            **annotate_kwargs,
         )
         .order_by("state_order", "-last_updated_at")
     )

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -46,10 +46,7 @@ from itou.utils.apis import geiq_label
 from itou.utils.auth import check_request
 from itou.utils.export import to_streaming_response
 from itou.utils.pagination import pager
-from itou.www.geiq_assessments_views.export import (
-    get_export_format,
-    serialize_employee_contract,
-)
+from itou.www.geiq_assessments_views.export import get_export_format, serialize_employee_contract
 from itou.www.geiq_assessments_views.forms import (
     ActionFinancialAssessmentForm,
     AllowanceRefusalJustificationForm,
@@ -1006,6 +1003,10 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
                 "grants_selection_validated_at",
                 "reviewed_at",
                 "final_reviewed_at",
+            ),
+            potential_allowance_amount=Sum(
+                "employees__contracts__employee__allowance_amount",
+                filter=Q(employees__contracts__allowance_granted=True),
             ),
             **annotate_kwargs,
         )

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2983,6 +2983,8 @@
                      ELSE %s
                  END AS "state_order",
                  GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
                  "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
                                                                             "geiq_assessments_assessmentcampaign"."id",
                                                                             "geiq_assessments_assessmentcampaign"."year",
@@ -2993,6 +2995,7 @@
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
@@ -3119,11 +3122,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3164,6 +3170,9 @@
                                       0
                                   </td>
                                   <td>
+                                      -
+                                  </td>
+                                  <td>
                                       100 000 €
                                   </td>
                                   <td>
@@ -3201,6 +3210,9 @@
                                   </td>
                                   <td>
                                       0
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -
@@ -3251,6 +3263,9 @@
                                   <td>
                                       -
                                   </td>
+                                  <td>
+                                      -
+                                  </td>
                               </tr>
                               <tr>
                                   <td>
@@ -3277,6 +3292,9 @@
                                   </td>
                                   <td>
                                       0
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       90 000 €
@@ -3315,6 +3333,9 @@
                                   </td>
                                   <td>
                                       0
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       80 000 €
@@ -3366,11 +3387,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3414,6 +3438,9 @@
                                   <td>
                                       -
                                   </td>
+                                  <td>
+                                      -
+                                  </td>
                               </tr>
                               <tr>
                                   <td>
@@ -3435,6 +3462,9 @@
                                   </td>
                                   <td>
                                       2
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -
@@ -3479,6 +3509,9 @@
                                   <td>
                                       -
                                   </td>
+                                  <td>
+                                      -
+                                  </td>
                               </tr>
                               <tr>
                                   <td>
@@ -3500,6 +3533,9 @@
                                   </td>
                                   <td>
                                       4
+                                  </td>
+                                  <td>
+                                      3 256 €
                                   </td>
                                   <td>
                                       80 000 €
@@ -3551,11 +3587,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3593,6 +3632,9 @@
                                       3
                                   </td>
                                   <td>
+                                      2 442 €
+                                  </td>
+                                  <td>
                                       100 000 €
                                   </td>
                                   <td>
@@ -3626,6 +3668,9 @@
                                   </td>
                                   <td>
                                       2
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -
@@ -3672,6 +3717,9 @@
                                   <td>
                                       -
                                   </td>
+                                  <td>
+                                      -
+                                  </td>
                               </tr>
                               <tr>
                                   <td>
@@ -3695,6 +3743,9 @@
                                   </td>
                                   <td>
                                       4
+                                  </td>
+                                  <td>
+                                      3 256 €
                                   </td>
                                   <td>
                                       80 000 €
@@ -3766,11 +3817,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3810,6 +3864,9 @@
                                       <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
                                           En attente
                                       </span>
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -
@@ -3862,11 +3919,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3919,6 +3979,9 @@
                                   <td>
                                       -
                                   </td>
+                                  <td>
+                                      -
+                                  </td>
                               </tr>
                           </tbody>
                       </table>
@@ -3958,11 +4021,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -3999,6 +4065,9 @@
                                       <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
                                           En attente
                                       </span>
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -
@@ -4051,11 +4120,14 @@
                                   <th scope="col">
                                       Référent
                                   </th>
-                                  <th scope="col">
-                                      Statut du bilan
+                                  <th aria-label="Statut du bilan" scope="col">
+                                      Statut
                                   </th>
                                   <th scope="col">
                                       Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant potentiel
                                   </th>
                                   <th scope="col">
                                       Montant accordé
@@ -4092,6 +4164,9 @@
                                       <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
                                           En attente
                                       </span>
+                                  </td>
+                                  <td>
+                                      -
                                   </td>
                                   <td>
                                       -

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2983,11 +2983,12 @@
                      ELSE %s
                  END AS "state_order",
                  GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
-                 "geiq_assessments_assessmentcampaign"."id",
-                 "geiq_assessments_assessmentcampaign"."year",
-                 "geiq_assessments_assessmentcampaign"."opening_date",
-                 "geiq_assessments_assessmentcampaign"."submission_deadline",
-                 "geiq_assessments_assessmentcampaign"."review_deadline"
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -3314,6 +3315,386 @@
                                   </td>
                                   <td>
                                       0
+                                  </td>
+                                  <td>
+                                      80 000 €
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                          80 %
+                                      </span>
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: TestListAssessmentsView.test_display_amounts[limited access][assessment list with amounts]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="row">
+              <div class="col-12">
+                  <p>
+                      4 résultats
+                  </p>
+                  <div class="table-responsive mt-3 mt-md-4">
+                      <table class="table table-hover">
+                          <caption class="visually-hidden">
+                              Liste des bilans d’exécution
+                          </caption>
+                          <thead>
+                              <tr>
+                                  <th scope="col">
+                                      GEIQ
+                                  </th>
+                                  <th scope="col">
+                                      Structures
+                                  </th>
+                                  <th scope="col">
+                                      Campagne
+                                  </th>
+                                  <th scope="col">
+                                      Référent
+                                  </th>
+                                  <th scope="col">
+                                      Statut du bilan
+                                  </th>
+                                  <th scope="col">
+                                      Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant accordé
+                                  </th>
+                                  <th scope="col">
+                                      Montant conventionné
+                                  </th>
+                                  <th scope="col">
+                                      Taux de réalisation
+                                  </th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>
+                                      Bilan à valider
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-info">
+                                          À valider
+                                      </span>
+                                  </td>
+                                  <td>
+                                      3
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      Bilan envoyé
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                          À contrôler
+                                      </span>
+                                  </td>
+                                  <td>
+                                      2
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      Nouveau bilan
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                          <li>
+                                              Siège (département non disponible)
+                                          </li>
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                          En attente
+                                      </span>
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      Bilan validé
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                          Validé
+                                      </span>
+                                  </td>
+                                  <td>
+                                      4
+                                  </td>
+                                  <td>
+                                      80 000 €
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                          80 %
+                                      </span>
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: TestListAssessmentsView.test_display_amounts[unlimited access][assessment list with amounts]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="row">
+              <div class="col-12">
+                  <p>
+                      4 résultats
+                  </p>
+                  <div class="table-responsive mt-3 mt-md-4">
+                      <table class="table table-hover">
+                          <caption class="visually-hidden">
+                              Liste des bilans d’exécution
+                          </caption>
+                          <thead>
+                              <tr>
+                                  <th scope="col">
+                                      GEIQ
+                                  </th>
+                                  <th scope="col">
+                                      Structures
+                                  </th>
+                                  <th scope="col">
+                                      Campagne
+                                  </th>
+                                  <th scope="col">
+                                      Référent
+                                  </th>
+                                  <th scope="col">
+                                      Statut du bilan
+                                  </th>
+                                  <th scope="col">
+                                      Nombre de contrats
+                                  </th>
+                                  <th scope="col">
+                                      Montant accordé
+                                  </th>
+                                  <th scope="col">
+                                      Montant conventionné
+                                  </th>
+                                  <th scope="col">
+                                      Taux de réalisation
+                                  </th>
+                              </tr>
+                          </thead>
+                          <tbody>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          Bilan à valider
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-info">
+                                          À valider
+                                      </span>
+                                  </td>
+                                  <td>
+                                      3
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      100 000 €
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success-lighter text-success">
+                                          100 %
+                                      </span>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          Bilan envoyé
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                          À contrôler
+                                      </span>
+                                  </td>
+                                  <td>
+                                      2
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          Nouveau bilan
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                          <li>
+                                              Siège (département non disponible)
+                                          </li>
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                          En attente
+                                      </span>
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                                  <td>
+                                      -
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          Bilan validé
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <ul class="mb-0">
+                                      </ul>
+                                  </td>
+                                  <td>
+                                      2024
+                                  </td>
+                                  <td>
+                                  </td>
+                                  <td>
+                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                          Validé
+                                      </span>
+                                  </td>
+                                  <td>
+                                      4
                                   </td>
                                   <td>
                                       80 000 €

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -76,6 +76,104 @@ class TestListAssessmentsView:
             name="assessment list without links to details"
         )
 
+    @pytest.mark.parametrize("with_limited_access", [True, False], ids=["limited access", "unlimited access"])
+    def test_display_amounts(self, client, with_limited_access, snapshot):
+        if with_limited_access:
+            kind = random.choice(
+                list(
+                    set(INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_LIST).difference(
+                        INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS
+                    )
+                )
+            )
+        else:
+            kind = random.choice(INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS)
+
+        membership = InstitutionMembershipFactory(institution__kind=kind)
+        geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
+        ddets_membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DDETS_GEIQ, institution__name="Une DDETS"
+        )
+
+        campaign = AssessmentCampaignFactory(year=2024)
+        new = AssessmentFactory(
+            id=uuid.UUID("00000000-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            with_main_geiq=True,
+            label_geiq_name="Nouveau bilan",
+        )
+        submitted = AssessmentFactory(
+            id=uuid.UUID("11111111-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            label_geiq_name="Bilan envoyé",
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            convention_amount=100_001,
+            advance_amount=50_001,
+            granted_amount=100_001,
+        )
+        reviewed = AssessmentFactory(
+            id=uuid.UUID("22222222-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            label_geiq_name="Bilan à valider",
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            reviewed_by=ddets_membership.user,
+            reviewed_by_institution=ddets_membership.institution,
+            review_comment="Bravo !",
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=100_000,
+        )
+        final_reviewed = AssessmentFactory(
+            id=uuid.UUID("33333333-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            label_geiq_name="Bilan validé",
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            reviewed_by=membership.user,
+            reviewed_by_institution=membership.institution,
+            review_comment="Bravo !",
+            final_reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            final_reviewed_by=membership.user,
+            final_reviewed_by_institution=membership.institution,
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=80_000,
+        )
+
+        for idx, assessment in enumerate([new, submitted, reviewed, final_reviewed]):
+            EmployeeContractFactory.create_batch(
+                idx + 1,
+                employee__assessment=assessment,
+                allowance_requested=True,
+                allowance_granted=True,
+                employee__allowance_amount=814,
+            )
+            if not with_limited_access:
+                # DDETS or DREETS need to have an institution link to see an assessment
+                AssessmentInstitutionLink.objects.create(
+                    assessment=assessment,
+                    institution=membership.institution,
+                )
+
+        client.force_login(membership.user)
+        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
+            name="assessment list with amounts"
+        )
+
     @pytest.mark.parametrize(
         "institution_kind",
         set(INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_LIST).intersection(INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS),

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -16,6 +16,7 @@ from itou.institutions.enums import InstitutionKind
 from itou.www.geiq_assessments_views.views import (
     INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS,
     INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_LIST,
+    get_allowance_stats_for_institution,
 )
 from tests.companies.factories import CompanyMembershipFactory
 from tests.geiq_assessments.factories import (
@@ -333,6 +334,75 @@ class TestListAssessmentsView:
                 final_reviewed_assessment,
             ],
         )
+
+    @freeze_time("2025-05-21 12:00", tick=True)
+    def test_potential_allowance_amount_coherence(self, client):
+        geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        client.force_login(membership.user)
+        campaign = AssessmentCampaignFactory()
+        ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)
+        assessment = AssessmentFactory(
+            id=uuid.UUID("11111111-0d2c-4f29-ba5b-a27ffb8ecc84"),
+            campaign=campaign,
+            created_by__first_name="Marie",
+            created_by__last_name="Curie",
+            label_antennas=[{"id": 1, "name": "Un Superbe GEIQ", "post_code": "12345"}],
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            reviewed_by=ddets_membership.user,
+            reviewed_by_institution=ddets_membership.institution,
+            review_comment="Bravo !",
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=100_000,
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment, institution=membership.institution, with_convention=True
+        )
+        # Contracts taken into account for potential_allowance_amount
+        contract = EmployeeContractFactory(
+            allowance_requested=True,
+            allowance_granted=True,
+            employee__assessment=assessment,
+            employee__allowance_amount=1400,
+        )
+        EmployeeContractFactory(allowance_requested=True, allowance_granted=True, employee=contract.employee)
+        EmployeeContractFactory(
+            allowance_requested=True,
+            allowance_granted=True,
+            employee__assessment=assessment,
+            employee__allowance_amount=814,
+        )
+        # Contracts not taken into account for potential_allowance_amount
+        EmployeeContractFactory(allowance_requested=False, allowance_granted=False, employee=contract.employee)
+        EmployeeContractFactory(
+            allowance_requested=False,
+            allowance_granted=False,
+            employee__assessment=assessment,
+            employee__allowance_amount=814,
+        )
+        EmployeeContractFactory(
+            allowance_requested=True,
+            allowance_granted=False,
+            employee__assessment=assessment,
+            employee__allowance_amount=1400,
+        )
+
+        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        context_potential_amout = response.context["assessments"].get().potential_allowance_amount
+        expected_potential_amout = get_allowance_stats_for_institution(assessment, for_assessment_details=False)[
+            "potential_allowance_amount"
+        ]
+        assert context_potential_amout == 3614
+        assert context_potential_amout == expected_potential_amout
 
 
 class TestAssessmentDetailsForInstitutionView:


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://app.notion.com/p/gip-inclusion/Ajout-d-une-colonne-Montant-potentiel-sur-la-page-de-suivi-33c5f321b604809290a5d872e7a40d4a




## 🆘 Help

- [x] Surement possible d'alléger la [requeste pour l'affichage](https://github.com/gip-inclusion/les-emplois/pull/8185/changes#diff-1b11b5ff3e12bfdb0a3d7792e3706e13277f742f5a19e994432816eaa731ea87R1005-R1008) des `assessment.stats.potential_allowance_amount` dans la vue `list_for_institution`
- [x] Ajouter un test qui vérifie que les bilans présents dans request.context['assessments'] ont bien une annotation potential_allowance_amount donc la valeur est égale à get_allowance_stats_for_institution(assessment, for_assessment_details=False)['potential_allowance_amount'] (mais avec des cas un peu plus complexe comme des salariés avec plusieurs contrats, etc)

## :desert_island: Comment tester ?

- Se connecter en admin@test (password fourni sur demande)
- Détourner Laura (pk 9) 
- Checker les bilans d'exécutions de la DDRETS-PACA


## :computer: Captures d'écran <!-- optionnel -->
<img width="1651" height="322" alt="capture 2026-06-05 à 10 11 20" src="https://github.com/user-attachments/assets/f9f53b40-72b7-42b4-a0c8-98808e931a9c" />



