### PR TITLE
GEIQ : Se baser sur `state` pour le rendu des badges des bilans

### DIFF
--- a/itou/www/geiq_assessments_views/templatetags/geiq_assessments_badges.py
+++ b/itou/www/geiq_assessments_views/templatetags/geiq_assessments_badges.py
@@ -1,6 +1,7 @@
 from django import template
 from django.utils.html import format_html
 
+from itou.geiq_assessments.enums import AssessmentState
 from itou.utils.templatetags.format_filters import formatfloat_with_unit
 
 
@@ -9,18 +10,21 @@ register = template.Library()
 
 @register.simple_tag
 def state_for_institution(assessment, *, extra_classes="badge-sm"):
-    if not assessment.submitted_at:
-        text = "En attente"
-        state_classes = "bg-warning"
-    elif not assessment.reviewed_at:
-        text = "À contrôler"
-        state_classes = "bg-accent-03 text-primary"
-    elif not assessment.final_reviewed_at:
-        text = "À valider"
-        state_classes = "bg-info"
-    else:
-        text = "Validé"
-        state_classes = "bg-success"
+    match assessment.state:
+        case AssessmentState.NEW:
+            text = "En attente"
+            state_classes = "bg-warning"
+        case AssessmentState.SUBMITTED:
+            text = "À contrôler"
+            state_classes = "bg-accent-03 text-primary"
+        case AssessmentState.REVIEWED:
+            text = "À valider"
+            state_classes = "bg-info"
+        case AssessmentState.FINAL_REVIEWED:
+            text = "Validé"
+            state_classes = "bg-success"
+        case _:
+            raise ValueError(f"Wrong state {assessment.state}")
 
     class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes}"
     return format_html('<span class="{}">{}</span>', class_attr, text)
@@ -28,15 +32,18 @@ def state_for_institution(assessment, *, extra_classes="badge-sm"):
 
 @register.simple_tag
 def state_for_geiq(assessment, *, extra_classes="badge-sm"):
-    if not assessment.submitted_at:
-        text = "À compléter"
-        state_classes = "bg-info"
-    elif not assessment.final_reviewed_at:
-        text = "Envoyé"
-        state_classes = "text-info bg-info-lightest"
-    else:
-        text = "Traité"
-        state_classes = "text-success bg-success-lightest"
+    match assessment.state:
+        case AssessmentState.NEW:
+            text = "À compléter"
+            state_classes = "bg-info"
+        case AssessmentState.SUBMITTED | AssessmentState.REVIEWED:
+            text = "Envoyé"
+            state_classes = "text-info bg-info-lightest"
+        case AssessmentState.FINAL_REVIEWED:
+            text = "Traité"
+            state_classes = "text-success bg-success-lightest"
+        case _:
+            raise ValueError("Wrong state {assessment.state}")
 
     class_attr = f"badge rounded-pill text-nowrap {extra_classes} {state_classes}"
     return format_html('<span class="{}">{}</span>', class_attr, text)


### PR DESCRIPTION
## :thinking: Pourquoi ?

C’est plus cohérent que de recalculer à partir des timestamps `*_at`.
Et les contraintes en base de données nous rassurent, ça devrait revenir exactement au même.

