### PR TITLE
GEIQ : Ajout d’un premier filtre, "Référent", sur la liste des bilans d’exécution des institutions

### DIFF
--- a/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
@@ -1,0 +1,7 @@
+<div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+    <div class="col-12">
+        <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.institutions only %}
+        </div>
+    </div>
+</div>

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load str_filters %}
 
-<div class="col-12">
+<div class="col-12" id="assessments-results">
     <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
     <section>
         {% if not assessments %}

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
@@ -1,0 +1,99 @@
+{% load format_filters %}
+{% load geiq_assessments_badges %}
+{% load str_filters %}
+
+<div class="col-12">
+    {% if assessments %}
+        <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
+        <section>
+            <div class="table-responsive mt-3 mt-md-4">
+                <table class="table table-hover">
+                    <caption class="visually-hidden">Liste des bilans d’exécution</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">GEIQ</th>
+                            <th scope="col">Structures</th>
+                            <th scope="col">Campagne</th>
+                            <th scope="col">Référent</th>
+                            <th scope="col" aria-label="Statut du bilan">Statut</th>
+                            <th scope="col">Nombre de contrats</th>
+                            <th scope="col">Montant potentiel</th>
+                            <th scope="col">Montant accordé</th>
+                            <th scope="col">Montant conventionné</th>
+                            <th scope="col">Taux de réalisation</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for assessment in assessments %}
+                            <tr>
+                                <td>
+                                    {% if can_access_details %}
+                                        <a class="btn-link" href="{% url "geiq_assessments_views:details_for_institution" pk=assessment.pk %}">
+                                            {{ assessment.label_geiq_name }}
+                                        </a>
+                                    {% else %}
+                                        {{ assessment.label_geiq_name }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <ul class="mb-0">
+                                        {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
+                                    </ul>
+                                </td>
+                                <td>{{ assessment.campaign.year }}</td>
+                                <td>
+                                    {% for institution in assessment.conventionned_institutions %}
+                                        {{ institution.name }}
+                                        {% if not forloop.last %}<br>{% endif %}
+                                    {% endfor %}
+                                </td>
+                                <td>{% state_for_institution assessment %}</td>
+                                <td>
+                                    {% if assessment.submitted_at %}
+                                        {{ assessment.contracts_nb }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assessment.can_view_amounts %}
+                                        {{ assessment.potential_allowance_amount|format_int_euros }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assessment.can_view_amounts %}
+                                        {{ assessment.granted_amount|format_int_euros }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assessment.can_view_amounts %}
+                                        {{ assessment.convention_amount|format_int_euros }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if assessment.can_view_amounts %}
+                                        {% grant_percentage_badge assessment %}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    {% else %}
+        <div class="text-center my-3 my-md-4">
+            <p class="mb-1 mt-3">
+                <strong>Aucun bilan pour le moment</strong>
+            </p>
+        </div>
+    {% endif %}
+</div>

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
@@ -1,11 +1,19 @@
 {% load format_filters %}
 {% load geiq_assessments_badges %}
+{% load static %}
 {% load str_filters %}
 
 <div class="col-12">
-    {% if assessments %}
-        <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
-        <section>
+    <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
+    <section>
+        {% if not assessments %}
+            <div class="text-center my-3 my-md-4">
+                <img class="img-fluid" src="{% static 'img/illustration-card-no-result.png' %}" alt="" loading="lazy">
+                <p class="mb-1 mt-3">
+                    <strong>Aucun bilan pour le moment</strong>
+                </p>
+            </div>
+        {% else %}
             <div class="table-responsive mt-3 mt-md-4">
                 <table class="table table-hover">
                     <caption class="visually-hidden">Liste des bilans d’exécution</caption>
@@ -88,12 +96,6 @@
                     </tbody>
                 </table>
             </div>
-        </section>
-    {% else %}
-        <div class="text-center my-3 my-md-4">
-            <p class="mb-1 mt-3">
-                <strong>Aucun bilan pour le moment</strong>
-            </p>
-        </div>
-    {% endif %}
+        {% endif %}
+    </section>
 </div>

--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load components %}
 {% load django_bootstrap5 %}
+{% load static %}
 
 {% block title %}Bilans d’exécution GEIQ {{ block.super }}{% endblock %}
 
@@ -15,9 +16,18 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            <form hx-get="{{ request.path }}" hx-trigger="change delay:.5s" hx-indicator="#assessments-results" hx-target="#assessments-results" hx-swap="outerHTML" hx-push-url="true">
+                {% include "geiq_assessments_views/includes/assessments_list_filters_for_institutions.html" with filters_form=filters_form only %}
+            </form>
             <div class="s-section__row row">
                 {% include "geiq_assessments_views/includes/assessments_list_results_for_institutions.html" with request=request assessments=assessments can_access_details=can_access_details only %}
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script src='{% static "js/htmx_compat.js" %}'></script>
+    <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
 {% endblock %}

--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -1,10 +1,6 @@
 {% extends "layout/base.html" %}
 {% load components %}
 {% load django_bootstrap5 %}
-{% load format_filters %}
-{% load geiq_assessments_badges %}
-{% load static %}
-{% load str_filters %}
 
 {% block title %}Bilans d’exécution GEIQ {{ block.super }}{% endblock %}
 
@@ -19,100 +15,8 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    {% if assessments %}
-                        <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
-                        <div class="table-responsive mt-3 mt-md-4">
-                            <table class="table table-hover">
-                                <caption class="visually-hidden">Liste des bilans d’exécution</caption>
-                                <thead>
-                                    <tr>
-                                        <th scope="col">GEIQ</th>
-                                        <th scope="col">Structures</th>
-                                        <th scope="col">Campagne</th>
-                                        <th scope="col">Référent</th>
-                                        <th scope="col" aria-label="Statut du bilan">Statut</th>
-                                        <th scope="col">Nombre de contrats</th>
-                                        <th scope="col">Montant potentiel</th>
-                                        <th scope="col">Montant accordé</th>
-                                        <th scope="col">Montant conventionné</th>
-                                        <th scope="col">Taux de réalisation</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for assessment in assessments %}
-                                        <tr>
-                                            <td>
-                                                {% if can_access_details %}
-                                                    <a class="btn-link" href="{% url "geiq_assessments_views:details_for_institution" pk=assessment.pk %}">
-                                                        {{ assessment.label_geiq_name }}
-                                                    </a>
-                                                {% else %}
-                                                    {{ assessment.label_geiq_name }}
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                <ul class="mb-0">
-                                                    {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
-                                                </ul>
-                                            </td>
-                                            <td>{{ assessment.campaign.year }}</td>
-                                            <td>
-                                                {% for institution in assessment.conventionned_institutions %}
-                                                    {{ institution.name }}
-                                                    {% if not forloop.last %}<br>{% endif %}
-                                                {% endfor %}
-                                            </td>
-                                            <td>{% state_for_institution assessment %}</td>
-                                            <td>
-                                                {% if assessment.submitted_at %}
-                                                    {{ assessment.contracts_nb }}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if assessment.can_view_amounts %}
-                                                    {{ assessment.potential_allowance_amount|format_int_euros }}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if assessment.can_view_amounts %}
-                                                    {{ assessment.granted_amount|format_int_euros }}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if assessment.can_view_amounts %}
-                                                    {{ assessment.convention_amount|format_int_euros }}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if assessment.can_view_amounts %}
-                                                    {% grant_percentage_badge assessment %}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                    {% else %}
-                        <div class="text-center my-3 my-md-4">
-                            <p class="mb-1 mt-3">
-                                <strong>Aucun bilan pour le moment</strong>
-                            </p>
-                        </div>
-                    {% endif %}
-                </div>
+            <div class="s-section__row row">
+                {% include "geiq_assessments_views/includes/assessments_list_results_for_institutions.html" with request=request assessments=assessments can_access_details=can_access_details only %}
             </div>
         </div>
     </section>

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -1,11 +1,12 @@
 from django import forms
-from django.forms import widgets
+from django.db.models import Exists, OuterRef, Q
+from django.forms import CheckboxSelectMultiple, widgets
 from django.utils import timezone
 from django_select2.forms import Select2Widget
 
 from itou.files.forms import ItouFileField
 from itou.geiq_assessments.enums import AllowanceJustificationReason, AllowanceRefusalReason
-from itou.geiq_assessments.models import Assessment, Employee
+from itou.geiq_assessments.models import Assessment, AssessmentInstitutionLink, Employee
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
 from itou.utils.constants import MB
@@ -227,6 +228,37 @@ class ReviewForm(forms.ModelForm):
     def save(self, commit=True):
         self.instance.decision_validated_at = timezone.now()
         return super().save(commit=commit)
+
+
+class AssessmentsFilterForInstitutionForm(forms.Form):
+    institutions = forms.MultipleChoiceField(required=False, label="Référent", widget=CheckboxSelectMultiple)
+
+    def __init__(self, assessments_qs, data, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        self.fields["institutions"].choices = self._get_choices_for_institutions(assessments_qs)
+
+    def _get_choices_for_institutions(self, assessments_qs):
+        institutions_qs = Institution.objects.filter(
+            Exists(
+                AssessmentInstitutionLink.objects.filter(
+                    assessment__pk__in=assessments_qs.values_list("pk", flat=True),
+                    institution=OuterRef("pk"),
+                    with_convention=True,
+                )
+            )
+        ).order_by("name")
+        return [(institution.pk, institution.name) for institution in institutions_qs]
+
+    def filter(self, queryset):
+        filters = []
+
+        if institutions := self.cleaned_data.get("institutions"):
+            institutions_filter = Q(
+                institution_links__institution__in=institutions, institution_links__with_convention=True
+            )
+            filters.append(institutions_filter)
+
+        return queryset.filter(*filters)
 
 
 class ContractFilterForm(forms.Form):

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -52,6 +52,7 @@ from itou.www.geiq_assessments_views.forms import (
     AllowanceRefusalJustificationForm,
     AllowanceRequestJustificationForm,
     AskForFixCommentForm,
+    AssessmentsFilterForInstitutionForm,
     ContractFilterForm,
     CreateForm,
     GeiqCommentForm,
@@ -1012,11 +1013,24 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
         )
         .order_by("state_order", "-last_updated_at")
     )
+
+    filters_form = AssessmentsFilterForInstitutionForm(assessments, request.GET)
+
+    if filters_form.is_valid():
+        assessments = filters_form.filter(assessments)
+
     context = {
         "assessments": assessments,
         "can_access_details": organization_kind in INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS,
+        "filters_form": filters_form,
     }
-    return render(request, template_name, context)
+    return render(
+        request,
+        "geiq_assessments_views/includes/assessments_list_results_for_institutions.html"
+        if request.htmx
+        else template_name,
+        context,
+    )
 
 
 @check_request(lambda request: request.from_institution)

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2750,7 +2750,7 @@
 # ---
 # name: TestListAssessmentsView.test_complex_list[SQL queries]
   dict({
-    'num_queries': 13,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -2934,6 +2934,51 @@
       }),
       dict({
         'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" V0
+               WHERE (V0."assessment_id" IN
+                        (SELECT U0."id" AS "pk"
+                         FROM "geiq_assessments_assessment" U0
+                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
+                         WHERE U1."institution_id" = %s
+                         GROUP BY 1)
+                      AND V0."institution_id" = ("institutions_institution"."id")
+                      AND V0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
           'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
@@ -3101,8 +3146,31 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_institutions_0" name="institutions" type="checkbox" value="[PK of Institution]"/>
+                                          <label class="form-check-label" for="id_institutions_0">
+                                              Un DREETS GEIQ
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       5 résultats
                   </p>
@@ -3368,8 +3436,23 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       4 résultats
                   </p>
@@ -3570,8 +3653,23 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       4 résultats
                   </p>
@@ -3782,8 +3880,23 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       0 résultat
                   </p>
@@ -3808,8 +3921,31 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_institutions_0" name="institutions" type="checkbox" value="[PK of Institution]"/>
+                                          <label class="form-check-label" for="id_institutions_0">
+                                              Une institution GEIQ
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       1 résultat
                   </p>
@@ -3912,8 +4048,31 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_institutions_0" name="institutions" type="checkbox" value="[PK of Institution]"/>
+                                          <label class="form-check-label" for="id_institutions_0">
+                                              Une institution GEIQ
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       1 résultat
                   </p>
@@ -4012,12 +4171,395 @@
   
   '''
 # ---
+# name: TestListAssessmentsView.test_institutions_filter[SQL queries]
+  dict({
+    'num_queries': 11,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" V0
+               WHERE (V0."assessment_id" IN
+                        (SELECT U0."id" AS "pk"
+                         FROM "geiq_assessments_assessment" U0
+                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
+                         WHERE U1."institution_id" = %s
+                         GROUP BY 1)
+                      AND V0."institution_id" = ("institutions_institution"."id")
+                      AND V0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" T7 ON ("geiq_assessments_assessment"."id" = T7."assessment_id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND T7."institution_id" IN (%s)
+                 AND T7."with_convention")
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s), (%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
 # name: TestListAssessmentsView.test_limited_access_without_links_to_details[DGEFP GEIQ][assessment list without links to details]
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       1 résultat
                   </p>
@@ -4117,8 +4659,23 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
+          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+              <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
+                  <div class="col-12">
+                      <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Référent
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </form>
           <div class="s-section__row row">
-              <div class="col-12">
+              <div class="col-12" id="assessments-results">
                   <p>
                       1 résultat
                   </p>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2934,7 +2934,7 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
           'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
@@ -3009,7 +3009,7 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
           'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
@@ -3032,7 +3032,7 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
           'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
@@ -3784,13 +3784,19 @@
       <div class="s-section__container container">
           <div class="s-section__row row">
               <div class="col-12">
-                  <div class="text-center my-3 my-md-4">
-                      <p class="mb-1 mt-3">
-                          <strong>
-                              Aucun bilan pour le moment
-                          </strong>
-                      </p>
-                  </div>
+                  <p>
+                      0 résultat
+                  </p>
+                  <section>
+                      <div class="text-center my-3 my-md-4">
+                          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-card-no-result.png"/>
+                          <p class="mb-1 mt-3">
+                              <strong>
+                                  Aucun bilan pour le moment
+                              </strong>
+                          </p>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2934,7 +2934,8 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/list_for_institution.html]',
+          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3008,7 +3009,8 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/list_for_institution.html]',
+          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3030,7 +3032,8 @@
       }),
       dict({
         'origin': list([
-          'IfNode[geiq_assessments_views/list_for_institution.html]',
+          'IfNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3098,260 +3101,262 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       5 résultats
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Un Superbe GEIQ (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-info">
-                                          À valider
-                                      </span>
-                                  </td>
-                                  <td>
-                                      0
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success-lighter text-success">
-                                          100 %
-                                      </span>
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Un Beau GEIQ
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (23)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
-                                          À contrôler
-                                      </span>
-                                  </td>
-                                  <td>
-                                      0
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Un Joli GEIQ
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (12)
-                                          </li>
-                                          <li>
-                                              Une antenne (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Un Superbe GEIQ (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
-                                          Validé
-                                      </span>
-                                  </td>
-                                  <td>
-                                      0
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      90 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
-                                          90 %
-                                      </span>
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/44444444-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Un Superbe GEIQ (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Un DREETS GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
-                                          Validé
-                                      </span>
-                                  </td>
-                                  <td>
-                                      0
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      80 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
-                                          80 %
-                                      </span>
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Un Superbe GEIQ (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Un DREETS GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-info">
+                                              À valider
+                                          </span>
+                                      </td>
+                                      <td>
+                                          0
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success-lighter text-success">
+                                              100 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Un Beau GEIQ
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (23)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Un DREETS GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                              À contrôler
+                                          </span>
+                                      </td>
+                                      <td>
+                                          0
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Un Joli GEIQ
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (12)
+                                              </li>
+                                              <li>
+                                                  Une antenne (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Un DREETS GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Un Superbe GEIQ (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Un DREETS GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                              Validé
+                                          </span>
+                                      </td>
+                                      <td>
+                                          0
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          90 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                              90 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/44444444-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Un Superbe GEIQ (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Un DREETS GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                              Validé
+                                          </span>
+                                      </td>
+                                      <td>
+                                          0
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          80 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                              80 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -3363,195 +3368,197 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       4 résultats
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      Bilan à valider
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-info">
-                                          À valider
-                                      </span>
-                                  </td>
-                                  <td>
-                                      3
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      Bilan envoyé
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
-                                          À contrôler
-                                      </span>
-                                  </td>
-                                  <td>
-                                      2
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      Nouveau bilan
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (département non disponible)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      Bilan validé
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
-                                          Validé
-                                      </span>
-                                  </td>
-                                  <td>
-                                      4
-                                  </td>
-                                  <td>
-                                      3 256 €
-                                  </td>
-                                  <td>
-                                      80 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
-                                          80 %
-                                      </span>
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          Bilan à valider
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-info">
+                                              À valider
+                                          </span>
+                                      </td>
+                                      <td>
+                                          3
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          Bilan envoyé
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                              À contrôler
+                                          </span>
+                                      </td>
+                                      <td>
+                                          2
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          Nouveau bilan
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (département non disponible)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          Bilan validé
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                              Validé
+                                          </span>
+                                      </td>
+                                      <td>
+                                          4
+                                      </td>
+                                      <td>
+                                          3 256 €
+                                      </td>
+                                      <td>
+                                          80 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                              80 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -3563,205 +3570,207 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       4 résultats
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Bilan à valider
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-info">
-                                          À valider
-                                      </span>
-                                  </td>
-                                  <td>
-                                      3
-                                  </td>
-                                  <td>
-                                      2 442 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success-lighter text-success">
-                                          100 %
-                                      </span>
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Bilan envoyé
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
-                                          À contrôler
-                                      </span>
-                                  </td>
-                                  <td>
-                                      2
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Nouveau bilan
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (département non disponible)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Bilan validé
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-success">
-                                          Validé
-                                      </span>
-                                  </td>
-                                  <td>
-                                      4
-                                  </td>
-                                  <td>
-                                      3 256 €
-                                  </td>
-                                  <td>
-                                      80 000 €
-                                  </td>
-                                  <td>
-                                      100 000 €
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
-                                          80 %
-                                      </span>
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Bilan à valider
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-info">
+                                              À valider
+                                          </span>
+                                      </td>
+                                      <td>
+                                          3
+                                      </td>
+                                      <td>
+                                          2 442 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success-lighter text-success">
+                                              100 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/11111111-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Bilan envoyé
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-accent-03 text-primary">
+                                              À contrôler
+                                          </span>
+                                      </td>
+                                      <td>
+                                          2
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Nouveau bilan
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (département non disponible)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/33333333-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Bilan validé
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-success">
+                                              Validé
+                                          </span>
+                                      </td>
+                                      <td>
+                                          4
+                                      </td>
+                                      <td>
+                                          3 256 €
+                                      </td>
+                                      <td>
+                                          80 000 €
+                                      </td>
+                                      <td>
+                                          100 000 €
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning-lighter text-warning">
+                                              80 %
+                                          </span>
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -3773,7 +3782,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <div class="text-center my-3 my-md-4">
                       <p class="mb-1 mt-3">
@@ -3793,97 +3802,99 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       1 résultat
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Un Joli GEIQ
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (12)
-                                          </li>
-                                          <li>
-                                              Une antenne (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Une institution GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Un Joli GEIQ
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (12)
+                                              </li>
+                                              <li>
+                                                  Une antenne (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Une institution GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -3895,97 +3906,99 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       1 résultat
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
-                                          Un Joli GEIQ
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (12)
-                                          </li>
-                                          <li>
-                                              Une antenne (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                      Une institution GEIQ
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/institution/00000000-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Un Joli GEIQ
+                                          </a>
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (12)
+                                              </li>
+                                              <li>
+                                                  Une antenne (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                          Une institution GEIQ
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -3997,94 +4010,96 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       1 résultat
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      Un Joli GEIQ
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (12)
-                                          </li>
-                                          <li>
-                                              Une antenne (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          Un Joli GEIQ
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (12)
+                                              </li>
+                                              <li>
+                                                  Une antenne (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>
@@ -4096,94 +4111,96 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <div class="row">
+          <div class="s-section__row row">
               <div class="col-12">
                   <p>
                       1 résultat
                   </p>
-                  <div class="table-responsive mt-3 mt-md-4">
-                      <table class="table table-hover">
-                          <caption class="visually-hidden">
-                              Liste des bilans d’exécution
-                          </caption>
-                          <thead>
-                              <tr>
-                                  <th scope="col">
-                                      GEIQ
-                                  </th>
-                                  <th scope="col">
-                                      Structures
-                                  </th>
-                                  <th scope="col">
-                                      Campagne
-                                  </th>
-                                  <th scope="col">
-                                      Référent
-                                  </th>
-                                  <th aria-label="Statut du bilan" scope="col">
-                                      Statut
-                                  </th>
-                                  <th scope="col">
-                                      Nombre de contrats
-                                  </th>
-                                  <th scope="col">
-                                      Montant potentiel
-                                  </th>
-                                  <th scope="col">
-                                      Montant accordé
-                                  </th>
-                                  <th scope="col">
-                                      Montant conventionné
-                                  </th>
-                                  <th scope="col">
-                                      Taux de réalisation
-                                  </th>
-                              </tr>
-                          </thead>
-                          <tbody>
-                              <tr>
-                                  <td>
-                                      Un Joli GEIQ
-                                  </td>
-                                  <td>
-                                      <ul class="mb-0">
-                                          <li>
-                                              Siège (12)
-                                          </li>
-                                          <li>
-                                              Une antenne (12)
-                                          </li>
-                                      </ul>
-                                  </td>
-                                  <td>
-                                      2024
-                                  </td>
-                                  <td>
-                                  </td>
-                                  <td>
-                                      <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
-                                          En attente
-                                      </span>
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                                  <td>
-                                      -
-                                  </td>
-                              </tr>
-                          </tbody>
-                      </table>
-                  </div>
+                  <section>
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          GEIQ
+                                      </th>
+                                      <th scope="col">
+                                          Structures
+                                      </th>
+                                      <th scope="col">
+                                          Campagne
+                                      </th>
+                                      <th scope="col">
+                                          Référent
+                                      </th>
+                                      <th aria-label="Statut du bilan" scope="col">
+                                          Statut
+                                      </th>
+                                      <th scope="col">
+                                          Nombre de contrats
+                                      </th>
+                                      <th scope="col">
+                                          Montant potentiel
+                                      </th>
+                                      <th scope="col">
+                                          Montant accordé
+                                      </th>
+                                      <th scope="col">
+                                          Montant conventionné
+                                      </th>
+                                      <th scope="col">
+                                          Taux de réalisation
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          Un Joli GEIQ
+                                      </td>
+                                      <td>
+                                          <ul class="mb-0">
+                                              <li>
+                                                  Siège (12)
+                                              </li>
+                                              <li>
+                                                  Une antenne (12)
+                                              </li>
+                                          </ul>
+                                      </td>
+                                      <td>
+                                          2024
+                                      </td>
+                                      <td>
+                                      </td>
+                                      <td>
+                                          <span class="badge rounded-pill text-nowrap badge-sm bg-warning">
+                                              En attente
+                                          </span>
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                      <td>
+                                          -
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </section>
               </div>
           </div>
       </div>

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -24,8 +24,9 @@ from tests.geiq_assessments.factories import (
     AssessmentFactory,
     EmployeeContractFactory,
 )
-from tests.institutions.factories import InstitutionMembershipFactory
+from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory
 from tests.users.factories import EmployerFactory, JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.utils.htmx.testing import assertSoupEqual, update_page_with_htmx
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
@@ -202,9 +203,15 @@ class TestListAssessmentsView:
 
         client.force_login(membership.user)
         response = client.get(self.URL)
-        assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessment list with links to details"
-        )
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                ".s-section",
+                replace_in_attr=[
+                    ("value", f"{membership.institution.pk}", "[PK of Institution]"),
+                ],
+            )
+        ) == snapshot(name="assessment list with links to details")
 
     @freeze_time("2025-05-21 12:00", tick=True)
     def test_complex_list(self, client, snapshot):
@@ -321,9 +328,15 @@ class TestListAssessmentsView:
 
         with assertSnapshotQueries(snapshot(name="SQL queries")):
             response = client.get(self.URL)
-        assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessments complex list"
-        )
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                ".s-section",
+                replace_in_attr=[
+                    ("value", f"{membership.institution.pk}", "[PK of Institution]"),
+                ],
+            )
+        ) == snapshot(name="assessments complex list")
         assertQuerySetEqual(
             response.context["assessments"],
             [
@@ -403,6 +416,100 @@ class TestListAssessmentsView:
         ]
         assert context_potential_amout == 3614
         assert context_potential_amout == expected_potential_amout
+
+    @freeze_time("2025-05-21 12:00", tick=True)
+    def test_institutions_filter(self, client, snapshot):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        ddets = InstitutionFactory(kind=InstitutionKind.DDETS_GEIQ, name="Une DDETS GEIQ")
+        campaign = AssessmentCampaignFactory()
+        assessment_dreets_ddets = AssessmentFactory(campaign=campaign)
+        # User selected both institutions in the creation form
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_dreets_ddets, institution=membership.institution, with_convention=True
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_dreets_ddets, institution=ddets, with_convention=True
+        )
+
+        assessment_ddets = AssessmentFactory(campaign=campaign)
+        # User selected only the DDETS in the creation form
+        AssessmentInstitutionLink.objects.create(assessment=assessment_ddets, institution=membership.institution)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_ddets, institution=ddets, with_convention=True)
+
+        # Another unlinked assessment that should not be seen anywhere
+        AssessmentFactory(campaign=campaign)
+
+        client.force_login(membership.user)
+        # No filter
+        response = client.get(self.URL)
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
+        )
+
+        # Filter on the DDETS
+        with assertSnapshotQueries(snapshot(name="SQL queries")):
+            response = client.get(self.URL, {"institutions": ddets.pk})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
+        )
+
+        # Filter on the DREETS
+        response = client.get(self.URL, {"institutions": membership.institution.pk})
+        assertQuerySetEqual(response.context["assessments"], [assessment_dreets_ddets])
+        # Filter on both the DDETS and the DREETS
+        response = client.get(self.URL, {"institutions": [membership.institution.pk, ddets.pk]})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
+        )
+
+        # Invalid data: do nothing, ie. do not filter
+        response = client.get(self.URL, {"institutions": "invalid"})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
+        )
+
+    @freeze_time("2025-05-21 12:00", tick=True)
+    def test_filters_htmx(self, client):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        ddets = InstitutionFactory(kind=InstitutionKind.DDETS_GEIQ, name="Une DDETS GEIQ")
+        campaign = AssessmentCampaignFactory()
+        assessment_dreets_ddets = AssessmentFactory(campaign=campaign)
+        # User selected both institutions in the creation form
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_dreets_ddets, institution=membership.institution, with_convention=True
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_dreets_ddets, institution=ddets, with_convention=True
+        )
+
+        assessment_ddets = AssessmentFactory(campaign=campaign)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_ddets, institution=membership.institution)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_ddets, institution=ddets, with_convention=True)
+
+        client.force_login(membership.user)
+        # No filter
+        response = client.get(self.URL)
+        page = parse_response_to_soup(response, selector="#main")
+
+        # institutions filter
+        ddets_checkbox = page.find("input", attrs={"type": "checkbox", "name": "institutions", "value": str(ddets.pk)})
+        ddets_checkbox["checked"] = ""  # simulate select checkbox
+        response = client.get(self.URL, {"institutions": ddets.pk}, headers={"HX-Request": "true"})
+        update_page_with_htmx(page, f"form[hx-get='{self.URL}']", response)
+        response = client.get(self.URL, {"institutions": ddets.pk})
+        fresh_page = parse_response_to_soup(response, selector="#main")
+        assertSoupEqual(page, fresh_page)
+        ddets_checkbox["checked"] = ""  # simulate unselect checkbox
+        response = client.get(self.URL, headers={"HX-Request": "true"})
+        update_page_with_htmx(page, f"form[hx-get='{self.URL}']", response)
+        response = client.get(self.URL)
+        fresh_page = parse_response_to_soup(response, selector="#main")
 
 
 class TestAssessmentDetailsForInstitutionView:

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -30,13 +30,13 @@ from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
 class TestListAssessmentsView:
+    URL = reverse("geiq_assessments_views:list_for_institution")
+
     def test_anonymous_access(self, client):
-        url = reverse("geiq_assessments_views:list_for_institution")
-        response = client.get(url)
-        assertRedirects(response, reverse("account_login") + f"?next={url}")
+        response = client.get(self.URL)
+        assertRedirects(response, reverse("account_login") + f"?next={self.URL}")
 
     def test_unauthorized_access(self, client):
-        url = reverse("geiq_assessments_views:list_for_institution")
         for user, expected_status in [
             (JobSeekerFactory(), 403),
             (PrescriberFactory(membership=True), 403),
@@ -44,13 +44,13 @@ class TestListAssessmentsView:
             (LaborInspectorFactory(membership=True), 404),
         ]:
             client.force_login(user)
-            response = client.get(url)
+            response = client.get(self.URL)
             assert response.status_code == expected_status
 
     def test_empty_list(self, client, snapshot):
         membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DREETS_GEIQ)
         client.force_login(membership.user)
-        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        response = client.get(self.URL)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
             name="assessments empty list"
         )
@@ -72,7 +72,7 @@ class TestListAssessmentsView:
         )
 
         client.force_login(user)
-        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        response = client.get(self.URL)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
             name="assessment list without links to details"
         )
@@ -170,7 +170,7 @@ class TestListAssessmentsView:
                 )
 
         client.force_login(membership.user)
-        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        response = client.get(self.URL)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
             name="assessment list with amounts"
         )
@@ -201,7 +201,7 @@ class TestListAssessmentsView:
         _unrelated_assessment = AssessmentFactory()
 
         client.force_login(membership.user)
-        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        response = client.get(self.URL)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
             name="assessment list with links to details"
         )
@@ -320,7 +320,7 @@ class TestListAssessmentsView:
         AssessmentFactory(campaign=campaign)  # Another assessment not linked to the institution
 
         with assertSnapshotQueries(snapshot(name="SQL queries")):
-            response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+            response = client.get(self.URL)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
             name="assessments complex list"
         )
@@ -396,7 +396,7 @@ class TestListAssessmentsView:
             employee__allowance_amount=1400,
         )
 
-        response = client.get(reverse("geiq_assessments_views:list_for_institution"))
+        response = client.get(self.URL)
         context_potential_amout = response.context["assessments"].get().potential_allowance_amount
         expected_potential_amout = get_allowance_stats_for_institution(assessment, for_assessment_details=False)[
             "potential_allowance_amount"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les DREETS peuvent se retrouver avec beaucoup de bilans à contrôler. Les filtrer est une fonctionnalité attendue.

Cette PR met le mécanisme HTMX en place et ajoute le premier filtre sur les référents (= institutions conventionnées associées au bilan)

[Carte Notion](https://app.notion.com/p/gip-inclusion/Ajouter-des-filtres-l-espace-de-suivi-des-bilans-geiq-33c5f321b604803abf75dab884efc2f8?v=2845f321b60480bd9ef6000c92a2d6ab&source=copy_link)