### PR TITLE
Structure d'insertion : ajout de la liste des services

### DIFF
--- a/itou/templates/insertion/includes/structure_card_tab_description.html
+++ b/itou/templates/insertion/includes/structure_card_tab_description.html
@@ -1,0 +1,22 @@
+{% load markdownify %}
+{% load matomo %}
+
+<h2>Description de la structure</h2>
+<div class="row">
+    <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+        <div class="c-box">
+            <article>
+                <h3>Présentation de la structure</h3>
+                {{ structure.description|markdownify }}
+            </article>
+        </div>
+    </div>
+    <div class="col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
+        <div class="c-box mb-3 mb-md-4">
+            <h3>Informations pratiques</h3>
+            <button class="btn btn-secondary btn-block" type="button" data-bs-toggle="modal" data-bs-target="#structure-contact-modal" {% matomo_event "fiche-structure" "clic" "voir-coordonnees-structure" %}>
+                Voir les coordonnées de la structure
+            </button>
+        </div>
+    </div>
+</div>

--- a/itou/templates/insertion/includes/structure_card_tab_services.html
+++ b/itou/templates/insertion/includes/structure_card_tab_services.html
@@ -1,0 +1,28 @@
+{% load matomo %}
+
+{% if services %}
+    <h2>Services</h2>
+    <ul class="list-group list-group-flush list-group-link">
+        {% for service in services %}
+            <li class="list-group-item list-group-item-action">
+                <div class="d-flex align-items-center">
+                    <div>
+                        <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                            <a href="{% url 'insertion_views:service_detail' service_uid=service.uid %}"
+                               target="_blank"
+                               rel="noopener"
+                               class="fw-bold text-decoration-none stretched-link order-2 order-md-1"
+                               {% matomo_event "fiche-structure" "clic" "voir-service" %}>{{ service.name }}</a>
+                        </div>
+                        <span class="fs-sm mt-1 d-flex align-items-center">
+                            <i class="ri-map-pin-2-line ri-sm me-1" aria-hidden="true"></i>
+                            Périmètre : {{ service.perimeter }}
+                        </span>
+                    </div>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p class="mb-0">Cette structure ne comporte pas de service.</p>
+{% endif %}

--- a/itou/templates/insertion/includes/structure_card_tabs.html
+++ b/itou/templates/insertion/includes/structure_card_tabs.html
@@ -1,0 +1,10 @@
+<div id="structure-tabs">
+    <div class="tab-content">
+        <div id="structure-description" class="tab-pane active show" aria-labelledby="structure-description-tab" role="tabpanel">
+            {% include "insertion/includes/structure_card_tab_description.html" %}
+        </div>
+        <div id="structure-services" class="tab-pane" aria-labelledby="structure-services-tab" role="tabpanel">
+            {% include "insertion/includes/structure_card_tab_services.html" %}
+        </div>
+    </div>
+</div>

--- a/itou/templates/insertion/structure_card.html
+++ b/itou/templates/insertion/structure_card.html
@@ -2,9 +2,8 @@
 
 {% load components %}
 {% load format_filters %}
-{% load markdownify %}
 {% load matomo %}
-
+{% load static %}
 
 {% block title %}{{ structure.name }} {{ block.super }}{% endblock %}
 
@@ -27,32 +26,47 @@
     {% endcomponent_title %}
 {% endblock %}
 
+{% block title_extra %}
+    <ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true" aria-labelledby="structure-tabs-title">
+        <li class="nav-item" role="presentation">
+            <a id="structure-description-tab"
+               class="nav-link active"
+               role="tab"
+               href="#structure-description"
+               data-bs-toggle="tab"
+               aria-selected="true"
+               aria-controls="structure-description"
+               {% matomo_event "fiche-structure" "clic" "onglet-structure" %}>Description de la structure</a>
+        </li>
+        <li class="nav-item" role="presentation">
+            <a id="structure-services-tab"
+               class="nav-link"
+               role="tab"
+               href="#structure-services"
+               data-bs-toggle="tab"
+               aria-selected="false"
+               aria-controls="structure-services"
+               {% matomo_event "fiche-structure" "clic" "onglet-services" %}>
+                <span>Services</span>
+                <span class="badge badge-sm rounded-pill ms-2">{{ services|length }}</span>
+            </a>
+        </li>
+    </ul>
+{% endblock %}
+
+
 {% block content %}
-    <section class="s-section">
+    <section id="structure-content-tabs" class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
-                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
-                    <div class="c-box">
-                        <article>
-                            <h3>Présentation de la structure</h3>
-                            {{ structure.description|markdownify }}
-                        </article>
-                    </div>
-                </div>
-                <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
-                    <div class="c-box mb-3 mb-md-4">
-                        <h3>Informations pratiques</h3>
-                        <button class="btn btn-secondary btn-block" type="button" data-bs-toggle="modal" data-bs-target="#structure-contact-modal" {% matomo_event "fiche-structure" "clic" "voir-coordonnees-structure" %}>
-                            Voir les coordonnées de la structure
-                        </button>
-                    </div>
-                </div>
+                <div class="s-section__col col-12">{% include "insertion/includes/structure_card_tabs.html" %}</div>
             </div>
         </div>
     </section>
 {% endblock %}
 
 {% block modals %}
+    {{ block.super }}
     <div class="modal fade" id="structure-contact-modal" tabindex="-1" aria-labelledby="structure-contact-modal-label" aria-modal="true" role="dialog">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
@@ -95,9 +109,7 @@
                                    target="_blank"
                                    class="btn-link fw-medium has-external-link"
                                    aria-label="Voir le site web de la structure (ouverture dans un nouvel onglet)"
-                                   {% matomo_event "fiche-structure" "clic" "lien-site-web" %}>
-                                    {{ structure.website }}
-                                </a>
+                                   {% matomo_event "fiche-structure" "clic" "lien-site-web" %}>{{ structure.website }}</a>
                             </div>
                         {% endif %}
                     {% endif %}
@@ -108,4 +120,9 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script src='{% static "js/sliding_tabs.js" %}'></script>
 {% endblock %}

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -56,10 +56,14 @@ class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
         )
 
     def get_context_data(self, **kwargs):
+        services = list(self.structure.services.all())
+        for service in services:
+            service.perimeter = get_division_label(service.eligibility_zones) or "France entière"
         return super().get_context_data(**kwargs) | {
             "structure": self.structure,
             "matomo_custom_title": "Fiche structure d’insertion",
             "back_url": get_safe_url(self.request, "back_url", fallback_url=reverse("home:hp")),
+            "services": services,
         }
 
 

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -816,3 +816,151 @@
   
   '''
 # ---
+# name: TestStructures.test_card_view_renders_bootstrap_tabs_with_full_payload
+  '''
+  <main class="s-main" id="main" role="main">
+      <div aria-atomic="true" aria-live="polite" class="toast-container">
+      </div>
+      <section class="s-title-02">
+          <div class="s-title-02__container container">
+              <div class="s-title-02__row row">
+                  <div class="s-title-02__col col-12">
+                      <div class="c-navinfo">
+                          <div class="c-navinfo__prevstep">
+                              <a aria-label="Retour à la page précédente" class="btn btn-ico btn-link ps-0" href="/">
+                                  <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium">
+                                  </i>
+                                  <span>
+                                      Retour
+                                  </span>
+                              </a>
+                          </div>
+                      </div>
+                      <div class="c-title">
+                          <div class="c-title__main">
+                              <h1>
+                                  Structure test
+                              </h1>
+                          </div>
+                      </div>
+                      <ul aria-labelledby="structure-tabs-title" class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
+                          <li class="nav-item" role="presentation">
+                              <a aria-controls="structure-description" aria-selected="true" class="nav-link active" data-bs-toggle="tab" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="onglet-structure" href="#structure-description" id="structure-description-tab" role="tab">
+                                  Description de la structure
+                              </a>
+                          </li>
+                          <li class="nav-item" role="presentation">
+                              <a aria-controls="structure-services" aria-selected="false" class="nav-link" data-bs-toggle="tab" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="onglet-services" href="#structure-services" id="structure-services-tab" role="tab">
+                                  <span>
+                                      Services
+                                  </span>
+                                  <span class="badge badge-sm rounded-pill ms-2">
+                                      3
+                                  </span>
+                              </a>
+                          </li>
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section" id="structure-content-tabs">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12">
+                      <div id="structure-tabs">
+                          <div class="tab-content">
+                              <div aria-labelledby="structure-description-tab" class="tab-pane active show" id="structure-description" role="tabpanel">
+                                  <h2>
+                                      Description de la structure
+                                  </h2>
+                                  <div class="row">
+                                      <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                                          <div class="c-box">
+                                              <article>
+                                                  <h3>
+                                                      Présentation de la structure
+                                                  </h3>
+                                                  <p>
+                                                      Description of test structure
+                                                  </p>
+                                              </article>
+                                          </div>
+                                      </div>
+                                      <div class="col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
+                                          <div class="c-box mb-3 mb-md-4">
+                                              <h3>
+                                                  Informations pratiques
+                                              </h3>
+                                              <button class="btn btn-secondary btn-block" data-bs-target="#structure-contact-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="voir-coordonnees-structure" type="button">
+                                                  Voir les coordonnées de la structure
+                                              </button>
+                                          </div>
+                                      </div>
+                                  </div>
+                              </div>
+                              <div aria-labelledby="structure-services-tab" class="tab-pane" id="structure-services" role="tabpanel">
+                                  <h2>
+                                      Services
+                                  </h2>
+                                  <ul class="list-group list-group-flush list-group-link">
+                                      <li class="list-group-item list-group-item-action">
+                                          <div class="d-flex align-items-center">
+                                              <div>
+                                                  <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                                                      <a class="fw-bold text-decoration-none stretched-link order-2 order-md-1" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="voir-service" href="/insertion/services/service-uid-0/" rel="noopener" target="_blank">
+                                                          Test service 0
+                                                      </a>
+                                                  </div>
+                                                  <span class="fs-sm mt-1 d-flex align-items-center">
+                                                      <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1">
+                                                      </i>
+                                                      Périmètre : Perimeter 1
+                                                  </span>
+                                              </div>
+                                          </div>
+                                      </li>
+                                      <li class="list-group-item list-group-item-action">
+                                          <div class="d-flex align-items-center">
+                                              <div>
+                                                  <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                                                      <a class="fw-bold text-decoration-none stretched-link order-2 order-md-1" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="voir-service" href="/insertion/services/service-uid-1/" rel="noopener" target="_blank">
+                                                          Test service 1
+                                                      </a>
+                                                  </div>
+                                                  <span class="fs-sm mt-1 d-flex align-items-center">
+                                                      <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1">
+                                                      </i>
+                                                      Périmètre : Perimeter 2
+                                                  </span>
+                                              </div>
+                                          </div>
+                                      </li>
+                                      <li class="list-group-item list-group-item-action">
+                                          <div class="d-flex align-items-center">
+                                              <div>
+                                                  <div class="d-flex flex-column flex-lg-row align-items-lg-center">
+                                                      <a class="fw-bold text-decoration-none stretched-link order-2 order-md-1" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="voir-service" href="/insertion/services/service-uid-2/" rel="noopener" target="_blank">
+                                                          Test service 2
+                                                      </a>
+                                                  </div>
+                                                  <span class="fs-sm mt-1 d-flex align-items-center">
+                                                      <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1">
+                                                      </i>
+                                                      Périmètre : Perimeter 3
+                                                  </span>
+                                              </div>
+                                          </div>
+                                      </li>
+                                  </ul>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  </main>
+  
+  '''
+# ---

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -72,6 +72,31 @@ class TestStructures:
         modal = parse_response_to_soup(response, selector="#structure-contact-modal")
         assert pretty_indented(modal) == snapshot
 
+    def test_card_view_renders_bootstrap_tabs_with_full_payload(self, client, snapshot):
+        structure = StructureFactory(name="Structure test", description="Description of test structure")
+
+        services = []
+        for i in range(3):
+            service = ServiceFactory(structure=structure, name=f"Test service {i}", uid=f"service-uid-{i}")
+            services.append(service)
+
+        with patch(
+            "itou.www.insertion_views.views.get_division_label",
+            side_effect=["Perimeter 1", "Perimeter 2", "Perimeter 3"],
+        ):
+            response = client.get(self.get_structure_url(structure))
+
+        assert pretty_indented(parse_response_to_soup(response, "main")) == snapshot
+
+    def test_card_view_services_link_to_service_detail(self, client):
+        structure = StructureFactory()
+        service = ServiceFactory(structure=structure)
+
+        response = client.get(self.get_structure_url(structure))
+
+        expected_href = reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid})
+        assertContains(response, f'href="{expected_href}"')
+
 
 class TestServices:
     LOGIN_URL = reverse("login:existing_user")


### PR DESCRIPTION
:warning: **À rebaser et merger après #7810**

## :thinking: Pourquoi ?

Ajout de la liste des services à la page d'une structure d'insertion.

## :cake: Comment ? <!-- optionnel -->

La fiche structure est scindée en deux onglets (Description / Services), avec liste de services paginée dont chaque carte renvoie à sa fiche. L'onglet actif est porté par ?tab= (source de vérité serveur) : il survit au rafraîchissement, au précédent/suivant, et l'URL est partageable.

Les onglets sont de vraies navigations htmx (`hx-get` + `hx-push-url`) plutôt que des bascules Bootstrap côté client : cliquer un onglet écrit `?tab=` dans l'URL (exactement comme la pagination écrit `?page=`) et le serveur, qui lit `?tab=` comme source de vérité, renvoie le bon fragment en se basant sur l'en-tête `hx-target` (toute la région d'onglets pour un changement d'onglet, seulement la liste de services pour une page).

## :desert_island: Comment tester ?

Aller sur une page structure et naviguer entre les onglets Description et Services, ainsi qu'entre les pages de services.

Exemple page structure : http://localhost:8000/insertion/structure/soliguide--9997/card

## :computer: Captures d'écran <!-- optionnel -->

<img width="1655" height="545" alt="image" src="https://github.com/user-attachments/assets/a6510e6b-d468-4351-accb-33f30a594da6" />
<img width="1659" height="807" alt="image" src="https://github.com/user-attachments/assets/dc9c3d9d-1059-4d61-8499-e826b7f51b87" />

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
