### PR TITLE
Demandeur d’emploi : Ne pas importer les adresses et numéro de téléphone de FranceConnect

### DIFF
--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -40,15 +40,7 @@ class FranceConnectUserData(OIDConnectUserData):
         )
         attrs = standard_attrs | {
             "birthdate": datetime.date.fromisoformat(user_info["birthdate"]) if user_info.get("birthdate") else None,
-            "phone": user_info.get("phone_number"),
         }
-        if "address" in user_info:
-            if user_info["address"].get("country") == "France":
-                attrs |= {
-                    "address_line_1": user_info["address"].get("street_address"),
-                    "post_code": user_info["address"].get("postal_code"),
-                    "city": user_info["address"].get("locality"),
-                }
         with contextlib.suppress(KeyError):
             gender = user_info["gender"]
             attrs["title"] = TITLE_MAP[gender]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ces champs ne sont pas fournis depuis Juin 2022.

https://docs.partenaires.franceconnect.gouv.fr/fs/fs-pilotage/fs-projet-donnees-identites/
https://github.com/france-connect/sources/blob/main/CHANGELOG.md#v3115--v31160
https://github.com/france-connect/sources/commit/73799b7a0f736d1f2977bfcb9114bc13e345d292
