### PR TITLE
Expliquer quand hiring_start_at peut être NULL

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -692,6 +692,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         verbose_name="partage du motif de refus avec le candidat", default=False
     )
 
+    # Set on accepted job applications, except when they were imported from
+    # external systems, such as Origin.PE_APPROVAL.
     hiring_start_at = models.DateField(verbose_name="date de début du contrat", blank=True, null=True)
     hiring_end_at = models.DateField(verbose_name="date prévisionnelle de fin du contrat", blank=True, null=True)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mieux documenter la valeur, aurait évité l’erreur corrigée avec 16c6434ca352b6b5b36673cca330317c03e8cadd.
