### PR TITLE
Demandeur d’emploi : Bloquer l’édition des informations d’identité lorsqu’elles sont fournies par un service externe

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -484,9 +484,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
         if not request.user.is_superuser:
             readonly_fields.extend(["is_staff", "is_superuser", "groups", "user_permissions"])
         if obj and obj.has_sso_provider:
-            readonly_fields.append("username")
-            if obj.identity_provider != IdentityProvider.PE_CONNECT:
-                readonly_fields.extend(["first_name", "last_name", "email"])
+            readonly_fields.extend(["username", "first_name", "last_name", "email"])
         if obj:
             readonly_fields.append("kind")  # kind is never editable, but still addable
         return readonly_fields

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -11,7 +11,6 @@ from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
 from itou.communications import registry as notification_registry
 from itou.communications.models import NotificationRecord, NotificationSettings
-from itou.users.enums import IdentityProvider
 from itou.users.forms import JobSeekerProfileModelForm
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.urls import get_zendesk_form_url
@@ -20,9 +19,8 @@ from itou.utils.urls import get_zendesk_form_url
 class SSOReadonlyMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance.has_sso_provider and self.instance.identity_provider != IdentityProvider.PE_CONNECT:
-            # When a user has logged in with a SSO other than PEAMU
-            # it should see the field but most should be disabled
+        if self.instance.has_sso_provider:
+            # When users log in with a SSO, the fields should be disabled
             # (that’s a requirement on FranceConnect’s side).
             disabled_fields = ["first_name", "last_name", "email", "birthdate", "title"]
             for name in self.fields.keys():
@@ -77,8 +75,8 @@ class EditJobSeekerInfoForm(
         assert self.instance.is_job_seeker, self.instance
 
         # Noboby can edit its own email.
-        if self.instance.identity_provider == IdentityProvider.FRANCE_CONNECT:
-            # If the job seeker uses FranceConnect, point them to the modification process
+        if self.instance.has_sso_provider:
+            # Point them to the modification process
             self.fields["email"].help_text = (
                 "Si vous souhaitez modifier votre adresse e-mail merci de "
                 f"<a href='{get_zendesk_form_url()}' target='_blank'>"

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -834,13 +834,7 @@ class TestEditJobSeekerInfo:
         for attr in ["birthdate", "birth_place", "birth_country"]:
             assert getattr(refreshed_job_seeker.jobseeker_profile, attr) == getattr(job_seeker.jobseeker_profile, attr)
 
-    @pytest.mark.parametrize(
-        "identity_provider",
-        [
-            IdentityProvider.FRANCE_CONNECT,
-            # TODO: IdentityProvider.PE_CONNECT
-        ],
-    )
+    @pytest.mark.parametrize("identity_provider", [IdentityProvider.FRANCE_CONNECT, IdentityProvider.PE_CONNECT])
     def test_sso_fields_readonly(self, client, identity_provider, mocker):
         mocker.patch(
             "itou.utils.apis.geocoding.get_geocoding_data",

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -10,7 +10,7 @@ from pytest_django.asserts import assertContains, assertFormError, assertNotCont
 
 from itou.asp.models import Commune, Country
 from itou.cities.models import City
-from itou.users.enums import LackOfNIRReason, LackOfPoleEmploiId, Title
+from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, Title
 from itou.users.models import User
 from itou.users.notifications import EditJobSeekerInfoNotification
 from itou.utils.mocks.address_format import mock_get_geocoding_data_by_ban_api_resolved
@@ -832,4 +832,56 @@ class TestEditJobSeekerInfo:
         for attr in ["title", "first_name", "last_name"]:
             assert getattr(refreshed_job_seeker, attr) == getattr(job_seeker, attr)
         for attr in ["birthdate", "birth_place", "birth_country"]:
+            assert getattr(refreshed_job_seeker.jobseeker_profile, attr) == getattr(job_seeker.jobseeker_profile, attr)
+
+    @pytest.mark.parametrize(
+        "identity_provider",
+        [
+            IdentityProvider.FRANCE_CONNECT,
+            # TODO: IdentityProvider.PE_CONNECT
+        ],
+    )
+    def test_sso_fields_readonly(self, client, identity_provider, mocker):
+        mocker.patch(
+            "itou.utils.apis.geocoding.get_geocoding_data",
+            side_effect=mock_get_geocoding_data_by_ban_api_resolved,
+        )
+        org = prescribers_factories.PrescriberOrganizationFactory()
+        member = prescribers_factories.PrescriberMembershipFactory(organization=org).user
+        job_seeker = JobSeekerFactory(identity_provider=identity_provider, created_by=member)
+        user_fields = {"email", "title", "first_name", "last_name"}
+        profile_fields = {"birthdate"}
+        readonly_fields = user_fields | profile_fields
+
+        client.force_login(member)
+        url = reverse(
+            "dashboard:edit_job_seeker_info",
+            kwargs={"job_seeker_public_id": job_seeker.public_id},
+        )
+        response = client.get(url)
+        soup = parse_response_to_soup(response)
+        assert readonly_fields <= {field["name"] for field in soup.find_all(attrs={"disabled": ""})}
+
+        new_birthdate = datetime.date(1978, 12, 20)
+        response = client.post(
+            url,
+            {
+                "title": "M",
+                "first_name": "Manuel",
+                "last_name": "Calavera",
+                "email": job_seeker.email,
+                "birthdate": new_birthdate.isoformat(),
+                "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
+                "birth_place": (
+                    Commune.objects.filter(start_date__lte=new_birthdate, end_date__gte=new_birthdate).first().pk
+                ),
+                "confirm": True,
+                **self.address_form_fields,
+            },
+        )
+        assertRedirects(response, reverse("dashboard:index"))
+        refreshed_job_seeker = User.objects.select_related("jobseeker_profile").get(pk=job_seeker.pk)
+        for attr in user_fields:
+            assert getattr(refreshed_job_seeker, attr) == getattr(job_seeker, attr)
+        for attr in profile_fields:
             assert getattr(refreshed_job_seeker.jobseeker_profile, attr) == getattr(job_seeker.jobseeker_profile, attr)

--- a/tests/www/dashboard/test_edit_user_email.py
+++ b/tests/www/dashboard/test_edit_user_email.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from django.contrib import messages
 from django.urls import reverse
@@ -77,10 +78,11 @@ class TestChangeEmailView:
             assert new_address.email == new_email
             assert new_address.verified
 
-    def test_update_email_forbidden(self, client):
+    @pytest.mark.parametrize("identity_provider", [IdentityProvider.FRANCE_CONNECT, IdentityProvider.PE_CONNECT])
+    def test_update_email_forbidden(self, client, identity_provider):
         url = reverse("dashboard:edit_user_email")
 
-        job_seeker = JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT)
+        job_seeker = JobSeekerFactory(identity_provider=identity_provider)
         client.force_login(job_seeker)
         response = client.get(url)
         assert response.status_code == 403

--- a/tests/www/dashboard/test_edit_user_info.py
+++ b/tests/www/dashboard/test_edit_user_info.py
@@ -674,9 +674,10 @@ class TestEditUserInfoView:
             assert getattr(refreshed_job_seeker.jobseeker_profile, attr) == getattr(job_seeker.jobseeker_profile, attr)
 
     @freeze_time("2023-03-10")
-    def test_edit_sso(self, client):
+    @pytest.mark.parametrize("identity_provider", [IdentityProvider.FRANCE_CONNECT, IdentityProvider.PE_CONNECT])
+    def test_edit_sso(self, client, identity_provider):
         user = JobSeekerFactory(
-            identity_provider=IdentityProvider.FRANCE_CONNECT,
+            identity_provider=identity_provider,
             first_name="Not Bob",
             last_name="Not Saint Clar",
             jobseeker_profile__birthdate=date(1970, 1, 1),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Évite la confusion liée à l’écrasement automatique des données saisies par l’utilisateur.

Préparatifs pour https://app.notion.com/p/gip-inclusion/ETQ-candidat-pro-Indiquer-que-la-modification-d-un-candidat-qui-utilise-un-SSO-est-faire-sur-les-3435f321b604805b88bfdb8f8063b176
