### PR TITLE
GEIQ: Affichage des SHA en hexadécimal dans les logs

### DIFF
--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -107,7 +107,7 @@ class LabelApiClient:
         if x_geiq_id := response_data.headers.get("x-geiq-id"):
             if x_geiq_id != str(geiq_id):
                 raise LabelAPIError(f"Unexpected x-geiq-id: {x_geiq_id}")
-        logger.info(f"Successfully retrieved {command} - sha256=%s", hashlib.sha256(response_data.content).digest())
+        logger.info(f"Successfully retrieved {command} - sha256={hashlib.sha256(response_data.content).hexdigest()}")
         return response_data.content
 
     def get_compte_pdf(self, *, geiq_id):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Fignolage de #8207 où les SHA256 des fichiers récupérés étaient affichés en binaire :
```
Successfully retrieved DownloadCompte - sha256=b'\xa0r5\x80\x9b^\x80J\xf0X\x8a9\x7f\xda\t:\xee\xf1\r\x8dK\x90\xf4\x12}L\xd09\x82\x9a>\x1e'
```

Peut-être pas très pratique si on a besoin un jour de grep dans les logs -- espérons que ce jour ne vienne jamais.

## :cake: Comment ? <!-- optionnel -->

.

## :desert_island: Comment tester ?

.

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
