### PR TITLE
GEIQ: ajout de vérification dans le client de l'API Label

### DIFF
--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -29,6 +29,12 @@ class LabelCommand(enum.StrEnum):
     TauxGeiq = "TauxGeiq"
 
 
+def check_data_salarie_geiq_id(data, geiq_id):
+    for item in data:
+        if item["salarie"]["geiq_id"] != geiq_id:
+            raise LabelAPIError(f"Data returned incorrect geiq_id={item['geiq_id']} (expected {geiq_id})")
+
+
 class LabelApiClient:
     def __init__(self, base_url: str, token: str):
         self.client = httpx.Client(
@@ -73,6 +79,9 @@ class LabelApiClient:
         data = []
         if geiq_id:
             data.extend(self._command(LabelCommand.TauxGeiq, where=f"geiq,=,{geiq_id}"))
+            for item in data:
+                if item["geiq_id"] != geiq_id:
+                    raise LabelAPIError(f"Data returned incorrect geiq_id={item['geiq_id']} (expected {geiq_id})")
         else:
             p = 1
             while new_values := self._command(LabelCommand.TauxGeiq, sort="geiq.id", n=page_size, p=p):
@@ -135,6 +144,7 @@ class LabelApiClient:
                 break
             p += 1
         assert len(data) == expected_nb
+        check_data_salarie_geiq_id(data, geiq_id)
         logger.info("Retrieved nb=%s contracts", expected_nb)
         return data
 
@@ -163,6 +173,7 @@ class LabelApiClient:
                 break
             p += 1
         assert len(data) == expected_nb
+        check_data_salarie_geiq_id(data, geiq_id)
         logger.info("Retrieved nb=%s prequalifications", expected_nb)
         return data
 

--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -82,35 +82,27 @@ class LabelApiClient:
                 p += 1
         return data
 
-    def get_compte_pdf(self, *, geiq_id):
+    def _get_pdf(self, *, command, geiq_id):
+        if command not in (LabelCommand.DownloadCompte, LabelCommand.SynthesePDF):
+            raise ValueError(f"{command} does not return a PDF")
         try:
             response_data = self.client.get(
-                f"rest/{LabelCommand.DownloadCompte}",
-                params={"id": geiq_id},
-            ).raise_for_status()
-        except httpx.HTTPError as exc:
-            raise LabelAPIError(f"Error requesting Label API: {exc.__class__.__name__}") from exc
-        if response_data.headers["content-type"] != "application/pdf":
-            raise LabelAPIError(f"Unexpected content-type: {response_data.headers.get('content-type')}")
-        logger.info(
-            "Successfully retrieved DownloadCompte - sha256=%s",
-            hashlib.sha256(response_data.content).digest(),
-        )
-        return response_data.content
-
-    def get_synthese_pdf(self, *, geiq_id):
-        try:
-            response_data = self.client.get(
-                f"rest/{LabelCommand.SynthesePDF}",
+                f"rest/{command}",
                 params={"id": geiq_id},
                 timeout=httpx.Timeout(API_TIMEOUT_SECONDS, read=10),  # this endpoint can be slow to generate the PDF
             ).raise_for_status()
         except httpx.HTTPError as exc:
-            raise LabelAPIError(f"Error requesting Label API: {exc.__class__.__name__}") from exc
+            raise LabelAPIError(f"Error requesting Label API {command}: {exc.__class__.__name__}") from exc
         if response_data.headers["content-type"] != "application/pdf":
             raise LabelAPIError(f"Unexpected content-type: {response_data.headers.get('content-type')}")
-        logger.info("Successfully retrieved SynthesePDF - sha256=%s", hashlib.sha256(response_data.content).digest())
+        logger.info(f"Successfully retrieved {command} - sha256=%s", hashlib.sha256(response_data.content).digest())
         return response_data.content
+
+    def get_compte_pdf(self, *, geiq_id):
+        return self._get_pdf(command=LabelCommand.DownloadCompte, geiq_id=geiq_id)
+
+    def get_synthese_pdf(self, *, geiq_id):
+        return self._get_pdf(command=LabelCommand.SynthesePDF, geiq_id=geiq_id)
 
     def get_all_contracts(self, geiq_id, *, page_size=100, date_fin=None):
         data = []

--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -95,6 +95,9 @@ class LabelApiClient:
             raise LabelAPIError(f"Error requesting Label API {command}: {exc.__class__.__name__}") from exc
         if response_data.headers["content-type"] != "application/pdf":
             raise LabelAPIError(f"Unexpected content-type: {response_data.headers.get('content-type')}")
+        if x_geiq_id := response_data.headers.get("x-geiq-id"):
+            if x_geiq_id != str(geiq_id):
+                raise LabelAPIError(f"Unexpected x-geiq-id: {x_geiq_id}")
         logger.info(f"Successfully retrieved {command} - sha256=%s", hashlib.sha256(response_data.content).digest())
         return response_data.content
 

--- a/tests/utils/apis/test_geiq_label.py
+++ b/tests/utils/apis/test_geiq_label.py
@@ -88,7 +88,8 @@ def test_get_all_contracts_empty(respx_mock, label_settings):
 def test_get_all_contracts(respx_mock, label_settings):
     base = label_settings.API_GEIQ_LABEL_BASE_URL
     expected_data = [
-        {"id": nb, "antenne": {}, "salarie": {"id": nb * 11, "nom": f"Salarie du contrat {nb}"}} for nb in range(1, 91)
+        {"id": nb, "antenne": {}, "salarie": {"id": nb * 11, "geiq_id": 123, "nom": f"Salarie du contrat {nb}"}}
+        for nb in range(1, 91)
     ]
     respx_mock.get(
         f"{base}/rest/SalarieContrat"
@@ -122,7 +123,7 @@ def test_get_all_prequalifications(respx_mock, label_settings):
     expected_data = [
         {
             "id": nb,
-            "salarie": {"id": nb * 11, "nom": f"Salarie de la prequalification {nb}"},
+            "salarie": {"id": nb * 11, "geiq_id": 123, "nom": f"Salarie de la prequalification {nb}"},
             "action_pre_qualification": {"id": 3, "libelle": "POE", "libelle_abr": "POE"},
         }
         for nb in range(1, 10)
@@ -140,16 +141,14 @@ def test_get_all_prequalifications(respx_mock, label_settings):
 
 def test_get_taux_geiq_single(respx_mock, label_settings):
     expected_data = [
-        [
-            {
-                "geiq_id": 123,
-                "taux_rupture_periode_essai": "",
-                "taux_rupture_hors_periode_essai": "",
-                "taux_sortie_emploi_durable": "50.0",
-                "taux_sortie_emploi": "50.0",
-                "taux_obtention_qualification": "75.0",
-            }
-        ]
+        {
+            "geiq_id": 123,
+            "taux_rupture_periode_essai": "",
+            "taux_rupture_hors_periode_essai": "",
+            "taux_sortie_emploi_durable": "50.0",
+            "taux_sortie_emploi": "50.0",
+            "taux_obtention_qualification": "75.0",
+        }
     ]
     respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/TauxGeiq?where=geiq,=,123").respond(
         200, json={"status": "Success", "result": expected_data}
@@ -157,6 +156,26 @@ def test_get_taux_geiq_single(respx_mock, label_settings):
 
     client = geiq_label.get_client()
     assert client.get_taux_geiq(geiq_id=123) == expected_data
+
+
+def test_get_taux_geiq_single_invalid_geiq(respx_mock, label_settings):
+    expected_data = [
+        {
+            "geiq_id": 321,
+            "taux_rupture_periode_essai": "",
+            "taux_rupture_hors_periode_essai": "",
+            "taux_sortie_emploi_durable": "50.0",
+            "taux_sortie_emploi": "50.0",
+            "taux_obtention_qualification": "75.0",
+        }
+    ]
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/TauxGeiq?where=geiq,=,123").respond(
+        200, json={"status": "Success", "result": expected_data}
+    )
+
+    client = geiq_label.get_client()
+    with pytest.raises(geiq_label.LabelAPIError, match=r"Data returned incorrect geiq_id=321 \(expected 123\)"):
+        client.get_taux_geiq(geiq_id=123)
 
 
 def test_get_taux_geiq_batch(respx_mock, label_settings):

--- a/tests/utils/apis/test_geiq_label.py
+++ b/tests/utils/apis/test_geiq_label.py
@@ -184,7 +184,9 @@ def test_get_taux_geiq_batch(respx_mock, label_settings):
     assert client.get_taux_geiq() == expected_data
 
 
-def test_get_compte_pdf(respx_mock, label_settings):
+@pytest.mark.parametrize("with_x_geiq_id", [True, False])
+def test_get_compte_pdf(respx_mock, label_settings, with_x_geiq_id):
+    extra_header = {"x-geiq-id": "123"} if with_x_geiq_id else {}
     expected_data = b"some pdf file"
     respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/DownloadCompte?id=123").respond(
         200,
@@ -193,6 +195,7 @@ def test_get_compte_pdf(respx_mock, label_settings):
             "content-length": f"{len(expected_data)}",
             "content-transfer-encoding": "binary",
             "content-type": "application/pdf",
+            **extra_header,
         },
     )
 
@@ -210,13 +213,33 @@ def test_get_compte_pdf_invalid_content_type(respx_mock, label_settings):
             "content-length": "0",
             "content-transfer-encoding": "binary",
             "content-type": "text/html",
+            "x-geiq-id": "123",
         },
     )
     with pytest.raises(geiq_label.LabelAPIError):
         assert client.get_compte_pdf(geiq_id=123)
 
 
-def test_get_synthese_pdf(respx_mock, label_settings):
+def test_get_compte_pdf_invalid_x_geiq_id(respx_mock, label_settings):
+    client = geiq_label.get_client()
+
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/DownloadCompte?id=123").respond(
+        200,
+        content=b"",
+        headers={
+            "content-length": "0",
+            "content-transfer-encoding": "binary",
+            "content-type": "text/html",
+            "x-geiq-id": "321",
+        },
+    )
+    with pytest.raises(geiq_label.LabelAPIError):
+        assert client.get_compte_pdf(geiq_id=123)
+
+
+@pytest.mark.parametrize("with_x_geiq_id", [True, False])
+def test_get_synthese_pdf(respx_mock, label_settings, with_x_geiq_id):
+    extra_header = {"x-geiq-id": "123"} if with_x_geiq_id else {}
     expected_data = b"some pdf file"
     respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/SynthesePDF?id=123").respond(
         200,
@@ -225,6 +248,7 @@ def test_get_synthese_pdf(respx_mock, label_settings):
             "content-length": f"{len(expected_data)}",
             "content-transfer-encoding": "binary",
             "content-type": "application/pdf",
+            **extra_header,
         },
     )
 
@@ -242,6 +266,24 @@ def test_get_synthese_pdf_invalid_content_type(respx_mock, label_settings):
             "content-length": "0",
             "content-transfer-encoding": "binary",
             "content-type": "text/html",
+            "x-geiq-id": "123",
+        },
+    )
+    with pytest.raises(geiq_label.LabelAPIError):
+        assert client.get_synthese_pdf(geiq_id=123)
+
+
+def test_get_synthese_pdf_invalid_x_geiq_id(respx_mock, label_settings):
+    client = geiq_label.get_client()
+
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/SynthesePDF?id=123").respond(
+        200,
+        content=b"",
+        headers={
+            "content-length": "0",
+            "content-transfer-encoding": "binary",
+            "content-type": "text/html",
+            "x-geiq-id": "321",
         },
     )
     with pytest.raises(geiq_label.LabelAPIError):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il est arrivé que l'API renvoie une réponse correspondant à un autre GEIQ que celui demandé. Un correctif a été implémenté coté Label mais on rajoute tout de même des petites vérifications de notre coté pour essayer de détecter le cas s'il se reproduit.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
