### PR TITLE
GEIQ : Ajout des filtres Campagne, Status et Nom du GEIQ à la liste des bilans d’exécution des institutions

### DIFF
--- a/itou/geiq_assessments/enums.py
+++ b/itou/geiq_assessments/enums.py
@@ -30,6 +30,24 @@ class AssessmentState(models.TextChoices):
     REVIEWED = "reviewed", "Contrôlé"
     FINAL_REVIEWED = "final_reviewed", "Contrôlé (DREETS)"
 
+    def get_label_for_geiq(self):
+        labels = {
+            self.NEW: "À compléter",
+            self.SUBMITTED: "Envoyé",
+            self.REVIEWED: "Envoyé",
+            self.FINAL_REVIEWED: "Traité",
+        }
+        return labels[self]
+
+    def get_label_for_institution(self):
+        labels = {
+            self.NEW: "En attente",
+            self.SUBMITTED: "À contrôler",
+            self.REVIEWED: "À valider",
+            self.FINAL_REVIEWED: "Validé",
+        }
+        return labels[self]
+
 
 class AssessmentTransition(enum.StrEnum):
     SUBMIT = "submit"

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
@@ -1,6 +1,7 @@
 <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
     <div class="col-12">
         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.campaigns only %}
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.institutions only %}
         </div>
     </div>

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
@@ -3,6 +3,7 @@
         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.campaigns only %}
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.institutions only %}
+            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.states only %}
         </div>
     </div>
 </div>

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_filters_for_institutions.html
@@ -1,9 +1,22 @@
+{% load str_filters %}
 <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
     <div class="col-12">
         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.campaigns only %}
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.institutions only %}
             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.states only %}
+            {% partialdef assessments-filter-counter inline %}
+                <div class="ms-md-auto" id="assessments-filter-counter"{% if hx_swap_oob|default:False %} hx-swap-oob="true"{% endif %}>
+                    {% if filters_counter > 0 %}
+                        <a href="{% url "geiq_assessments_views:list_for_institution" %}"
+                           class="btn btn-ico btn-dropdown-filter"
+                           aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
+                            <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
+                            <span>Effacer tout</span>
+                        </a>
+                    {% endif %}
+                </div>
+            {% endpartialdef %}
         </div>
     </div>
 </div>

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
@@ -98,4 +98,5 @@
 
 {% if request.htmx %}
     {% include "geiq_assessments_views/list_for_institution.html#assessments-count" with hx_swap_oob=True assessments=assessments only %}
+    {% include "geiq_assessments_views/includes/assessments_list_filters_for_institutions.html#assessments-filter-counter" with hx_swap_oob=True filters_counter=filters_counter only %}
 {% endif %}

--- a/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
+++ b/itou/templates/geiq_assessments_views/includes/assessments_list_results_for_institutions.html
@@ -1,101 +1,101 @@
 {% load format_filters %}
 {% load geiq_assessments_badges %}
 {% load static %}
-{% load str_filters %}
 
-<div class="col-12" id="assessments-results">
-    <p>{{ assessments|length }} résultat{{ assessments|pluralizefr }}</p>
-    <section>
-        {% if not assessments %}
-            <div class="text-center my-3 my-md-4">
-                <img class="img-fluid" src="{% static 'img/illustration-card-no-result.png' %}" alt="" loading="lazy">
-                <p class="mb-1 mt-3">
-                    <strong>Aucun bilan pour le moment</strong>
-                </p>
-            </div>
-        {% else %}
-            <div class="table-responsive mt-3 mt-md-4">
-                <table class="table table-hover">
-                    <caption class="visually-hidden">Liste des bilans d’exécution</caption>
-                    <thead>
+<section id="assessments-results">
+    {% if not assessments %}
+        <div class="text-center my-3 my-md-4">
+            <img class="img-fluid" src="{% static 'img/illustration-card-no-result.png' %}" alt="" loading="lazy">
+            <p class="mb-1 mt-3">
+                <strong>Aucun bilan pour le moment</strong>
+            </p>
+        </div>
+    {% else %}
+        <div class="table-responsive mt-3 mt-md-4">
+            <table class="table table-hover">
+                <caption class="visually-hidden">Liste des bilans d’exécution</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">GEIQ</th>
+                        <th scope="col">Structures</th>
+                        <th scope="col">Campagne</th>
+                        <th scope="col">Référent</th>
+                        <th scope="col" aria-label="Statut du bilan">Statut</th>
+                        <th scope="col">Nombre de contrats</th>
+                        <th scope="col">Montant potentiel</th>
+                        <th scope="col">Montant accordé</th>
+                        <th scope="col">Montant conventionné</th>
+                        <th scope="col">Taux de réalisation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for assessment in assessments %}
                         <tr>
-                            <th scope="col">GEIQ</th>
-                            <th scope="col">Structures</th>
-                            <th scope="col">Campagne</th>
-                            <th scope="col">Référent</th>
-                            <th scope="col" aria-label="Statut du bilan">Statut</th>
-                            <th scope="col">Nombre de contrats</th>
-                            <th scope="col">Montant potentiel</th>
-                            <th scope="col">Montant accordé</th>
-                            <th scope="col">Montant conventionné</th>
-                            <th scope="col">Taux de réalisation</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for assessment in assessments %}
-                            <tr>
-                                <td>
-                                    {% if can_access_details %}
-                                        <a class="btn-link" href="{% url "geiq_assessments_views:details_for_institution" pk=assessment.pk %}">
-                                            {{ assessment.label_geiq_name }}
-                                        </a>
-                                    {% else %}
+                            <td>
+                                {% if can_access_details %}
+                                    <a class="btn-link" href="{% url "geiq_assessments_views:details_for_institution" pk=assessment.pk %}">
                                         {{ assessment.label_geiq_name }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <ul class="mb-0">
-                                        {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
-                                    </ul>
-                                </td>
-                                <td>{{ assessment.campaign.year }}</td>
-                                <td>
-                                    {% for institution in assessment.conventionned_institutions %}
-                                        {{ institution.name }}
-                                        {% if not forloop.last %}<br>{% endif %}
-                                    {% endfor %}
-                                </td>
-                                <td>{% state_for_institution assessment %}</td>
-                                <td>
-                                    {% if assessment.submitted_at %}
-                                        {{ assessment.contracts_nb }}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if assessment.can_view_amounts %}
-                                        {{ assessment.potential_allowance_amount|format_int_euros }}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if assessment.can_view_amounts %}
-                                        {{ assessment.granted_amount|format_int_euros }}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if assessment.can_view_amounts %}
-                                        {{ assessment.convention_amount|format_int_euros }}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if assessment.can_view_amounts %}
-                                        {% grant_percentage_badge assessment %}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        {% endif %}
-    </section>
-</div>
+                                    </a>
+                                {% else %}
+                                    {{ assessment.label_geiq_name }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                <ul class="mb-0">
+                                    {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
+                                </ul>
+                            </td>
+                            <td>{{ assessment.campaign.year }}</td>
+                            <td>
+                                {% for institution in assessment.conventionned_institutions %}
+                                    {{ institution.name }}
+                                    {% if not forloop.last %}<br>{% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>{% state_for_institution assessment %}</td>
+                            <td>
+                                {% if assessment.submitted_at %}
+                                    {{ assessment.contracts_nb }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if assessment.can_view_amounts %}
+                                    {{ assessment.potential_allowance_amount|format_int_euros }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if assessment.can_view_amounts %}
+                                    {{ assessment.granted_amount|format_int_euros }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if assessment.can_view_amounts %}
+                                    {{ assessment.convention_amount|format_int_euros }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if assessment.can_view_amounts %}
+                                    {% grant_percentage_badge assessment %}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+</section>
+
+{% if request.htmx %}
+    {% include "geiq_assessments_views/list_for_institution.html#assessments-count" with hx_swap_oob=True assessments=assessments only %}
+{% endif %}

--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -1,6 +1,8 @@
 {% extends "layout/base.html" %}
 {% load components %}
+{% load django_bootstrap5 %}
 {% load static %}
+{% load str_filters %}
 
 {% block title %}Bilans d’exécution GEIQ {{ block.super }}{% endblock %}
 
@@ -15,11 +17,31 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <form hx-get="{{ request.path }}" hx-trigger="change delay:.5s" hx-indicator="#assessments-results" hx-target="#assessments-results" hx-swap="outerHTML" hx-push-url="true">
+            <form hx-get="{{ request.path }}"
+                  hx-trigger="change delay:.5s, change from:#id_company delay:.5s"
+                  hx-indicator="#assessments-results"
+                  hx-target="#assessments-results"
+                  hx-swap="outerHTML"
+                  hx-push-url="true"
+                  hx-include="#id_company">
                 {% include "geiq_assessments_views/includes/assessments_list_filters_for_institutions.html" with filters_form=filters_form only %}
             </form>
             <div class="s-section__row row">
-                {% include "geiq_assessments_views/includes/assessments_list_results_for_institutions.html" with request=request assessments=assessments can_access_details=can_access_details only %}
+                <div class="col-12">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                        <div class="flex-md-grow-1">
+                            {% partialdef assessments-count inline %}
+                                <p class="mb-0" id="assessments-count"{% if hx_swap_oob|default:False %} hx-swap-oob="true"{% endif %}>
+                                    {{ assessments|length }} résultat{{ assessments|pluralizefr }}
+                                </p>
+                            {% endpartialdef %}
+                        </div>
+                        <div class="flex-column flex-md-row mt-3 mt-md-0">
+                            {% bootstrap_field filters_form.company wrapper_class="w-lg-400px" show_label=False %}
+                        </div>
+                    </div>
+                    {% include "geiq_assessments_views/includes/assessments_list_results_for_institutions.html" with request=request assessments=assessments can_access_details=can_access_details only %}
+                </div>
             </div>
         </div>
     </section>

--- a/itou/templates/geiq_assessments_views/list_for_institution.html
+++ b/itou/templates/geiq_assessments_views/list_for_institution.html
@@ -24,7 +24,7 @@
                   hx-swap="outerHTML"
                   hx-push-url="true"
                   hx-include="#id_company">
-                {% include "geiq_assessments_views/includes/assessments_list_filters_for_institutions.html" with filters_form=filters_form only %}
+                {% include "geiq_assessments_views/includes/assessments_list_filters_for_institutions.html" with filters_form=filters_form filters_counter=filters_counter only %}
             </form>
             <div class="s-section__row row">
                 <div class="col-12">

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -247,10 +247,16 @@ class ReviewForm(forms.ModelForm):
 
 class AssessmentsFilterForInstitutionForm(forms.Form):
     institutions = forms.MultipleChoiceField(required=False, label="Référent", widget=CheckboxSelectMultiple)
+    campaigns = forms.MultipleChoiceField(required=False, label="Campagne", widget=CheckboxSelectMultiple)
 
     def __init__(self, assessments_qs, data, *args, **kwargs):
         super().__init__(data, *args, **kwargs)
+        self.fields["campaigns"].choices = self._get_choices_for_campaigns(assessments_qs)
         self.fields["institutions"].choices = self._get_choices_for_institutions(assessments_qs)
+
+    def _get_choices_for_campaigns(self, assessments_qs):
+        campaigns = assessments_qs.order_by("-campaign__year").distinct().values_list("campaign__pk", "campaign__year")
+        return campaigns
 
     def _get_choices_for_institutions(self, assessments_qs):
         institutions_qs = Institution.objects.filter(
@@ -267,6 +273,9 @@ class AssessmentsFilterForInstitutionForm(forms.Form):
     def filter(self, queryset):
         filters = []
 
+        if campaigns := self.cleaned_data.get("campaigns"):
+            campaigns_filter = Q(campaign__in=campaigns)
+            filters.append(campaigns_filter)
         if institutions := self.cleaned_data.get("institutions"):
             institutions_filter = Q(
                 institution_links__institution__in=institutions, institution_links__with_convention=True

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from django_select2.forms import Select2Widget
 
 from itou.files.forms import ItouFileField
-from itou.geiq_assessments.enums import AllowanceJustificationReason, AllowanceRefusalReason
+from itou.geiq_assessments.enums import AllowanceJustificationReason, AllowanceRefusalReason, AssessmentState
 from itou.geiq_assessments.models import Assessment, AssessmentInstitutionLink, Employee
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
@@ -248,6 +248,12 @@ class ReviewForm(forms.ModelForm):
 class AssessmentsFilterForInstitutionForm(forms.Form):
     institutions = forms.MultipleChoiceField(required=False, label="Référent", widget=CheckboxSelectMultiple)
     campaigns = forms.MultipleChoiceField(required=False, label="Campagne", widget=CheckboxSelectMultiple)
+    states = forms.MultipleChoiceField(
+        required=False,
+        label="Statut",
+        widget=CheckboxSelectMultiple,
+        choices=[(choice.value, choice.get_label_for_institution()) for choice in AssessmentState],
+    )
 
     def __init__(self, assessments_qs, data, *args, **kwargs):
         super().__init__(data, *args, **kwargs)
@@ -281,6 +287,9 @@ class AssessmentsFilterForInstitutionForm(forms.Form):
                 institution_links__institution__in=institutions, institution_links__with_convention=True
             )
             filters.append(institutions_filter)
+        if states := self.cleaned_data.get("states"):
+            states_filter = Q(state__in=states)
+            filters.append(states_filter)
 
         return queryset.filter(*filters)
 

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -254,27 +254,38 @@ class AssessmentsFilterForInstitutionForm(forms.Form):
         widget=CheckboxSelectMultiple,
         choices=[(choice.value, choice.get_label_for_institution()) for choice in AssessmentState],
     )
+    company = forms.ChoiceField(
+        required=False,
+        label="Nom du GEIQ",
+        widget=Select2Widget(attrs={"data-placeholder": "Nom du GEIQ"}),
+    )
 
     def __init__(self, assessments_qs, data, *args, **kwargs):
         super().__init__(data, *args, **kwargs)
-        self.fields["campaigns"].choices = self._get_choices_for_campaigns(assessments_qs)
-        self.fields["institutions"].choices = self._get_choices_for_institutions(assessments_qs)
+        assessments = list(assessments_qs)
+        self.fields["campaigns"].choices = self._get_choices_for_campaigns(assessments)
+        self.fields["institutions"].choices = self._get_choices_for_institutions(assessments)
+        self.fields["company"].choices = self._get_choices_for_company(assessments)
 
-    def _get_choices_for_campaigns(self, assessments_qs):
-        campaigns = assessments_qs.order_by("-campaign__year").distinct().values_list("campaign__pk", "campaign__year")
-        return campaigns
+    def _get_choices_for_campaigns(self, assessments):
+        choices = {(assessment.campaign.pk, assessment.campaign.year) for assessment in assessments}
+        return sorted(choices, key=lambda c: c[1])
 
-    def _get_choices_for_institutions(self, assessments_qs):
+    def _get_choices_for_institutions(self, assessments):
         institutions_qs = Institution.objects.filter(
             Exists(
                 AssessmentInstitutionLink.objects.filter(
-                    assessment__pk__in=assessments_qs.values_list("pk", flat=True),
+                    assessment__pk__in=[assessment.pk for assessment in assessments],
                     institution=OuterRef("pk"),
                     with_convention=True,
                 )
             )
         ).order_by("name")
         return [(institution.pk, institution.name) for institution in institutions_qs]
+
+    def _get_choices_for_company(self, assessments):
+        choices = {(assessment.label_geiq_id, assessment.label_geiq_name) for assessment in assessments}
+        return sorted(choices, key=lambda c: c[1])
 
     def filter(self, queryset):
         filters = []
@@ -290,6 +301,9 @@ class AssessmentsFilterForInstitutionForm(forms.Form):
         if states := self.cleaned_data.get("states"):
             states_filter = Q(state__in=states)
             filters.append(states_filter)
+        if company := self.cleaned_data.get("company"):
+            company_filter = Q(label_geiq_id=company)
+            filters.append(company_filter)
 
         return queryset.filter(*filters)
 

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -307,6 +307,9 @@ class AssessmentsFilterForInstitutionForm(forms.Form):
 
         return queryset.filter(*filters)
 
+    def get_filters_counter(self):
+        return sum(bool(self.cleaned_data.get(field.name)) for field in self)
+
 
 class ContractFilterForm(forms.Form):
     """

--- a/itou/www/geiq_assessments_views/templatetags/geiq_assessments_badges.py
+++ b/itou/www/geiq_assessments_views/templatetags/geiq_assessments_badges.py
@@ -10,42 +10,29 @@ register = template.Library()
 
 @register.simple_tag
 def state_for_institution(assessment, *, extra_classes="badge-sm"):
-    match assessment.state:
-        case AssessmentState.NEW:
-            text = "En attente"
-            state_classes = "bg-warning"
-        case AssessmentState.SUBMITTED:
-            text = "À contrôler"
-            state_classes = "bg-accent-03 text-primary"
-        case AssessmentState.REVIEWED:
-            text = "À valider"
-            state_classes = "bg-info"
-        case AssessmentState.FINAL_REVIEWED:
-            text = "Validé"
-            state_classes = "bg-success"
-        case _:
-            raise ValueError(f"Wrong state {assessment.state}")
+    state_classes = {
+        AssessmentState.NEW: "bg-warning",
+        AssessmentState.SUBMITTED: "bg-accent-03 text-primary",
+        AssessmentState.REVIEWED: "bg-info",
+        AssessmentState.FINAL_REVIEWED: "bg-success",
+    }
 
-    class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes}"
+    text = AssessmentState(assessment.state).get_label_for_institution()
+    class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes[assessment.state]}"
     return format_html('<span class="{}">{}</span>', class_attr, text)
 
 
 @register.simple_tag
 def state_for_geiq(assessment, *, extra_classes="badge-sm"):
-    match assessment.state:
-        case AssessmentState.NEW:
-            text = "À compléter"
-            state_classes = "bg-info"
-        case AssessmentState.SUBMITTED | AssessmentState.REVIEWED:
-            text = "Envoyé"
-            state_classes = "text-info bg-info-lightest"
-        case AssessmentState.FINAL_REVIEWED:
-            text = "Traité"
-            state_classes = "text-success bg-success-lightest"
-        case _:
-            raise ValueError("Wrong state {assessment.state}")
+    state_classes = {
+        AssessmentState.NEW: "bg-info",
+        AssessmentState.SUBMITTED: "text-info bg-info-lightest",
+        AssessmentState.REVIEWED: "text-info bg-info-lightest",
+        AssessmentState.FINAL_REVIEWED: "text-success bg-success-lightest",
+    }
 
-    class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes}"
+    text = AssessmentState(assessment.state).get_label_for_geiq()
+    class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes[assessment.state]}"
     return format_html('<span class="{}">{}</span>', class_attr, text)
 
 

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -1021,6 +1021,7 @@ def list_for_institution(request, template_name="geiq_assessments_views/list_for
         "assessments": assessments,
         "can_access_details": organization_kind in INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_DETAILS,
         "filters_form": filters_form,
+        "filters_counter": filters_form.get_filters_counter(),
     }
     return render(
         request,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -3588,6 +3588,45 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                       </div>
                   </div>
               </div>
@@ -3885,6 +3924,45 @@
                               <ul class="dropdown-menu">
                               </ul>
                           </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                       </div>
                   </div>
               </div>
@@ -4115,6 +4193,45 @@
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
                               </ul>
                           </div>
                       </div>
@@ -4351,6 +4468,45 @@
                               <ul class="dropdown-menu">
                               </ul>
                           </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                       </div>
                   </div>
               </div>
@@ -4410,6 +4566,45 @@
                                           <input class="form-check-input" id="id_institutions_0" name="institutions" type="checkbox" value="[PK of Institution]"/>
                                           <label class="form-check-label" for="id_institutions_0">
                                               Une institution GEIQ
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
                                           </label>
                                       </div>
                                   </li>
@@ -4552,6 +4747,45 @@
                                           <input class="form-check-input" id="id_institutions_0" name="institutions" type="checkbox" value="[PK of Institution]"/>
                                           <label class="form-check-label" for="id_institutions_0">
                                               Une institution GEIQ
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
                                           </label>
                                       </div>
                                   </li>
@@ -5080,6 +5314,45 @@
                               <ul class="dropdown-menu">
                               </ul>
                           </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                       </div>
                   </div>
               </div>
@@ -5209,6 +5482,45 @@
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Statut
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                                          <label class="form-check-label" for="id_states_0">
+                                              En attente
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="submitted"/>
+                                          <label class="form-check-label" for="id_states_1">
+                                              À contrôler
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="reviewed"/>
+                                          <label class="form-check-label" for="id_states_2">
+                                              À valider
+                                          </label>
+                                      </div>
+                                  </li>
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="final_reviewed"/>
+                                          <label class="form-check-label" for="id_states_3">
+                                              Validé
+                                          </label>
+                                      </div>
+                                  </li>
                               </ul>
                           </div>
                       </div>
@@ -5632,7 +5944,8 @@
           WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
                  AND "geiq_assessments_assessment"."campaign_id" IN (%s)
                  AND T8."institution_id" IN (%s)
-                 AND T8."with_convention")
+                 AND T8."with_convention"
+                 AND "geiq_assessments_assessment"."state" IN (%s))
           GROUP BY "geiq_assessments_assessment"."id",
                    34,
                    35,
@@ -5721,6 +6034,392 @@
         'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
           'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: TestListAssessmentsView.test_states_filter[SQL queries]
+  dict({
+    'num_queries': 12,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
+                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   2
+          ORDER BY 2 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" V0
+               WHERE (V0."assessment_id" IN
+                        (SELECT U0."id" AS "pk"
+                         FROM "geiq_assessments_assessment" U0
+                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
+                         WHERE U1."institution_id" = %s
+                         GROUP BY 1)
+                      AND V0."institution_id" = ("institutions_institution"."id")
+                      AND V0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND "geiq_assessments_assessment"."state" IN (%s))
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
       }),

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -4286,6 +4286,8 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
+                          </div>
                       </div>
                   </div>
               </div>
@@ -4646,6 +4648,8 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
+                          </div>
                       </div>
                   </div>
               </div>
@@ -4943,6 +4947,8 @@
                                       </div>
                                   </li>
                               </ul>
+                          </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
                           </div>
                       </div>
                   </div>
@@ -5244,6 +5250,8 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
+                          </div>
                       </div>
                   </div>
               </div>
@@ -5361,6 +5369,8 @@
                                       </div>
                                   </li>
                               </ul>
+                          </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
                           </div>
                       </div>
                   </div>
@@ -5560,6 +5570,8 @@
                                       </div>
                                   </li>
                               </ul>
+                          </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
                           </div>
                       </div>
                   </div>
@@ -6230,6 +6242,8 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
+                          </div>
                       </div>
                   </div>
               </div>
@@ -6417,6 +6431,8 @@
                                       </div>
                                   </li>
                               </ul>
+                          </div>
+                          <div class="ms-md-auto" id="assessments-filter-counter">
                           </div>
                       </div>
                   </div>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2750,7 +2750,7 @@
 # ---
 # name: TestListAssessmentsView.test_campaigns_filter[SQL queries]
   dict({
-    'num_queries': 12,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -2939,8 +2939,56 @@
           '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
-                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -2949,8 +2997,58 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
-                   2
-          ORDER BY 2 DESC
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
         ''',
       }),
       dict({
@@ -2982,26 +3080,18 @@
           FROM "institutions_institution"
           WHERE EXISTS
               (SELECT %s AS "a"
-               FROM "geiq_assessments_assessmentinstitutionlink" V0
-               WHERE (V0."assessment_id" IN
-                        (SELECT U0."id" AS "pk"
-                         FROM "geiq_assessments_assessment" U0
-                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
-                         WHERE U1."institution_id" = %s
-                         GROUP BY 1)
-                      AND V0."institution_id" = ("institutions_institution"."id")
-                      AND V0."with_convention")
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
                LIMIT 1)
           ORDER BY "institutions_institution"."name" ASC
         ''',
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3076,8 +3166,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3096,8 +3186,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3135,9 +3225,9 @@
     ]),
   })
 # ---
-# name: TestListAssessmentsView.test_complex_list[SQL queries]
+# name: TestListAssessmentsView.test_company_filter[SQL queries]
   dict({
-    'num_queries': 15,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -3326,8 +3416,56 @@
           '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
-                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -3336,8 +3474,58 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
-                   2
-          ORDER BY 2 DESC
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
         ''',
       }),
       dict({
@@ -3369,26 +3557,497 @@
           FROM "institutions_institution"
           WHERE EXISTS
               (SELECT %s AS "a"
-               FROM "geiq_assessments_assessmentinstitutionlink" V0
-               WHERE (V0."assessment_id" IN
-                        (SELECT U0."id" AS "pk"
-                         FROM "geiq_assessments_assessment" U0
-                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
-                         WHERE U1."institution_id" = %s
-                         GROUP BY 1)
-                      AND V0."institution_id" = ("institutions_institution"."id")
-                      AND V0."with_convention")
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
                LIMIT 1)
           ORDER BY "institutions_institution"."name" ASC
         ''',
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND "geiq_assessments_assessment"."label_geiq_id" = %s)
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: TestListAssessmentsView.test_complex_list[SQL queries]
+  dict({
+    'num_queries': 17,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
+                                                                                 %s,
+                                                                                 %s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s, %s, %s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3462,8 +4121,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3485,8 +4144,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -3554,7 +4213,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -3632,11 +4291,34 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      5 résultats
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              5 résultats
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="3">
+                                  </option>
+                                  <option value="2">
+                                      Un Beau GEIQ
+                                  </option>
+                                  <option value="1">
+                                      Un Joli GEIQ
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -3680,6 +4362,7 @@
                                   <tr>
                                       <td>
                                           <a class="btn-link" href="/geiq-assessments/institution/22222222-0d2c-4f29-ba5b-a27ffb8ecc84">
+                                              Un Beau GEIQ
                                           </a>
                                       </td>
                                       <td>
@@ -3898,7 +4581,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -3968,11 +4651,38 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      4 résultats
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              4 résultats
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="3">
+                                      Bilan envoyé
+                                  </option>
+                                  <option value="5">
+                                      Bilan validé
+                                  </option>
+                                  <option value="4">
+                                      Bilan à valider
+                                  </option>
+                                  <option value="2">
+                                      Nouveau bilan
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -4169,7 +4879,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -4239,11 +4949,38 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      4 résultats
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              4 résultats
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="3">
+                                      Bilan envoyé
+                                  </option>
+                                  <option value="5">
+                                      Bilan validé
+                                  </option>
+                                  <option value="4">
+                                      Bilan à valider
+                                  </option>
+                                  <option value="2">
+                                      Nouveau bilan
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -4450,7 +5187,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -4512,11 +5249,26 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      0 résultat
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              0 résultat
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="text-center my-3 my-md-4">
                           <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-card-no-result.png"/>
                           <p class="mb-1 mt-3">
@@ -4537,7 +5289,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -4615,11 +5367,29 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      1 résultat
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              1 résultat
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="1">
+                                      Un Joli GEIQ
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -4718,7 +5488,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -4796,11 +5566,29 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      1 résultat
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              1 résultat
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="1">
+                                      Un Joli GEIQ
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -4897,7 +5685,7 @@
 # ---
 # name: TestListAssessmentsView.test_institutions_filter[SQL queries]
   dict({
-    'num_queries': 12,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -5086,8 +5874,56 @@
           '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
-                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -5096,8 +5932,57 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
-                   2
-          ORDER BY 2 DESC
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s), (%s))
         ''',
       }),
       dict({
@@ -5129,26 +6014,18 @@
           FROM "institutions_institution"
           WHERE EXISTS
               (SELECT %s AS "a"
-               FROM "geiq_assessments_assessmentinstitutionlink" V0
-               WHERE (V0."assessment_id" IN
-                        (SELECT U0."id" AS "pk"
-                         FROM "geiq_assessments_assessment" U0
-                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
-                         WHERE U1."institution_id" = %s
-                         GROUP BY 1)
-                      AND V0."institution_id" = ("institutions_institution"."id")
-                      AND V0."with_convention")
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
                LIMIT 1)
           ORDER BY "institutions_institution"."name" ASC
         ''',
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -5210,11 +6087,11 @@
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
           LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
-          INNER JOIN "geiq_assessments_assessmentinstitutionlink" T7 ON ("geiq_assessments_assessment"."id" = T7."assessment_id")
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" T8 ON ("geiq_assessments_assessment"."id" = T8."assessment_id")
           WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
-                 AND T7."institution_id" IN (%s)
-                 AND T7."with_convention")
+                 AND T8."institution_id" IN (%s)
+                 AND T8."with_convention")
           GROUP BY "geiq_assessments_assessment"."id",
                    34,
                    35,
@@ -5225,8 +6102,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -5245,8 +6122,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -5288,7 +6165,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -5358,11 +6235,29 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      1 résultat
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              1 résultat
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="1">
+                                      Un Joli GEIQ
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -5458,7 +6353,7 @@
   '''
   <section class="s-section">
       <div class="s-section__container container">
-          <form hx-get="/geiq-assessments/institution/list" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s">
+          <form hx-get="/geiq-assessments/institution/list" hx-include="#id_company" hx-indicator="#assessments-results" hx-push-url="true" hx-swap="outerHTML" hx-target="#assessments-results" hx-trigger="change delay:.5s, change from:#id_company delay:.5s">
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
@@ -5528,11 +6423,29 @@
               </div>
           </form>
           <div class="s-section__row row">
-              <div class="col-12" id="assessments-results">
-                  <p>
-                      1 résultat
-                  </p>
-                  <section>
+              <div class="col-12">
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="assessments-count">
+                              1 résultat
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_company">
+                                  Nom du GEIQ
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du GEIQ" data-theme="bootstrap-5" id="id_company" lang="fr" name="company">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="1">
+                                      Un Joli GEIQ
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <section id="assessments-results">
                       <div class="table-responsive mt-3 mt-md-4">
                           <table class="table table-hover">
                               <caption class="visually-hidden">
@@ -5626,7 +6539,7 @@
 # ---
 # name: TestListAssessmentsView.test_mishmash[SQL queries]
   dict({
-    'num_queries': 15,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -5815,8 +6728,56 @@
           '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
-                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -5825,8 +6786,58 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
-                   2
-          ORDER BY 2 DESC
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s), (%s))
         ''',
       }),
       dict({
@@ -5858,26 +6869,18 @@
           FROM "institutions_institution"
           WHERE EXISTS
               (SELECT %s AS "a"
-               FROM "geiq_assessments_assessmentinstitutionlink" V0
-               WHERE (V0."assessment_id" IN
-                        (SELECT U0."id" AS "pk"
-                         FROM "geiq_assessments_assessment" U0
-                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
-                         WHERE U1."institution_id" = %s
-                         GROUP BY 1)
-                      AND V0."institution_id" = ("institutions_institution"."id")
-                      AND V0."with_convention")
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
                LIMIT 1)
           ORDER BY "institutions_institution"."name" ASC
         ''',
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -5945,7 +6948,8 @@
                  AND "geiq_assessments_assessment"."campaign_id" IN (%s)
                  AND T8."institution_id" IN (%s)
                  AND T8."with_convention"
-                 AND "geiq_assessments_assessment"."state" IN (%s))
+                 AND "geiq_assessments_assessment"."state" IN (%s)
+                 AND "geiq_assessments_assessment"."label_geiq_id" = %s)
           GROUP BY "geiq_assessments_assessment"."id",
                    34,
                    35,
@@ -5956,8 +6960,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -5975,8 +6979,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -6042,7 +7046,7 @@
 # ---
 # name: TestListAssessmentsView.test_states_filter[SQL queries]
   dict({
-    'num_queries': 12,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -6231,8 +7235,56 @@
           '_check_request_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
-                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
           FROM "geiq_assessments_assessment"
           INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
           LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
@@ -6241,8 +7293,59 @@
           INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
           WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
           GROUP BY "geiq_assessments_assessment"."id",
-                   2
-          ORDER BY 2 DESC
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s,
+                                                                                 %s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
         ''',
       }),
       dict({
@@ -6274,26 +7377,18 @@
           FROM "institutions_institution"
           WHERE EXISTS
               (SELECT %s AS "a"
-               FROM "geiq_assessments_assessmentinstitutionlink" V0
-               WHERE (V0."assessment_id" IN
-                        (SELECT U0."id" AS "pk"
-                         FROM "geiq_assessments_assessment" U0
-                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
-                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
-                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
-                         WHERE U1."institution_id" = %s
-                         GROUP BY 1)
-                      AND V0."institution_id" = ("institutions_institution"."id")
-                      AND V0."with_convention")
+               FROM "geiq_assessments_assessmentinstitutionlink" U0
+               WHERE (U0."assessment_id" IN (%s, %s, %s, %s)
+                      AND U0."institution_id" = ("institutions_institution"."id")
+                      AND U0."with_convention")
                LIMIT 1)
           ORDER BY "institutions_institution"."name" ASC
         ''',
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -6368,8 +7463,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',
@@ -6387,8 +7482,8 @@
       }),
       dict({
         'origin': list([
-          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
-          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'VariableNode[geiq_assessments_views/list_for_institution.html]',
+          'PartialDefNode[geiq_assessments_views/list_for_institution.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
           'list_for_institution[www/geiq_assessments_views/views.py]',

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2748,9 +2748,9 @@
   
   '''
 # ---
-# name: TestListAssessmentsView.test_complex_list[SQL queries]
+# name: TestListAssessmentsView.test_campaigns_filter[SQL queries]
   dict({
-    'num_queries': 14,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -2931,6 +2931,414 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
+                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   2
+          ORDER BY 2 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" V0
+               WHERE (V0."assessment_id" IN
+                        (SELECT U0."id" AS "pk"
+                         FROM "geiq_assessments_assessment" U0
+                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
+                         WHERE U1."institution_id" = %s
+                         GROUP BY 1)
+                      AND V0."institution_id" = ("institutions_institution"."id")
+                      AND V0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND "geiq_assessments_assessment"."campaign_id" IN (%s))
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s,
+                                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: TestListAssessmentsView.test_complex_list[SQL queries]
+  dict({
+    'num_queries': 15,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
+                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   2
+          ORDER BY 2 DESC
+        ''',
       }),
       dict({
         'origin': list([
@@ -3150,6 +3558,21 @@
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
@@ -3442,6 +3865,21 @@
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
@@ -3657,6 +4095,21 @@
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
@@ -3886,6 +4339,13 @@
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
@@ -3925,6 +4385,21 @@
               <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                   <div class="col-12">
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
@@ -4054,6 +4529,21 @@
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
@@ -4173,7 +4663,7 @@
 # ---
 # name: TestListAssessmentsView.test_institutions_filter[SQL queries]
   dict({
-    'num_queries': 11,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -4354,6 +4844,27 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
+                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   2
+          ORDER BY 2 DESC
+        ''',
       }),
       dict({
         'origin': list([
@@ -4549,6 +5060,21 @@
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
@@ -4665,6 +5191,21 @@
                       <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                           <div class="dropdown">
                               <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
+                                  Campagne
+                              </button>
+                              <ul class="dropdown-menu">
+                                  <li class="dropdown-item">
+                                      <div class="form-check">
+                                          <input class="form-check-input" id="id_campaigns_0" name="campaigns" type="checkbox" value="[PK of Campaign]"/>
+                                          <label class="form-check-label" for="id_campaigns_0">
+                                              2024
+                                          </label>
+                                      </div>
+                                  </li>
+                              </ul>
+                          </div>
+                          <div class="dropdown">
+                              <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-display="static" data-bs-toggle="dropdown" type="button">
                                   Référent
                               </button>
                               <ul class="dropdown-menu">
@@ -4770,4 +5311,419 @@
   </section>
   
   '''
+# ---
+# name: TestListAssessmentsView.test_mishmash[SQL queries]
+  dict({
+    'num_queries': 15,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "geiq_assessments_assessment"."campaign_id" AS "campaign__pk",
+                          "geiq_assessments_assessmentcampaign"."year" AS "campaign__year"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+          GROUP BY "geiq_assessments_assessment"."id",
+                   2
+          ORDER BY 2 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'AssessmentsFilterForInstitutionForm._get_choices_for_institutions[www/geiq_assessments_views/forms.py]',
+          'AssessmentsFilterForInstitutionForm.__init__[www/geiq_assessments_views/forms.py]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "geiq_assessments_assessmentinstitutionlink" V0
+               WHERE (V0."assessment_id" IN
+                        (SELECT U0."id" AS "pk"
+                         FROM "geiq_assessments_assessment" U0
+                         INNER JOIN "geiq_assessments_assessmentinstitutionlink" U1 ON (U0."id" = U1."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U3 ON (U0."id" = U3."assessment_id")
+                         LEFT OUTER JOIN "geiq_assessments_employeecontract" U4 ON (U3."id" = U4."employee_id")
+                         LEFT OUTER JOIN "geiq_assessments_employee" U5 ON (U4."employee_id" = U5."id")
+                         WHERE U1."institution_id" = %s
+                         GROUP BY 1)
+                      AND V0."institution_id" = ("institutions_institution"."id")
+                      AND V0."with_convention")
+               LIMIT 1)
+          ORDER BY "institutions_institution"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE "geiq_assessments_employeecontract"."allowance_requested") AS "contracts_nb",
+                 CASE
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     WHEN "geiq_assessments_assessment"."state" = %s THEN %s
+                     ELSE %s
+                 END AS "state_order",
+                 GREATEST("geiq_assessments_assessment"."created_at", "geiq_assessments_assessment"."decision_validated_at", "geiq_assessments_assessment"."grants_selection_validated_at", "geiq_assessments_assessment"."reviewed_at", "geiq_assessments_assessment"."final_reviewed_at") AS "last_updated_at",
+                 SUM(T6."allowance_amount") FILTER (
+                                                    WHERE "geiq_assessments_employeecontract"."allowance_granted") AS "potential_allowance_amount",
+                 "geiq_assessments_assessment"."reviewed_at" IS NOT NULL AS "can_view_amounts",
+                                                                            "geiq_assessments_assessmentcampaign"."id",
+                                                                            "geiq_assessments_assessmentcampaign"."year",
+                                                                            "geiq_assessments_assessmentcampaign"."opening_date",
+                                                                            "geiq_assessments_assessmentcampaign"."submission_deadline",
+                                                                            "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_assessment"
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_employee"."assessment_id")
+          LEFT OUTER JOIN "geiq_assessments_employeecontract" ON ("geiq_assessments_employee"."id" = "geiq_assessments_employeecontract"."employee_id")
+          LEFT OUTER JOIN "geiq_assessments_employee" T6 ON ("geiq_assessments_employeecontract"."employee_id" = T6."id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" T8 ON ("geiq_assessments_assessment"."id" = T8."assessment_id")
+          WHERE ("geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND "geiq_assessments_assessment"."campaign_id" IN (%s)
+                 AND T8."institution_id" IN (%s)
+                 AND T8."with_convention")
+          GROUP BY "geiq_assessments_assessment"."id",
+                   34,
+                   35,
+                   "geiq_assessments_assessmentcampaign"."id"
+          ORDER BY 34 ASC,
+                   35 DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessmentinstitutionlink"."id",
+                 "geiq_assessments_assessmentinstitutionlink"."assessment_id",
+                 "geiq_assessments_assessmentinstitutionlink"."institution_id",
+                 "geiq_assessments_assessmentinstitutionlink"."with_convention"
+          FROM "geiq_assessments_assessmentinstitutionlink"
+          WHERE "geiq_assessments_assessmentinstitutionlink"."assessment_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'VariableNode[geiq_assessments_views/includes/assessments_list_results_for_institutions.html]',
+          'IncludeNode[geiq_assessments_views/list_for_institution.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[geiq_assessments_views/list_for_institution.html]',
+          'list_for_institution[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE ("institutions_institution"."id") IN ((%s), (%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Session.save[<site-packages>/django/db/models/base.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
 # ---

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -536,7 +536,108 @@ class TestListAssessmentsView:
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
         )
 
+    @freeze_time("2025-05-21 12:00", tick=True)
+    def test_states_filter(self, client, snapshot):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
+        campaign = AssessmentCampaignFactory()
+
+        assessment_new = AssessmentFactory(campaign=campaign)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_new, institution=membership.institution)
+
+        assessment_submitted = AssessmentFactory(
+            campaign=campaign,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=80_000,
+        )
+        AssessmentInstitutionLink.objects.create(assessment=assessment_submitted, institution=membership.institution)
+
+        assessment_reviewed = AssessmentFactory(
+            campaign=campaign,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=80_000,
+            review_comment="Bravo !",
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_by=membership.user,
+            reviewed_by_institution=membership.institution,
+        )
+        AssessmentInstitutionLink.objects.create(assessment=assessment_reviewed, institution=membership.institution)
+
+        assessment_final_reviewed = AssessmentFactory(
+            campaign=campaign,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=80_000,
+            review_comment="Bravo !",
+            decision_validated_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_at=timezone.now() + datetime.timedelta(hours=5),
+            reviewed_by=membership.user,
+            reviewed_by_institution=membership.institution,
+            final_reviewed_at=timezone.now() + datetime.timedelta(hours=6),
+            final_reviewed_by=membership.user,
+            final_reviewed_by_institution=membership.institution,
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_final_reviewed, institution=membership.institution
+        )
+
+        # Another unlinked assessment that should not be seen anywhere
+        AssessmentFactory(campaign=campaign)
+
+        client.force_login(membership.user)
+        # No filter
+        response = client.get(self.URL)
+        assertQuerySetEqual(
+            response.context["assessments"],
+            [assessment_new, assessment_submitted, assessment_reviewed, assessment_final_reviewed],
+            ordered=False,
+        )
+
+        # Filter on NEW
+        with assertSnapshotQueries(snapshot(name="SQL queries")):
+            response = client.get(self.URL, {"states": AssessmentState.NEW.value})
+        assertQuerySetEqual(response.context["assessments"], [assessment_new], ordered=False)
+
+        # Filter on SUBMITTED
+        response = client.get(self.URL, {"states": AssessmentState.SUBMITTED.value})
+        assertQuerySetEqual(response.context["assessments"], [assessment_submitted], ordered=False)
+
+        # Filter on both REVIEWED and FINAL_REVIEWED
+        response = client.get(
+            self.URL, {"states": [AssessmentState.REVIEWED.value, AssessmentState.FINAL_REVIEWED.value]}
+        )
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_reviewed, assessment_final_reviewed], ordered=False
+        )
+
+        # Invalid data: do nothing, ie. do not filter
+        response = client.get(self.URL, {"states": "invalid"})
+        assertQuerySetEqual(
+            response.context["assessments"],
+            [assessment_new, assessment_submitted, assessment_reviewed, assessment_final_reviewed],
+            ordered=False,
+        )
+
     def test_mishmash(self, client, snapshot):
+        geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
         membership = InstitutionMembershipFactory(
             institution__kind=InstitutionKind.DREETS_GEIQ,
             institution__name="Un DREETS GEIQ",
@@ -545,13 +646,28 @@ class TestListAssessmentsView:
         campaign_2023 = AssessmentCampaignFactory(year=2023)
         campaign_2024 = AssessmentCampaignFactory(year=2024)
 
-        assessment_2023_ddets = AssessmentFactory(campaign=campaign_2023)
+        assessment_2023_ddets = AssessmentFactory(
+            campaign=campaign_2023,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+        )
         AssessmentInstitutionLink.objects.create(assessment=assessment_2023_ddets, institution=membership.institution)
         AssessmentInstitutionLink.objects.create(
             assessment=assessment_2023_ddets, institution=ddets, with_convention=True
         )
 
-        assessment_2024_ddets_dreets = AssessmentFactory(campaign=campaign_2024)
+        assessment_2024_ddets_dreets = AssessmentFactory(
+            campaign=campaign_2024,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+            review_comment="Bravo !",
+            convention_amount=100_000,
+            advance_amount=50_000,
+            granted_amount=100_000,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(hours=4),
+        )
         AssessmentInstitutionLink.objects.create(
             assessment=assessment_2024_ddets_dreets, institution=membership.institution, with_convention=True
         )
@@ -562,12 +678,17 @@ class TestListAssessmentsView:
         client.force_login(membership.user)
 
         with assertSnapshotQueries(snapshot(name="SQL queries")):
-            # Select the DDETS only, and the 2023 campaign
-            response = client.get(self.URL, {"institutions": ddets.pk, "campaigns": campaign_2023.pk})
+            # Select the DDETS only, the 2023 campaign and the SUBMITTED state
+            response = client.get(
+                self.URL,
+                {"institutions": ddets.pk, "campaigns": campaign_2023.pk, "states": AssessmentState.SUBMITTED.value},
+            )
         assertQuerySetEqual(response.context["assessments"], [assessment_2023_ddets], ordered=False)
 
         # One invalid data: all the filters are sadly ignored
-        response = client.get(self.URL, {"institutions": ddets.pk, "campaigns": "invalid"})
+        response = client.get(
+            self.URL, {"institutions": ddets.pk, "campaigns": "invalid", "states": AssessmentState.SUBMITTED.value}
+        )
         assertQuerySetEqual(
             response.context["assessments"], [assessment_2023_ddets, assessment_2024_ddets_dreets], ordered=False
         )

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -67,6 +67,7 @@ class TestListAssessmentsView:
         AssessmentFactory(
             campaign=campaign,
             with_main_geiq=True,
+            label_geiq_id=1,
             label_geiq_name="Un Joli GEIQ",
             label_geiq_post_code="12345",
             label_antennas=[{"id": 1234, "name": "Une antenne", "post_code": "12345"}],
@@ -108,11 +109,13 @@ class TestListAssessmentsView:
             id=uuid.UUID("00000000-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
             with_main_geiq=True,
+            label_geiq_id=2,
             label_geiq_name="Nouveau bilan",
         )
         submitted = AssessmentFactory(
             id=uuid.UUID("11111111-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
+            label_geiq_id=3,
             label_geiq_name="Bilan envoyé",
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -126,6 +129,7 @@ class TestListAssessmentsView:
         reviewed = AssessmentFactory(
             id=uuid.UUID("22222222-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
+            label_geiq_id=4,
             label_geiq_name="Bilan à valider",
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -143,6 +147,7 @@ class TestListAssessmentsView:
         final_reviewed = AssessmentFactory(
             id=uuid.UUID("33333333-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
+            label_geiq_id=5,
             label_geiq_name="Bilan validé",
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -202,6 +207,7 @@ class TestListAssessmentsView:
             id=uuid.UUID("00000000-0d2c-4f29-ba5b-a27ffb8ecc84"),
             campaign=campaign,
             with_main_geiq=True,
+            label_geiq_id=1,
             label_geiq_name="Un Joli GEIQ",
             label_geiq_post_code="12345",
             label_antennas=[{"id": 1234, "name": "Une antenne", "post_code": "12345"}],
@@ -241,6 +247,7 @@ class TestListAssessmentsView:
             created_by__first_name="Jean",
             created_by__last_name="Dupont",
             with_main_geiq=True,
+            label_geiq_id=1,
             label_geiq_name="Un Joli GEIQ",
             label_geiq_post_code="12345",
             label_antennas=[{"id": 1234, "name": "Une antenne", "post_code": "12345"}],
@@ -254,6 +261,7 @@ class TestListAssessmentsView:
             created_by__first_name="Marie",
             created_by__last_name="Curie",
             with_main_geiq=True,
+            label_geiq_id=2,
             label_geiq_name="Un Beau GEIQ",
             label_geiq_post_code="23456",
             with_submission_requirements=True,
@@ -270,6 +278,8 @@ class TestListAssessmentsView:
             campaign=campaign,
             created_by__first_name="Marie",
             created_by__last_name="Curie",
+            label_geiq_id=2,
+            label_geiq_name="Un Beau GEIQ",  # Should be listed once in the filter select
             label_antennas=[{"id": 1, "name": "Un Superbe GEIQ", "post_code": "12345"}],
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -292,6 +302,7 @@ class TestListAssessmentsView:
             campaign=campaign,
             created_by__first_name="Marie",
             created_by__last_name="Curie",
+            label_geiq_id=3,
             label_antennas=[{"id": 1, "name": "Un Superbe GEIQ", "post_code": "12345"}],
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -317,6 +328,7 @@ class TestListAssessmentsView:
             campaign=campaign,
             created_by__first_name="Marie",
             created_by__last_name="Curie",
+            label_geiq_id=3,
             label_antennas=[{"id": 1, "name": "Un Superbe GEIQ", "post_code": "12345"}],
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
@@ -636,6 +648,52 @@ class TestListAssessmentsView:
             ordered=False,
         )
 
+    @freeze_time("2025-05-21 12:00", tick=True)
+    def test_company_filter(self, client, snapshot):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        campaign = AssessmentCampaignFactory()
+
+        assessment_almond = AssessmentFactory(campaign=campaign, label_geiq_id=1, label_geiq_name="GEIQ Amande")
+        AssessmentInstitutionLink.objects.create(assessment=assessment_almond, institution=membership.institution)
+
+        assessment_almond2 = AssessmentFactory(
+            campaign=campaign,
+            label_geiq_id=assessment_almond.label_geiq_id,
+            label_geiq_name=assessment_almond.label_geiq_name,
+        )
+        AssessmentInstitutionLink.objects.create(assessment=assessment_almond2, institution=membership.institution)
+
+        assessment_cashew = AssessmentFactory(campaign=campaign, label_geiq_id=2, label_geiq_name="GEIQ Cajou")
+        AssessmentInstitutionLink.objects.create(assessment=assessment_cashew, institution=membership.institution)
+
+        # Another unlinked assessment that should not be seen anywhere
+        AssessmentFactory(campaign=campaign)
+
+        client.force_login(membership.user)
+        # No filter
+        response = client.get(self.URL)
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_almond, assessment_almond2, assessment_cashew], ordered=False
+        )
+
+        # Filter on GEIQ Amande
+        with assertSnapshotQueries(snapshot(name="SQL queries")):
+            response = client.get(self.URL, {"company": "1"})
+        assertQuerySetEqual(response.context["assessments"], [assessment_almond, assessment_almond2], ordered=False)
+
+        # If several companies are provided, only the last one is used
+        response = client.get(self.URL, {"company": ["2", "1"]})
+        assertQuerySetEqual(response.context["assessments"], [assessment_almond, assessment_almond2], ordered=False)
+
+        # Invalid data: do nothing, ie. do not filter
+        response = client.get(self.URL, {"company": "invalid"})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_almond, assessment_almond2, assessment_cashew], ordered=False
+        )
+
     def test_mishmash(self, client, snapshot):
         geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
         membership = InstitutionMembershipFactory(
@@ -646,19 +704,39 @@ class TestListAssessmentsView:
         campaign_2023 = AssessmentCampaignFactory(year=2023)
         campaign_2024 = AssessmentCampaignFactory(year=2024)
 
-        assessment_2023_ddets = AssessmentFactory(
+        assessment_2023_ddets_almond = AssessmentFactory(
             campaign=campaign_2023,
+            label_geiq_id=1,
+            label_geiq_name="GEIQ Amande",
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
             submitted_by=geiq_membership.user,
         )
-        AssessmentInstitutionLink.objects.create(assessment=assessment_2023_ddets, institution=membership.institution)
         AssessmentInstitutionLink.objects.create(
-            assessment=assessment_2023_ddets, institution=ddets, with_convention=True
+            assessment=assessment_2023_ddets_almond, institution=membership.institution
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2023_ddets_almond, institution=ddets, with_convention=True
+        )
+        assessment_2023_ddets_cashew = AssessmentFactory(
+            campaign=campaign_2023,
+            label_geiq_id=2,
+            label_geiq_name="GEIQ Cajou",
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(hours=3),
+            submitted_by=geiq_membership.user,
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2023_ddets_cashew, institution=membership.institution
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2023_ddets_cashew, institution=ddets, with_convention=True
         )
 
         assessment_2024_ddets_dreets = AssessmentFactory(
             campaign=campaign_2024,
+            label_geiq_id=2,
+            label_geiq_name="GEIQ Cajou",
             with_submission_requirements=True,
             submitted_at=timezone.now() + datetime.timedelta(hours=3),
             submitted_by=geiq_membership.user,
@@ -678,19 +756,32 @@ class TestListAssessmentsView:
         client.force_login(membership.user)
 
         with assertSnapshotQueries(snapshot(name="SQL queries")):
-            # Select the DDETS only, the 2023 campaign and the SUBMITTED state
+            # Select the DDETS only, the 2023 campaign, the SUBMITTED state and GEIQ Amande
             response = client.get(
                 self.URL,
-                {"institutions": ddets.pk, "campaigns": campaign_2023.pk, "states": AssessmentState.SUBMITTED.value},
+                {
+                    "institutions": ddets.pk,
+                    "campaigns": campaign_2023.pk,
+                    "states": AssessmentState.SUBMITTED.value,
+                    "company": "1",
+                },
             )
-        assertQuerySetEqual(response.context["assessments"], [assessment_2023_ddets], ordered=False)
+        assertQuerySetEqual(response.context["assessments"], [assessment_2023_ddets_almond], ordered=False)
 
         # One invalid data: all the filters are sadly ignored
         response = client.get(
-            self.URL, {"institutions": ddets.pk, "campaigns": "invalid", "states": AssessmentState.SUBMITTED.value}
+            self.URL,
+            {
+                "institutions": ddets.pk,
+                "campaigns": "invalid",
+                "states": AssessmentState.SUBMITTED.value,
+                "company": "2",
+            },
         )
         assertQuerySetEqual(
-            response.context["assessments"], [assessment_2023_ddets, assessment_2024_ddets_dreets], ordered=False
+            response.context["assessments"],
+            [assessment_2023_ddets_almond, assessment_2023_ddets_cashew, assessment_2024_ddets_dreets],
+            ordered=False,
         )
 
     @freeze_time("2025-05-21 12:00", tick=True)

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -74,9 +74,15 @@ class TestListAssessmentsView:
 
         client.force_login(user)
         response = client.get(self.URL)
-        assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessment list without links to details"
-        )
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                ".s-section",
+                replace_in_attr=[
+                    ("value", f"{campaign.pk}", "[PK of Campaign]"),
+                ],
+            )
+        ) == snapshot(name="assessment list without links to details")
 
     @pytest.mark.parametrize("with_limited_access", [True, False], ids=["limited access", "unlimited access"])
     def test_display_amounts(self, client, with_limited_access, snapshot):
@@ -172,9 +178,15 @@ class TestListAssessmentsView:
 
         client.force_login(membership.user)
         response = client.get(self.URL)
-        assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessment list with amounts"
-        )
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                ".s-section",
+                replace_in_attr=[
+                    ("value", f"{campaign.pk}", "[PK of Campaign]"),
+                ],
+            )
+        ) == snapshot(name="assessment list with amounts")
 
     @pytest.mark.parametrize(
         "institution_kind",
@@ -208,6 +220,7 @@ class TestListAssessmentsView:
                 response,
                 ".s-section",
                 replace_in_attr=[
+                    ("value", f"{campaign.pk}", "[PK of Campaign]"),
                     ("value", f"{membership.institution.pk}", "[PK of Institution]"),
                 ],
             )
@@ -333,6 +346,7 @@ class TestListAssessmentsView:
                 response,
                 ".s-section",
                 replace_in_attr=[
+                    ("value", f"{campaign.pk}", "[PK of Campaign]"),
                     ("value", f"{membership.institution.pk}", "[PK of Institution]"),
                 ],
             )
@@ -418,6 +432,57 @@ class TestListAssessmentsView:
         assert context_potential_amout == expected_potential_amout
 
     @freeze_time("2025-05-21 12:00", tick=True)
+    def test_campaigns_filter(self, client, snapshot):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        campaign_2023 = AssessmentCampaignFactory(year=2023)
+        campaign_2024 = AssessmentCampaignFactory(year=2024)
+
+        assessment_2023 = AssessmentFactory(campaign=campaign_2023)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_2023, institution=membership.institution)
+
+        assessment_2024 = AssessmentFactory(campaign=campaign_2024)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_2024, institution=membership.institution)
+
+        another_assessment_2024 = AssessmentFactory(campaign=campaign_2024)
+        AssessmentInstitutionLink.objects.create(
+            assessment=another_assessment_2024, institution=membership.institution
+        )
+
+        # Another unlinked assessment that should not be seen anywhere
+        AssessmentFactory(campaign=campaign_2024)
+
+        client.force_login(membership.user)
+        # No filter
+        response = client.get(self.URL)
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
+        )
+
+        # Filter on 2024
+        with assertSnapshotQueries(snapshot(name="SQL queries")):
+            response = client.get(self.URL, {"campaigns": campaign_2024.pk})
+        assertQuerySetEqual(response.context["assessments"], [assessment_2024, another_assessment_2024], ordered=False)
+
+        # Filter on 2023
+        response = client.get(self.URL, {"campaigns": campaign_2023.pk})
+        assertQuerySetEqual(response.context["assessments"], [assessment_2023])
+
+        # Filter on both 2023 and 2024
+        response = client.get(self.URL, {"campaigns": [campaign_2023.pk, campaign_2024.pk]})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
+        )
+
+        # Invalid data: do nothing, ie. do not filter
+        response = client.get(self.URL, {"campaigns": "invalid"})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
+        )
+
+    @freeze_time("2025-05-21 12:00", tick=True)
     def test_institutions_filter(self, client, snapshot):
         membership = InstitutionMembershipFactory(
             institution__kind=InstitutionKind.DREETS_GEIQ,
@@ -469,6 +534,42 @@ class TestListAssessmentsView:
         response = client.get(self.URL, {"institutions": "invalid"})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
+        )
+
+    def test_mishmash(self, client, snapshot):
+        membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            institution__name="Un DREETS GEIQ",
+        )
+        ddets = InstitutionFactory(kind=InstitutionKind.DDETS_GEIQ, name="Une DDETS GEIQ")
+        campaign_2023 = AssessmentCampaignFactory(year=2023)
+        campaign_2024 = AssessmentCampaignFactory(year=2024)
+
+        assessment_2023_ddets = AssessmentFactory(campaign=campaign_2023)
+        AssessmentInstitutionLink.objects.create(assessment=assessment_2023_ddets, institution=membership.institution)
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2023_ddets, institution=ddets, with_convention=True
+        )
+
+        assessment_2024_ddets_dreets = AssessmentFactory(campaign=campaign_2024)
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2024_ddets_dreets, institution=membership.institution, with_convention=True
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment_2024_ddets_dreets, institution=ddets, with_convention=True
+        )
+
+        client.force_login(membership.user)
+
+        with assertSnapshotQueries(snapshot(name="SQL queries")):
+            # Select the DDETS only, and the 2023 campaign
+            response = client.get(self.URL, {"institutions": ddets.pk, "campaigns": campaign_2023.pk})
+        assertQuerySetEqual(response.context["assessments"], [assessment_2023_ddets], ordered=False)
+
+        # One invalid data: all the filters are sadly ignored
+        response = client.get(self.URL, {"institutions": ddets.pk, "campaigns": "invalid"})
+        assertQuerySetEqual(
+            response.context["assessments"], [assessment_2023_ddets, assessment_2024_ddets_dreets], ordered=False
         )
 
     @freeze_time("2025-05-21 12:00", tick=True)

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from itoutils.django.testing import assertSnapshotQueries
-from pytest_django.asserts import assertContains, assertQuerySetEqual, assertRedirects
+from pytest_django.asserts import assertContains, assertNotContains, assertQuerySetEqual, assertRedirects
 
 from itou.companies.enums import CompanyKind
 from itou.geiq_assessments.enums import AssessmentState, AssessmentTransition
@@ -32,6 +32,7 @@ from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 class TestListAssessmentsView:
     URL = reverse("geiq_assessments_views:list_for_institution")
+    RESET_BTN_MARKUP = "<span>Effacer tout</span>"
 
     def test_anonymous_access(self, client):
         response = client.get(self.URL)
@@ -472,27 +473,32 @@ class TestListAssessmentsView:
         assertQuerySetEqual(
             response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on 2024
         with assertSnapshotQueries(snapshot(name="SQL queries")):
             response = client.get(self.URL, {"campaigns": campaign_2024.pk})
         assertQuerySetEqual(response.context["assessments"], [assessment_2024, another_assessment_2024], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on 2023
         response = client.get(self.URL, {"campaigns": campaign_2023.pk})
         assertQuerySetEqual(response.context["assessments"], [assessment_2023])
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on both 2023 and 2024
         response = client.get(self.URL, {"campaigns": [campaign_2023.pk, campaign_2024.pk]})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
         )
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Invalid data: do nothing, ie. do not filter
         response = client.get(self.URL, {"campaigns": "invalid"})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_2023, assessment_2024, another_assessment_2024], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
     @freeze_time("2025-05-21 12:00", tick=True)
     def test_institutions_filter(self, client, snapshot):
@@ -525,6 +531,7 @@ class TestListAssessmentsView:
         assertQuerySetEqual(
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on the DDETS
         with assertSnapshotQueries(snapshot(name="SQL queries")):
@@ -532,21 +539,25 @@ class TestListAssessmentsView:
         assertQuerySetEqual(
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
         )
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on the DREETS
         response = client.get(self.URL, {"institutions": membership.institution.pk})
         assertQuerySetEqual(response.context["assessments"], [assessment_dreets_ddets])
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
         # Filter on both the DDETS and the DREETS
         response = client.get(self.URL, {"institutions": [membership.institution.pk, ddets.pk]})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
         )
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Invalid data: do nothing, ie. do not filter
         response = client.get(self.URL, {"institutions": "invalid"})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_dreets_ddets, assessment_ddets], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
     @freeze_time("2025-05-21 12:00", tick=True)
     def test_states_filter(self, client, snapshot):
@@ -622,15 +633,18 @@ class TestListAssessmentsView:
             [assessment_new, assessment_submitted, assessment_reviewed, assessment_final_reviewed],
             ordered=False,
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on NEW
         with assertSnapshotQueries(snapshot(name="SQL queries")):
             response = client.get(self.URL, {"states": AssessmentState.NEW.value})
         assertQuerySetEqual(response.context["assessments"], [assessment_new], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on SUBMITTED
         response = client.get(self.URL, {"states": AssessmentState.SUBMITTED.value})
         assertQuerySetEqual(response.context["assessments"], [assessment_submitted], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on both REVIEWED and FINAL_REVIEWED
         response = client.get(
@@ -639,6 +653,7 @@ class TestListAssessmentsView:
         assertQuerySetEqual(
             response.context["assessments"], [assessment_reviewed, assessment_final_reviewed], ordered=False
         )
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Invalid data: do nothing, ie. do not filter
         response = client.get(self.URL, {"states": "invalid"})
@@ -647,6 +662,7 @@ class TestListAssessmentsView:
             [assessment_new, assessment_submitted, assessment_reviewed, assessment_final_reviewed],
             ordered=False,
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
     @freeze_time("2025-05-21 12:00", tick=True)
     def test_company_filter(self, client, snapshot):
@@ -678,21 +694,25 @@ class TestListAssessmentsView:
         assertQuerySetEqual(
             response.context["assessments"], [assessment_almond, assessment_almond2, assessment_cashew], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Filter on GEIQ Amande
         with assertSnapshotQueries(snapshot(name="SQL queries")):
             response = client.get(self.URL, {"company": "1"})
         assertQuerySetEqual(response.context["assessments"], [assessment_almond, assessment_almond2], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # If several companies are provided, only the last one is used
         response = client.get(self.URL, {"company": ["2", "1"]})
         assertQuerySetEqual(response.context["assessments"], [assessment_almond, assessment_almond2], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # Invalid data: do nothing, ie. do not filter
         response = client.get(self.URL, {"company": "invalid"})
         assertQuerySetEqual(
             response.context["assessments"], [assessment_almond, assessment_almond2, assessment_cashew], ordered=False
         )
+        assertNotContains(response, self.RESET_BTN_MARKUP, html=True)
 
     def test_mishmash(self, client, snapshot):
         geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
@@ -767,6 +787,7 @@ class TestListAssessmentsView:
                 },
             )
         assertQuerySetEqual(response.context["assessments"], [assessment_2023_ddets_almond], ordered=False)
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
         # One invalid data: all the filters are sadly ignored
         response = client.get(
@@ -783,6 +804,8 @@ class TestListAssessmentsView:
             [assessment_2023_ddets_almond, assessment_2023_ddets_cashew, assessment_2024_ddets_dreets],
             ordered=False,
         )
+        # one or more fields are valid so display the reset button
+        assertContains(response, self.RESET_BTN_MARKUP, html=True)
 
     @freeze_time("2025-05-21 12:00", tick=True)
     def test_filters_htmx(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les DREETS peuvent se retrouver avec beaucoup de bilans à contrôler. Les filtrer est une fonctionnalité attendue.

Cette PR met en place les filtres Campagne, Statut et Nom du GEIQ.

[Carte Notion](https://app.notion.com/p/gip-inclusion/Ajouter-des-filtres-l-espace-de-suivi-des-bilans-geiq-33c5f321b604803abf75dab884efc2f8?v=2845f321b60480bd9ef6000c92a2d6ab&source=copy_link)

