### PR TITLE
Interface : ajout de messages explicatifs concernant les PASS suspendus

### DIFF
--- a/itou/templates/apply/includes/list_tr.html
+++ b/itou/templates/apply/includes/list_tr.html
@@ -106,7 +106,23 @@
             </td>
             <td>
                 {% if job_application.to_company.is_subject_to_iae_rules %}
-                    {% include "eligibility/includes/iae/eligibility_badge.html" with job_seeker=job_application.job_seeker eligibility_diagnosis=job_application.jobseeker_valid_eligibility_diagnosis force_valid_approval=False badge_size="badge-sm" only %}
+                    <div class="d-flex align-items-center">
+                        {% include "eligibility/includes/iae/eligibility_badge.html" with job_seeker=job_application.job_seeker eligibility_diagnosis=job_application.jobseeker_valid_eligibility_diagnosis force_valid_approval=False badge_size="badge-sm" only %}
+                        {% if job_application.job_seeker.has_valid_approval and job_application.job_seeker.latest_approval.state == "SUSPENDED" %}
+                            {% partialdef suspended-pass-info %}
+                                <i class="ms-1 ri-information-line text-info" aria-label="{{ suspended_tooltip }}" data-bs-toggle="tooltip" data-bs-title="{{ suspended_tooltip }}" role="button" tabindex="0"></i>
+                            {% endpartialdef %}
+                            {% if request.from_employer %}
+                                {% with suspended_tooltip="Vous pouvez embaucher ce candidat. Le PASS IAE se réactivera automatiquement à la déclaration d'une nouvelle embauche." %}
+                                    {% partial suspended-pass-info %}
+                                {% endwith %}
+                            {% else %}
+                                {% with suspended_tooltip="Le PASS IAE est valide, en pause entre deux contrats. Vous pouvez orienter ce candidat sans restriction." %}
+                                    {% partial suspended-pass-info %}
+                                {% endwith %}
+                            {% endif %}
+                        {% endif %}
+                    </div>
                     {% if job_application.job_seeker.has_valid_approval %}
                         {% if job_application.job_seeker.latest_approval.eligibility_diagnosis %}
                             {% if job_application.job_seeker.latest_approval.eligibility_diagnosis.is_from_employer %}

--- a/itou/templates/approvals/includes/suspended_pass_info_alert.html
+++ b/itou/templates/approvals/includes/suspended_pass_info_alert.html
@@ -1,0 +1,8 @@
+{% load components %}
+{% component_alert content=content variant="info" extra_classes="mt-3" %}
+    {% fragment as content %}
+        <p class="mb-0">
+            Le PASS est mis en pause entre deux contrats pour préserver sa durée restante. Il se réactive automatiquement à l'embauche.
+        </p>
+    {% endfragment %}
+{% endcomponent_alert %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -39,7 +39,17 @@
                                 {% endif %}
                             </td>
                             <td>
-                                {% include "eligibility/includes/iae/eligibility_badge.html" with job_seeker=job_seeker eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid_approval=False badge_size="badge-xs" only %}
+                                <div class="d-flex align-items-center">
+                                    {% include "eligibility/includes/iae/eligibility_badge.html" with job_seeker=job_seeker eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid_approval=False badge_size="badge-xs" only %}
+                                    {% if job_seeker.has_valid_approval and job_seeker.latest_approval.state == "SUSPENDED" %}
+                                        <i class="ms-1 ri-information-line text-info"
+                                           aria-label="Le PASS IAE est valide, en pause entre deux contrats. Vous pouvez orienter ce candidat sans restriction."
+                                           data-bs-toggle="tooltip"
+                                           data-bs-title="Le PASS IAE est valide, en pause entre deux contrats. Vous pouvez orienter ce candidat sans restriction."
+                                           role="button"
+                                           tabindex="0"></i>
+                                    {% endif %}
+                                </div>
                             </td>
                             <td>
                                 {{ job_seeker.last_advisor_with_org.0.get_inverted_full_name|default:"Non précisé" }} ({{ job_seeker.last_advisor_with_org.1.name|default:"Non précisé" }})

--- a/itou/templates/utils/templatetags/approval_box.html
+++ b/itou/templates/utils/templatetags/approval_box.html
@@ -69,6 +69,9 @@ Arguments:
         {% if approval.origin == ApprovalOrigin.PE_APPROVAL %}
             <p class="fs-sm fst-italic mt-3">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
         {% endif %}
+        {% if approval.state == "SUSPENDED" %}
+            {% include "approvals/includes/suspended_pass_info_alert.html" %}
+        {% endif %}
     {% else %}
         {% if approval.state == "VALID" %}
             {% with approval.pending_prolongation_request as pending_prolongation_request %}
@@ -90,7 +93,7 @@ Arguments:
                     <hr class="my-3 my-md-4">
                     <ul class="list-data">
                         <li>
-                            <small>Suspension en cours</small>
+                            <small>En pause</small>
                             <strong class="text-info">du {{ suspension.start_at|date:"d/m/Y" }} au {{ suspension.end_at|date:"d/m/Y" }}</strong>
                         </li>
                     </ul>
@@ -121,6 +124,9 @@ Arguments:
             {% endif %}
         {% endif %}
         {% if with_details_link %}
+            {% if approval.state == "SUSPENDED" %}
+                {% include "approvals/includes/suspended_pass_info_alert.html" %}
+            {% endif %}
             <a href="{% url 'approvals:details' public_id=approval.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-outline-primary btn-block btn-ico bg-white mt-3">
                 <i class="ri-eye-line font-weight-medium" aria-hidden="true"></i>
                 <span>Afficher le PASS IAE</span>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -9067,11 +9067,13 @@
                               Le prescripteur habilité n'a pas renseigné de critères.
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9115,11 +9117,13 @@
                               Le prescripteur habilité n'a pas renseigné de critères.
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9165,11 +9169,13 @@
                               Le prescripteur habilité n'a pas renseigné de critères.
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9371,11 +9377,13 @@
                               </ul>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-pass-valid-line">
-                                  </i>
-                                  PASS IAE valide
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-pass-valid-line">
+                                      </i>
+                                      PASS IAE valide
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par votre entreprise
                               </span>
@@ -9417,11 +9425,13 @@
                               Le prescripteur habilité n'a pas renseigné de critères.
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-pass-valid-line">
-                                  </i>
-                                  PASS IAE valide
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-pass-valid-line">
+                                      </i>
+                                      PASS IAE valide
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9465,11 +9475,13 @@
                               </i>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-pass-valid-line">
-                                  </i>
-                                  PASS IAE valide
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-pass-valid-line">
+                                      </i>
+                                      PASS IAE valide
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un employeur
                               </span>
@@ -9520,11 +9532,13 @@
                               </ul>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9575,11 +9589,13 @@
                               </ul>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9630,11 +9646,13 @@
                               </ul>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                                  <i aria-hidden="true" class="ri-check-line">
-                                  </i>
-                                  Éligible à l’IAE
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                      <i aria-hidden="true" class="ri-check-line">
+                                      </i>
+                                      Éligible à l’IAE
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Éligibilité validée par un prescripteur habilité
                               </span>
@@ -9678,11 +9696,13 @@
                               </i>
                           </td>
                           <td>
-                              <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                                  <i aria-hidden="true" class="ri-error-warning-line">
-                                  </i>
-                                  Éligibilité IAE à valider
-                              </span>
+                              <div class="d-flex align-items-center">
+                                  <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
+                                      <i aria-hidden="true" class="ri-error-warning-line">
+                                      </i>
+                                      Éligibilité IAE à valider
+                                  </span>
+                              </div>
                               <span class="d-block">
                                   Un diagnostic doit être réalisé
                               </span>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -8333,11 +8333,13 @@
                           </i>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
-                              </i>
-                              Éligibilité IAE à valider
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
+                                  <i aria-hidden="true" class="ri-error-warning-line">
+                                  </i>
+                                  Éligibilité IAE à valider
+                              </span>
+                          </div>
                           <span class="d-block">
                               Un diagnostic doit être réalisé
                           </span>
@@ -8385,11 +8387,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -8437,11 +8441,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -8489,11 +8495,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -8534,11 +8542,13 @@
                           </i>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-pass-valid-line">
-                              </i>
-                              PASS IAE valide
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-pass-valid-line">
+                                  </i>
+                                  PASS IAE valide
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un employeur
                           </span>
@@ -8584,11 +8594,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-pass-valid-line">
-                              </i>
-                              PASS IAE valide
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-pass-valid-line">
+                                  </i>
+                                  PASS IAE valide
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un employeur
                           </span>
@@ -8627,11 +8639,13 @@
                           Le prescripteur habilité n'a pas renseigné de critères.
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-pass-valid-line">
-                              </i>
-                              PASS IAE valide
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-pass-valid-line">
+                                  </i>
+                                  PASS IAE valide
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -9961,11 +9975,13 @@
                           </i>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
-                              </i>
-                              Éligibilité IAE à valider
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
+                                  <i aria-hidden="true" class="ri-error-warning-line">
+                                  </i>
+                                  Éligibilité IAE à valider
+                              </span>
+                          </div>
                           <span class="d-block">
                               Un diagnostic doit être réalisé
                           </span>
@@ -10013,11 +10029,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -10065,11 +10083,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -10117,11 +10137,13 @@
                           </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-check-line">
-                              </i>
-                              Éligible à l’IAE
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-check-line">
+                                  </i>
+                                  Éligible à l’IAE
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>
@@ -10162,11 +10184,13 @@
                           </i>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-pass-valid-line">
-                              </i>
-                              PASS IAE valide
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-pass-valid-line">
+                                  </i>
+                                  PASS IAE valide
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un employeur
                           </span>
@@ -10205,11 +10229,13 @@
                           Le prescripteur habilité n'a pas renseigné de critères.
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
-                              <i aria-hidden="true" class="ri-pass-valid-line">
-                              </i>
-                              PASS IAE valide
-                          </span>
+                          <div class="d-flex align-items-center">
+                              <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                                  <i aria-hidden="true" class="ri-pass-valid-line">
+                                  </i>
+                                  PASS IAE valide
+                              </span>
+                          </div>
                           <span class="d-block">
                               Éligibilité validée par un prescripteur habilité
                           </span>

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -38,6 +38,32 @@ from tests.utils.testing import (
 
 INVALID_VALUE_MESSAGE = "Sélectionnez un choix valide."
 
+_SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP = (
+    "Le PASS IAE est valide, en pause entre deux contrats. Vous pouvez orienter ce candidat sans restriction."
+)
+_SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP = (
+    "Vous pouvez embaucher ce candidat. "
+    "Le PASS IAE se réactivera automatiquement à la déclaration d'une nouvelle embauche."
+)
+
+
+SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP = f"""
+    <i class="ms-1 ri-information-line text-info"
+       aria-label="{_SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP}"
+       data-bs-toggle="tooltip"
+       data-bs-title="{_SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP}"
+       role="button"
+       tabindex="0"></i>"""
+
+
+SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP_MARKUP = f"""
+    <i class="ms-1 ri-information-line text-info"
+       aria-label="{_SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP}"
+       data-bs-toggle="tooltip"
+       data-bs-title="{_SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP}"
+       role="button"
+       tabindex="0"></i>"""
+
 
 class TestProcessListSiae:
     SELECTED_JOBS = "selected_jobs"
@@ -190,6 +216,24 @@ class TestProcessListSiae:
 
         # No selected jobs, the filter should not appear.
         assertNotContains(response, self.SELECTED_JOBS)
+
+    def test_list_for_siae_suspended_approval_info_tooltip(self, client):
+        company = CompanyFactory(with_membership=True, subject_to_iae_rules=True)
+        employer = company.members.first()
+
+        job_application = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            with_approval=True,
+            state=JobApplicationState.ACCEPTED,
+            to_company=company,
+        )
+        SuspensionFactory(approval=job_application.approval)
+
+        client.force_login(employer)
+        response = client.get(reverse("apply:list_for_siae"))
+
+        assertContains(response, SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP_MARKUP, html=True)
+        assertNotContains(response, SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP, html=True)
 
     def test_list_for_siae_hide_criteria_for_non_SIAE_employers(self, client, subtests):
         company = CompanyFactory(with_membership=True, subject_to_iae_rules=True)

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -19,7 +19,7 @@ from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import Title
 from itou.www.apply.views.list_views import JobApplicationOrder, JobApplicationsDisplayKind
-from tests.approvals.factories import ApprovalFactory
+from tests.approvals.factories import ApprovalFactory, SuspensionFactory
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
@@ -36,6 +36,10 @@ from tests.utils.testing import (
     get_rows_from_streaming_response,
     parse_response_to_soup,
     pretty_indented,
+)
+from tests.www.apply.test_list_for_siae import (
+    SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP_MARKUP,
+    SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP,
 )
 
 
@@ -78,6 +82,20 @@ def test_get(client):
         assert len(response.context["job_applications_page"].object_list) == organization.jobapplication_set.count()
 
         assertContains(response, job_application.job_seeker.get_inverted_full_name())
+
+
+def test_suspended_approval_info_tooltip(client):
+    job_application = JobApplicationFactory(
+        sent_by_authorized_prescriber=True,
+        with_approval=True,
+        state=JobApplicationState.ACCEPTED,
+    )
+    SuspensionFactory(approval=job_application.approval)
+    client.force_login(job_application.sender)
+
+    response = client.get(reverse("apply:list_prescriptions"))
+    assertContains(response, SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP, html=True)
+    assertNotContains(response, SUSPENDED_APPROVAL_EMPLOYER_TOOLTIP_MARKUP, html=True)
 
 
 @override_settings(PAGE_SIZE_DEFAULT=1)

--- a/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
@@ -630,7 +630,7 @@
   
   '''
 # ---
-# name: test_suspended_approval
+# name: test_suspended_approval[box]
   '''
   <html>
       <head>
@@ -688,13 +688,26 @@
               <ul class="list-data">
                   <li>
                       <small>
-                          Suspension en cours
+                          En pause
                       </small>
                       <strong class="text-info">
                           du 01/08/2024 au 31/08/2024
                       </strong>
                   </li>
               </ul>
+              <div class="alert alert-info mt-3" role="status">
+                  <div class="row">
+                      <div class="col-auto pe-0">
+                          <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                          </i>
+                      </div>
+                      <div class="col">
+                          <p class="mb-0">
+                              Le PASS est mis en pause entre deux contrats pour préserver sa durée restante. Il se réactive automatiquement à l'embauche.
+                          </p>
+                      </div>
+                  </div>
+              </div>
               <a class="btn btn-outline-primary btn-block btn-ico bg-white mt-3" href="/approvals/details/997a1eaf-6fad-4256-b371-31bb05c94862?back_url=/">
                   <i aria-hidden="true" class="ri-eye-line font-weight-medium">
                   </i>
@@ -702,6 +715,79 @@
                       Afficher le PASS IAE
                   </span>
               </a>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: test_suspended_approval[details_view]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--pass bg-info-lightest border-info">
+              <div class="mb-3 mb-md-4">
+                  <span class="badge badge-base rounded-pill bg-info text-white">
+                      <i aria-hidden="true" class="ri-pass-pending-line">
+                      </i>
+                      PASS IAE valide (suspendu)
+                  </span>
+              </div>
+              <ul class="list-data">
+                  <li>
+                      <small>
+                          Numéro de PASS IAE
+                      </small>
+                      <strong>
+                          <span>
+                              XXXXX
+                          </span>
+                          <span class="ms-1">
+                              12
+                          </span>
+                          <span class="ms-1">
+                              34567
+                          </span>
+                      </strong>
+                  </li>
+                  <li>
+                      <small>
+                          Date de début
+                      </small>
+                      <strong>
+                          01/01/2024
+                      </strong>
+                  </li>
+                  <li>
+                      <small>
+                          Durée de validité
+                          <i aria-label="La durée de validité est calculée sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, elle décroît donc tous les jours (samedi, dimanche et jours fériés compris)." class="ri-information-line ri-xl text-info" data-bs-title="La durée de validité est calculée sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, elle décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip" role="button" tabindex="0">
+                          </i>
+                      </small>
+                      <strong>
+                          486 jours (Environ 1 an et 3 mois)
+                          <br/>
+                          <a class="btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733528375185--PASS-IAE-Comment-%C3%A7a-marche" target="_blank">
+                              Comment est calculée cette durée ?
+                          </a>
+                      </strong>
+                  </li>
+              </ul>
+              <div class="alert alert-info mt-3" role="status">
+                  <div class="row">
+                      <div class="col-auto pe-0">
+                          <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                          </i>
+                      </div>
+                      <div class="col">
+                          <p class="mb-0">
+                              Le PASS est mis en pause entre deux contrats pour préserver sa durée restante. Il se réactive automatiquement à l'embauche.
+                          </p>
+                      </div>
+                  </div>
+              </div>
           </div>
       </body>
   </html>

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -237,6 +237,19 @@
       <p class="fs-sm fst-italic mt-3">
           Ce PASS IAE a été importé depuis un agrément Pôle emploi.
       </p>
+      <div class="alert alert-info mt-3" role="status">
+          <div class="row">
+              <div class="col-auto pe-0">
+                  <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                  </i>
+              </div>
+              <div class="col">
+                  <p class="mb-0">
+                      Le PASS est mis en pause entre deux contrats pour préserver sa durée restante. Il se réactive automatiquement à l'embauche.
+                  </p>
+              </div>
+          </div>
+      </div>
   </div>
   
   '''

--- a/tests/www/approvals_views/test_approval_box.py
+++ b/tests/www/approvals_views/test_approval_box.py
@@ -78,7 +78,8 @@ def test_valid_approval_with_pending_prolongation_request(snapshot):
 
 
 @freeze_time("2024-08-06")
-def test_suspended_approval(snapshot):
+@pytest.mark.parametrize("version", ["box", "details_view"])
+def test_suspended_approval(snapshot, version):
     approval = ApprovalFactory(
         start_at=datetime.date(2024, 1, 1),
         number=approval_number,
@@ -92,9 +93,10 @@ def test_suspended_approval(snapshot):
     )
     request = get_request(approval.eligibility_diagnosis.author)  # an authorized prescriber linked to the job seeker
     template = Template(
-        "{% load approvals %}{% approval_details_box approval=approval version='box' request=request %}"
+        "{% load approvals %}{% approval_details_box approval=approval version=version request=request %}"
     )
-    assert pretty_indented(template.render(Context({"approval": approval, "request": request}))) == snapshot
+    context = Context({"approval": approval, "request": request, "version": version})
+    assert pretty_indented(template.render(context)) == snapshot
 
 
 @freeze_time("2024-08-06")

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -1630,11 +1630,13 @@
                   </a>
               </td>
               <td>
-                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
-                      <i aria-hidden="true" class="ri-check-line">
-                      </i>
-                      Éligible à l’IAE
-                  </span>
+                  <div class="d-flex align-items-center">
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                          <i aria-hidden="true" class="ri-check-line">
+                          </i>
+                          Éligible à l’IAE
+                      </span>
+                  </div>
               </td>
               <td>
                   DERAY Odile (Pres. Org.)
@@ -1675,11 +1677,13 @@
                   </span>
               </td>
               <td>
-                  <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                      <i aria-hidden="true" class="ri-error-warning-line">
-                      </i>
-                      Éligibilité IAE à valider
-                  </span>
+                  <div class="d-flex align-items-center">
+                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                          <i aria-hidden="true" class="ri-error-warning-line">
+                          </i>
+                          Éligibilité IAE à valider
+                      </span>
+                  </div>
               </td>
               <td>
                   DERAY Odile (Pres. Org.)
@@ -1723,11 +1727,13 @@
                   </a>
               </td>
               <td>
-                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
-                      <i aria-hidden="true" class="ri-pass-valid-line">
-                      </i>
-                      PASS IAE valide
-                  </span>
+                  <div class="d-flex align-items-center">
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                          <i aria-hidden="true" class="ri-pass-valid-line">
+                          </i>
+                          PASS IAE valide
+                      </span>
+                  </div>
               </td>
               <td>
                   Non précisé (ACME Inc.)
@@ -1772,11 +1778,13 @@
                   </span>
               </td>
               <td>
-                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
-                      <i aria-hidden="true" class="ri-check-line">
-                      </i>
-                      Éligible à l’IAE
-                  </span>
+                  <div class="d-flex align-items-center">
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                          <i aria-hidden="true" class="ri-check-line">
+                          </i>
+                          Éligible à l’IAE
+                      </span>
+                  </div>
               </td>
               <td>
                   BIALÈS Patrick (Pres. Org.)
@@ -2760,11 +2768,13 @@
               </a>
           </td>
           <td>
-              <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                  <i aria-hidden="true" class="ri-error-warning-line">
-                  </i>
-                  Éligibilité IAE à valider
-              </span>
+              <div class="d-flex align-items-center">
+                  <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                      <i aria-hidden="true" class="ri-error-warning-line">
+                      </i>
+                      Éligibilité IAE à valider
+                  </span>
+              </div>
           </td>
           <td>
               Non précisé (Pres. Org.)
@@ -2801,11 +2811,13 @@
               </a>
           </td>
           <td>
-              <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
-                  <i aria-hidden="true" class="ri-check-line">
-                  </i>
-                  Éligible à l’IAE
-              </span>
+              <div class="d-flex align-items-center">
+                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                      <i aria-hidden="true" class="ri-check-line">
+                      </i>
+                      Éligible à l’IAE
+                  </span>
+              </div>
           </td>
           <td>
               GRAVIER Emile (Pres. Org.)
@@ -2842,11 +2854,13 @@
               </a>
           </td>
           <td>
-              <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                  <i aria-hidden="true" class="ri-error-warning-line">
-                  </i>
-                  Éligibilité IAE à valider
-              </span>
+              <div class="d-flex align-items-center">
+                  <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                      <i aria-hidden="true" class="ri-error-warning-line">
+                      </i>
+                      Éligibilité IAE à valider
+                  </span>
+              </div>
           </td>
           <td>
               Non précisé (ACME Inc.)

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -18,7 +18,7 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
 from itou.utils.templatetags.str_filters import mask_unless
-from tests.approvals.factories import ApprovalFactory
+from tests.approvals.factories import ApprovalFactory, SuspensionFactory
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, CompanyWith2MembershipsFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
@@ -35,6 +35,7 @@ from tests.users.factories import (
 )
 from tests.utils.htmx.testing import assertSoupEqual, update_page_with_htmx
 from tests.utils.testing import PAGINATION_PAGE_ONE_MARKUP, parse_response_to_soup, pretty_indented
+from tests.www.apply.test_list_for_siae import SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP
 from tests.www.apply.test_submit import fake_session_initialization
 
 
@@ -960,6 +961,24 @@ def test_filtered_by_approval_state(client, factory, url):
         job_seeker_expired_eligibility_expired_approval,
         job_seeker_expired_eligibility_valid_approval,
     ]
+
+
+@pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
+def test_suspended_approval_info_tooltip(client, url):
+    organization = PrescriberOrganizationWith2MembershipFactory()
+    prescriber = organization.members.first()
+    client.force_login(prescriber)
+
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=prescriber,
+        author_prescriber_organization=organization,
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    approval = ApprovalFactory(user=job_seeker)
+    SuspensionFactory(approval=approval)
+
+    assertContains(client.get(url), SUSPENDED_APPROVAL_PRESCRIBER_TOOLTIP_MARKUP, html=True)
 
 
 def test_filtered_by_is_stalled(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand un PASS IAE est suspendu, les candidats, prescripteurs et employeurs pensent à tort que cela empêche de candidater, d'orienter ou d'embaucher. Le support reçoit de nombreux messages à ce sujet. [Carte Notion](https://app.notion.com/p/gip-inclusion/Rassurer-les-pro-sur-la-suspension-du-PASS-3435f321b604802e87d7eda813bb15d5), [Figma](https://www.figma.com/design/qhc8O1yeuJXHlYtRSj2dgs/%F0%9F%8E%83-ASU---Tous-les-r%C3%B4les?node-id=3741-7735&t=50tfKz0XIiTNYRhg-0).

## :cake: Comment ?

- Renommage du statut "Valide (suspendu)" en "Valide - En pause" (énum, badge, filtre de la liste des PASS).
- Ajout d'une icône info 'i' sur le PASS suspendu dans "Mes accompagnements" et les listes de candidatures, avec un message adapté au profil (prescripteur / employeur).
- Ajout d'une alerte info sur le profil candidat et la page du PASS, et remplacement de "Suspension en cours" par "En pause".

## :computer: Captures d'écran

<img width="2278" height="1509" alt="image" src="https://github.com/user-attachments/assets/612eb570-8be3-4695-a266-0fbccee3c3f1" />

<img width="2278" height="1509" alt="image" src="https://github.com/user-attachments/assets/74fb360e-1938-4d3e-82c5-bfcc1328af86" />
