### PR TITLE
GEIQ: Préservation des filtres lors d'un changement de page

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -35,12 +35,14 @@
             {% if tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION and tab != AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}
                 <li class="nav-item">
                     {# FIXME(ewen): use span as below #}
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
+                    <a class="nav-link{% if active_tab == tab %} active{% endif %}"
+                       href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}?back_url={{ back_url|urlencode }}">{{ tab.label }}
                     </a>
                 </li>
             {% elif tab == AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION and request.from_employer and contract.requires_justification %}
                 <li class="nav-item">
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">
+                    <a class="nav-link{% if active_tab == tab %} active{% endif %}"
+                       href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}?back_url={{ back_url|urlencode }}">
                         <span>{{ tab.label }}</span>
                         {% if not contract.allowance_request_justification_reason %}
                             <i class="ri-error-warning-line text-warning ms-2"></i>
@@ -49,7 +51,8 @@
                 </li>
             {% elif tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION and request.from_institution and not contract.allowance_granted %}
                 <li class="nav-item">
-                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
+                    <a class="nav-link{% if active_tab == tab %} active{% endif %}"
+                       href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}?back_url={{ back_url|urlencode }}">{{ tab.label }}
                         {% if not contract.allowance_refusal_reason %}<i class="ri-error-warning-line ri-xl text-warning ms-2"></i>{% endif %}
                     </a>
                 </li>
@@ -65,9 +68,9 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 mt-xxl-6">
                     {% if request.from_employer %}
-                        {% include "geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html" with contract=contract csrf_token=csrf_token active_tab=active_tab disabled=contract.employee.assessment.contracts_selection_validated_at MIN_DAYS_IN_YEAR_FOR_ALLOWANCE=MIN_DAYS_IN_YEAR_FOR_ALLOWANCE only %}
+                        {% include "geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html" with contract=contract csrf_token=csrf_token active_tab=active_tab back_url=back_url disabled=contract.employee.assessment.contracts_selection_validated_at MIN_DAYS_IN_YEAR_FOR_ALLOWANCE=MIN_DAYS_IN_YEAR_FOR_ALLOWANCE only %}
                     {% elif request.from_institution %}
-                        {% include "geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html" with contract=contract csrf_token=csrf_token active_tab=active_tab disabled=contract.employee.assessment.grants_selection_validated_at only %}
+                        {% include "geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html" with contract=contract csrf_token=csrf_token active_tab=active_tab back_url=back_url disabled=contract.employee.assessment.grants_selection_validated_at only %}
                     {% endif %}
                 </div>
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -183,7 +183,8 @@
                                             {% for contract in contracts_page %}
                                                 <tr>
                                                     <td>
-                                                        <a class="btn-link" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.EMPLOYEE %}">{{ contract.employee.get_full_name }}</a>
+                                                        <a class="btn-link"
+                                                           href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.EMPLOYEE %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}">{{ contract.employee.get_full_name }}</a>
                                                         {% if contract.employee.allowance_granted_previous_year %}
                                                             <i class="ri-file-warning-line ri-lg text-warning"
                                                                aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière."
@@ -208,7 +209,7 @@
                                                         {% else %}
                                                             Non
                                                             {% if request.from_institution and contract.allowance_request_justification_reason %}
-                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.CONTRACT %}"
+                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.CONTRACT %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                                                                    class="text-info text-decoration-none lh-1"
                                                                    data-bs-toggle="tooltip"
                                                                    data-bs-title="Le GEIQ a motivé cette demande d’aide">

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -185,7 +185,8 @@
                                             {% for contract in contracts_page %}
                                                 <tr>
                                                     <td>
-                                                        <a class="btn-link" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.EMPLOYEE %}">{{ contract.employee.get_full_name }}</a>
+                                                        <a class="btn-link"
+                                                           href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=AssessmentContractDetailsTab.EMPLOYEE %}?back_url={{ request.get_full_path|urlencode }}">{{ contract.employee.get_full_name }}</a>
                                                         {% if contract.employee.allowance_granted_previous_year %}
                                                             <i class="ri-file-warning-line ri-lg text-warning"
                                                                aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière."
@@ -210,7 +211,7 @@
                                                         {% else %}
                                                             Non
                                                             {% if request.from_institution and contract.allowance_request_justification_reason %}
-                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.CONTRACT %}"
+                                                                <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.CONTRACT %}?back_url={{ request.get_full_path|urlencode }}"
                                                                    class="text-info text-decoration-none lh-1"
                                                                    data-bs-toggle="tooltip"
                                                                    data-bs-title="Le GEIQ a motivé cette demande d’aide">
@@ -223,9 +224,9 @@
                                                     <td class="text-end">{{ contract.employee.allowance_amount|format_int_euros }}</td>
                                                     <td>
                                                         {% if request.from_employer %}
-                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_requested csrf_token=csrf_token editable=can_validate request=request disable_stats_oob=True only %}
+                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_requested csrf_token=csrf_token editable=can_validate request=request current_url=request.get_full_path disable_stats_oob=True only %}
                                                         {% elif request.from_institution %}
-                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_granted csrf_token=csrf_token editable=can_validate request=request disable_stats_oob=True only %}
+                                                            {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_granted csrf_token=csrf_token editable=can_validate request=request current_url=request.get_full_path disable_stats_oob=True only %}
                                                         {% endif %}
                                                     </td>
                                                 </tr>

--- a/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
@@ -33,7 +33,7 @@
 
         {% if active_tab != active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
             <a class="btn btn-outline-primary bg-white btn-block mb-3{% if disabled %} disabled{% endif %}"
-               href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}">
+               href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}?back_url={{ back_url|urlencode }}">
                 <span>{{ contract.allowance_refusal_reason|yesno:"Modifier le motif de refus,Justifier le refus" }}</span>
             </a>
         {% endif %}

--- a/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_request_allowance_box_for_geiq.html
@@ -11,7 +11,7 @@
                 {% endif %}
             </p>
             <p>Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».</p>
-            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
+            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}?back_url={{ back_url|urlencode }}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-ico btn-outline-primary bg-white btn-block"{% if disabled %} disabled{% endif %}>
                     <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
@@ -21,14 +21,14 @@
             {% if active_tab is not active_tab.ALLOWANCE_REQUEST_JUSTIFICATION %}
                 <a class="btn btn-primary btn-block mt-3"
                    {% if disabled %}disabled{% endif %}
-                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REQUEST_JUSTIFICATION.value %}">
+                   href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REQUEST_JUSTIFICATION.value %}?back_url={{ back_url|urlencode }}">
                     {{ contract.allowance_request_justification_reason|yesno:"Modifier votre justification,Justifier la demande d’aide" }}
                 </a>
             {% endif %}
         {% else %}
             <h3>Aide sollicitée pour ce contrat</h3>
             <p>Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.</p>
-            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}">
+            <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_exclude' contract_pk=contract.pk %}?back_url={{ back_url|urlencode }}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-ico btn-primary btn-block"{% if disabled %} disabled{% endif %}>
                     <i class="ri-close-large-line font-weight-medium" aria-hidden="true"></i>
@@ -39,7 +39,7 @@
     {% else %}
         <h3>Aide non sollicitée pour ce contrat</h3>
         <p>Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.</p>
-        <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_include' contract_pk=contract.pk %}">
+        <form method="post" action="{% url 'geiq_assessments_views:assessment_contracts_include' contract_pk=contract.pk %}?back_url={{ back_url|urlencode }}">
             {% csrf_token %}
             <button type="submit" class="btn btn-primary btn-block"{% if disabled %} disabled{% endif %}>Solliciter l’aide</button>
         </form>

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -30,14 +30,14 @@
 
     {% if request.from_employer and contract.requires_justification %}
         {% if contract.allowance_request_justification_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                class="text-success text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous avez motivé la demande d’aide de ce contrat">
                 <i class="ri-check-line" aria-label="Vous avez motivé la demande d’aide de ce contrat" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                class="text-warning text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver la demande d’aide de ce contrat">
@@ -46,14 +46,14 @@
         {% endif %}
     {% elif request.from_institution and not contract.allowance_granted %}
         {% if contract.allowance_refusal_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                class="text-success text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Voir le motif de refus pour contrat.">
                 <i class="ri-check-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
                class="text-warning text-decoration-none lh-1"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver le refus pour ce contrat.">

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -26,14 +26,14 @@
 
     {% if request.from_employer and contract.requires_justification %}
         {% if contract.allowance_request_justification_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}?back_url={{ current_url|urlencode }}"
                class="text-success text-decoration-none"
                data-bs-toggle="tooltip"
                data-bs-title="Vous avez motivé la demande d’aide de ce contrat">
                 <i class="ri-check-line" aria-label="Vous avez motivé la demande d’aide de ce contrat" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION %}?back_url={{ current_url|urlencode }}"
                class="text-warning text-decoration-none"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver la demande d’aide de ce contrat">
@@ -42,14 +42,14 @@
         {% endif %}
     {% elif request.from_institution and not contract.allowance_granted %}
         {% if contract.allowance_refusal_reason %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}?back_url={{ current_url|urlencode }}"
                class="text-success text-decoration-none"
                data-bs-toggle="tooltip"
                data-bs-title="Voir le motif de refus pour contrat.">
                 <i class="ri-check-line" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
             </a>
         {% else %}
-            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}?back_url={{ current_url|urlencode }}"
                class="text-warning text-decoration-none"
                data-bs-toggle="tooltip"
                data-bs-title="Vous devez encore motiver le refus pour ce contrat.">

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -728,15 +728,16 @@ def assessment_contracts_details(
                                 "allowance_request_justification_details",
                             )
                         )
-                    return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={
-                                "contract_pk": str(contract.pk),
-                                "tab": AssessmentContractDetailsTab.CONTRACT.value,
-                            },
-                        )
+                    redirect_url = reverse(
+                        "geiq_assessments_views:assessment_contracts_details",
+                        kwargs={
+                            "contract_pk": str(contract.pk),
+                            "tab": AssessmentContractDetailsTab.CONTRACT.value,
+                        },
                     )
+                    if request.GET:
+                        redirect_url += f"?{request.GET.urlencode()}"
+                    return HttpResponseRedirect(redirect_url)
     elif request.from_institution:
         if not contract.employee.assessment.reviewed_at:
             editable = not contract.employee.assessment.grants_selection_validated_at
@@ -789,12 +790,13 @@ def assessment_contracts_details(
                     if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
                         redirect_to_tab = AssessmentContractDetailsTab.EMPLOYEE.value
                 if redirect_to_tab:
-                    return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
-                        )
+                    redirect_url = reverse(
+                        "geiq_assessments_views:assessment_contracts_details",
+                        kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
                     )
+                    if request.GET:
+                        redirect_url += f"?{request.GET.urlencode()}"
+                    return HttpResponseRedirect(redirect_url)
 
             elif action is InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION:
                 if details_tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
@@ -815,10 +817,14 @@ def assessment_contracts_details(
                         ]
                         contract.save(update_fields=("allowance_refusal_reason", "allowance_refusal_details"))
 
+    back_url = reverse(
+        "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
+    )
+    if request.GET:
+        back_url += f"?{request.GET.urlencode()}"
+
     context |= {
-        "back_url": reverse(
-            "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
-        ),
+        "back_url": back_url,
         "assessment": contract.employee.assessment,
         "editable": editable,
         "contract": contract,

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import content_disposition_header
 from django.views.decorators.http import require_POST
+from itoutils.urls import add_url_params
 
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, REGIONS
 from itou.companies.enums import CompanyKind
@@ -45,6 +46,7 @@ from itou.utils.auth import check_request
 from itou.utils.export import to_streaming_response
 from itou.utils.pagination import pager
 from itou.utils.readonly import http_methods, readonly_view
+from itou.utils.urls import get_safe_url
 from itou.www.geiq_assessments_views.export import get_export_format, serialize_employee_contract
 from itou.www.geiq_assessments_views.forms import (
     ActionFinancialAssessmentForm,
@@ -700,6 +702,13 @@ def assessment_contracts_details(
     if details_tab == AssessmentContractDetailsTab.SUPPORT_AND_TRAINING:
         contract_qs = contract_qs.prefetch_related("employee__prequalifications")
     contract = get_object_or_404(contract_qs, pk=contract_pk)
+    back_url = get_safe_url(
+        request,
+        "back_url",
+        fallback_url=reverse(
+            "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
+        ),
+    )
 
     editable = False
     context = {}
@@ -742,12 +751,15 @@ def assessment_contracts_details(
                             )
                         )
                     return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={
-                                "contract_pk": str(contract.pk),
-                                "tab": AssessmentContractDetailsTab.CONTRACT.value,
-                            },
+                        add_url_params(
+                            reverse(
+                                "geiq_assessments_views:assessment_contracts_details",
+                                kwargs={
+                                    "contract_pk": str(contract.pk),
+                                    "tab": AssessmentContractDetailsTab.CONTRACT.value,
+                                },
+                            ),
+                            {"back_url": back_url},
                         )
                     )
     elif request.from_institution:
@@ -803,9 +815,12 @@ def assessment_contracts_details(
                         redirect_to_tab = AssessmentContractDetailsTab.EMPLOYEE.value
                 if redirect_to_tab:
                     return HttpResponseRedirect(
-                        reverse(
-                            "geiq_assessments_views:assessment_contracts_details",
-                            kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
+                        add_url_params(
+                            reverse(
+                                "geiq_assessments_views:assessment_contracts_details",
+                                kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
+                            ),
+                            {"back_url": back_url},
                         )
                     )
 
@@ -829,9 +844,7 @@ def assessment_contracts_details(
                         contract.save(update_fields=("allowance_refusal_reason", "allowance_refusal_details"))
 
     context |= {
-        "back_url": reverse(
-            "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
-        ),
+        "back_url": back_url,
         "assessment": contract.employee.assessment,
         "editable": editable,
         "contract": contract,
@@ -898,9 +911,12 @@ def assessment_contracts_toggle(
                 "vous ne pouvez plus modifier le statut de sollicitation de l’aide pour ce contrat.",
             )
         return HttpResponseRedirect(
-            reverse(
-                "geiq_assessments_views:assessment_contracts_details",
-                kwargs={"contract_pk": contract.pk, "tab": tab.value},
+            add_url_params(
+                reverse(
+                    "geiq_assessments_views:assessment_contracts_details",
+                    kwargs={"contract_pk": contract.pk, "tab": tab.value},
+                ),
+                {"back_url": get_safe_url(request, "back_url")},
             )
         )
 
@@ -915,6 +931,10 @@ def assessment_contracts_toggle(
     context = {
         "assessment": assessment,
         "contract": contract,
+        # HTMX gives us the URL of the page the switch was toggled from: we pass it (with the active filters of the
+        # contracts list) to the links to the contract details.
+        "current_url": request.htmx.current_url_abs_path
+        or reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk}),
         "editable": True,
         "value": new_value,
         "stats": stats,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5953,7 +5953,7 @@
                                           Aide potentielle
                                       </th>
                                       <th scope="col">
-                                          Obtenir l’aide
+                                          Solliciter l’aide
                                       </th>
                                   </tr>
                               </thead>
@@ -5975,7 +5975,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -6009,7 +6009,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -6043,7 +6043,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>
@@ -6226,7 +6226,7 @@
                                           Aide potentielle
                                       </th>
                                       <th scope="col">
-                                          Obtenir l’aide
+                                          Solliciter l’aide
                                       </th>
                                   </tr>
                               </thead>
@@ -6248,7 +6248,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -6282,7 +6282,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -6316,7 +6316,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>
@@ -6548,7 +6548,7 @@
                                           Aide potentielle
                                       </th>
                                       <th scope="col">
-                                          Obtenir l’aide
+                                          Solliciter l’aide
                                       </th>
                                   </tr>
                               </thead>
@@ -6570,7 +6570,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -6604,7 +6604,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -6638,7 +6638,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>
@@ -7400,7 +7400,7 @@
                                               </i>
                                           </a>
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -7438,7 +7438,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -7476,7 +7476,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>
@@ -7658,7 +7658,7 @@
                                               </i>
                                           </a>
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -7696,7 +7696,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -7734,7 +7734,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>
@@ -7965,7 +7965,7 @@
                                               </i>
                                           </a>
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           1 400 €
                                       </td>
                                       <td>
@@ -8003,7 +8003,7 @@
                                       <td>
                                           Oui
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           0 €
                                       </td>
                                       <td>
@@ -8041,7 +8041,7 @@
                                       <td>
                                           Non
                                       </td>
-                                      <td>
+                                      <td class="text-end">
                                           814 €
                                       </td>
                                       <td>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -3677,7 +3677,7 @@
       <p>
           Si vous décidez d’accorder l'aide, le motif et le commentaire de refus seront supprimés.
       </p>
-      <a class="btn btn-outline-primary bg-white btn-block mb-3" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+      <a class="btn btn-outline-primary bg-white btn-block mb-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/refusal-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           <span>
               Modifier le motif de refus
           </span>
@@ -3709,7 +3709,7 @@
               
               tant que le bilan n'a pas été validé.
       </p>
-      <a class="btn btn-outline-primary bg-white btn-block mb-3" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+      <a class="btn btn-outline-primary bg-white btn-block mb-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/refusal-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           <span>
               Justifier le refus
           </span>
@@ -3771,7 +3771,7 @@
       <p>
           Si vous décidez d’accorder l'aide, le motif et le commentaire de refus seront supprimés.
       </p>
-      <a class="btn btn-outline-primary bg-white btn-block mb-3 disabled" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+      <a class="btn btn-outline-primary bg-white btn-block mb-3 disabled" href="/geiq-assessments/contracts/[PK of EmployeeContract]/refusal-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           <span>
               Modifier le motif de refus
           </span>
@@ -3795,7 +3795,7 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-primary btn-block" type="submit">
               Solliciter l’aide
@@ -3821,7 +3821,7 @@
       <p>
           Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-ico btn-outline-primary bg-white btn-block" type="submit">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
@@ -3831,7 +3831,7 @@
               </span>
           </button>
       </form>
-      <a class="btn btn-primary btn-block mt-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification">
+      <a class="btn btn-primary btn-block mt-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           Modifier votre justification
       </a>
   </div>
@@ -3856,7 +3856,7 @@
       <p>
           Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-ico btn-outline-primary bg-white btn-block" type="submit">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
@@ -3866,7 +3866,7 @@
               </span>
           </button>
       </form>
-      <a class="btn btn-primary btn-block mt-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification">
+      <a class="btn btn-primary btn-block mt-3" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           Justifier la demande d’aide
       </a>
   </div>
@@ -3882,7 +3882,7 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-primary btn-block" type="submit">
               Solliciter l’aide
@@ -3901,7 +3901,7 @@
       <p>
           Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-ico btn-primary btn-block" type="submit">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
@@ -3924,7 +3924,7 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-primary btn-block" disabled="" type="submit">
               Solliciter l’aide
@@ -3950,7 +3950,7 @@
       <p>
           Si vous ne souhaitez plus présenter ce contrat, cliquez sur « Ne plus solliciter l’aide ».
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-ico btn-outline-primary bg-white btn-block" disabled="" type="submit">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
@@ -3960,7 +3960,7 @@
               </span>
           </button>
       </form>
-      <a class="btn btn-primary btn-block mt-3" disabled="" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification">
+      <a class="btn btn-primary btn-block mt-3" disabled="" href="/geiq-assessments/contracts/[PK of EmployeeContract]/request-justification?back_url=/geiq-assessments/[PK of Assessment]/contracts">
           Modifier votre justification
       </a>
   </div>
@@ -3976,7 +3976,7 @@
       <p>
           Vous avez la possibilité de présenter ce contrat tant que le bilan n’a pas été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/include?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-primary btn-block" disabled="" type="submit">
               Solliciter l’aide
@@ -3995,7 +3995,7 @@
       <p>
           Vous avez la possibilité d’annuler la demande d’aide car le bilan n’a pas encore été envoyé.
       </p>
-      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude" method="post">
+      <form action="/geiq-assessments/contracts/[PK of EmployeeContract]/exclude?back_url=/geiq-assessments/[PK of Assessment]/contracts" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
           <button class="btn btn-ico btn-primary btn-block" disabled="" type="submit">
               <i aria-hidden="true" class="ri-close-large-line font-weight-medium">
@@ -5457,7 +5457,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPOND Jean-Pierre
                                           </a>
                                           <i aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." class="ri-file-warning-line ri-lg text-warning" data-bs-placement="top" data-bs-title="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." data-bs-toggle="tooltip" role="button" tabindex="0">
@@ -5493,7 +5493,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -5527,7 +5527,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>
@@ -5556,7 +5556,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Vous avez motivé la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Vous avez motivé la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Vous avez motivé la demande d’aide de ce contrat" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -5746,7 +5746,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPOND Jean-Pierre
                                           </a>
                                           <i aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." class="ri-file-warning-line ri-lg text-warning" data-bs-placement="top" data-bs-title="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." data-bs-toggle="tooltip" role="button" tabindex="0">
@@ -5782,7 +5782,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -5816,7 +5816,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>
@@ -5845,7 +5845,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Vous avez motivé la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Vous avez motivé la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Vous avez motivé la demande d’aide de ce contrat" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -6082,7 +6082,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPOND Jean-Pierre
                                           </a>
                                           <i aria-label="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." class="ri-file-warning-line ri-lg text-warning" data-bs-placement="top" data-bs-title="Salarié dont un des contrats a bénéficié d’une aide l’année dernière." data-bs-toggle="tooltip" role="button" tabindex="0">
@@ -6118,7 +6118,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -6152,7 +6152,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>
@@ -6181,7 +6181,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-warning text-decoration-none" data-bs-title="Vous devez encore motiver la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification">
+                                              <a class="text-warning text-decoration-none" data-bs-title="Vous devez encore motiver la demande d’aide de ce contrat" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/request-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Vous devez encore motiver la demande d’aide de ce contrat" class="ri-error-warning-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -6942,7 +6942,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONS Pean-Jierre
                                           </a>
                                       </td>
@@ -6954,7 +6954,7 @@
                                       </td>
                                       <td>
                                           Non
-                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract">
+                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               <i aria-label="Le GEIQ a motivé cette demande d’aide" class="ri-information-line ri-xl" role="button" tabindex="0">
                                               </i>
                                           </a>
@@ -6975,7 +6975,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -6984,7 +6984,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -7013,7 +7013,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -7022,7 +7022,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>
@@ -7218,7 +7218,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONS Pean-Jierre
                                           </a>
                                       </td>
@@ -7230,7 +7230,7 @@
                                       </td>
                                       <td>
                                           Non
-                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract">
+                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               <i aria-label="Le GEIQ a motivé cette demande d’aide" class="ri-information-line ri-xl" role="button" tabindex="0">
                                               </i>
                                           </a>
@@ -7251,7 +7251,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -7260,7 +7260,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -7289,7 +7289,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -7298,7 +7298,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>
@@ -7541,7 +7541,7 @@
                               <tbody>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONS Pean-Jierre
                                           </a>
                                       </td>
@@ -7553,7 +7553,7 @@
                                       </td>
                                       <td>
                                           Non
-                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract">
+                                          <a class="text-info text-decoration-none lh-1" data-bs-title="Le GEIQ a motivé cette demande d’aide" data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/contract?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               <i aria-label="Le GEIQ a motivé cette demande d’aide" class="ri-information-line ri-xl" role="button" tabindex="0">
                                               </i>
                                           </a>
@@ -7574,7 +7574,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-warning text-decoration-none" data-bs-title="Vous devez encore motiver le refus pour ce contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-warning text-decoration-none" data-bs-title="Vous devez encore motiver le refus pour ce contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-error-warning-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -7583,7 +7583,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               DUPONT Jean
                                           </a>
                                       </td>
@@ -7612,7 +7612,7 @@
                                                       </label>
                                                   </div>
                                               </form>
-                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                              <a class="text-success text-decoration-none" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                                   <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line" role="button" tabindex="0">
                                                   </i>
                                               </a>
@@ -7621,7 +7621,7 @@
                                   </tr>
                                   <tr>
                                       <td>
-                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee?back_url=/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts">
                                               MARTIN Cécile
                                           </a>
                                       </td>

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 import uuid
+from urllib.parse import quote
 
 import pytest
 from django.contrib import messages
@@ -260,6 +261,49 @@ class TestAssessmentContractsListAndToggle:
         contracts_list_url = reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk})
         response = client.get(contracts_list_url)
         assertContains(response, PAGINATION_PAGE_ONE_MARKUP % (contracts_list_url + "?page=1"), html=True)
+
+    def test_filters_are_kept_when_browsing_a_contract(self, client):
+        geiq_membership = CompanyMembershipFactory(
+            company__kind=CompanyKind.GEIQ,
+        )
+        assessment = AssessmentFactory(
+            campaign__year=2024,
+            companies=[geiq_membership.company],
+        )
+        contract = EmployeeContractFactory(
+            employee__assessment=assessment,
+            allowance_requested=False,
+            nb_days_in_campaign_year=89,
+        )
+        contracts_list_url = reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk})
+        filtered_contracts_list_url = f"{contracts_list_url}?duration_strictly_shorter_90=on"
+        back_url_param = f"back_url={quote(filtered_contracts_list_url)}"
+        employee_tab_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={"contract_pk": contract.pk, "tab": AssessmentContractDetailsTab.EMPLOYEE},
+        )
+        justification_tab_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={
+                "contract_pk": contract.pk,
+                "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION,
+            },
+        )
+
+        client.force_login(geiq_membership.user)
+        response = client.get(filtered_contracts_list_url)
+        assertContains(response, f'href="{employee_tab_url}?{back_url_param}"')
+
+        # The switch re-rendered by HTMX also links to the filtered list.
+        response = client.post(
+            reverse("geiq_assessments_views:assessment_contracts_include", kwargs={"contract_pk": contract.pk}),
+            headers={"HX-Request": "true", "HX-Current-URL": f"http://testserver{filtered_contracts_list_url}"},
+        )
+        assertContains(response, f'href="{justification_tab_url}?{back_url_param}"')
+
+        # The contract details page goes back to the filtered list.
+        response = client.get(f"{employee_tab_url}?{back_url_param}")
+        assertContains(response, f'href="{filtered_contracts_list_url}"')
 
     def test_access_as_institution(self, client, snapshot):
         ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)
@@ -865,15 +909,16 @@ class TestAssessmentContractsDetails:
                 "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.value,
             },
         )
+        contracts_list_url = reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk})
         JUSTIFICATION_TAB_LI = f"""
         <li class="nav-item">
-            <a class="nav-link" href="{details_justification_url}">
+            <a class="nav-link" href="{details_justification_url}?back_url={contracts_list_url}">
                 <span>Justification</span>
             </a>
         </li>"""
         JUSTIFICATION_TAB_WITH_ICON_LI = f"""
         <li class="nav-item">
-            <a class="nav-link" href="{details_justification_url}">
+            <a class="nav-link" href="{details_justification_url}?back_url={contracts_list_url}">
                 <span>Justification</span>
                 <i class="ri-error-warning-line text-warning ms-2"></i>
             </a>
@@ -888,7 +933,10 @@ class TestAssessmentContractsDetails:
             parse_response_to_soup(
                 response,
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                replace_in_attr=[("action", str(contract.pk), "[PK of EmployeeContract]")],
+                replace_in_attr=[
+                    ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("action", str(assessment.pk), "[PK of Assessment]"),
+                ],
             )
         ) == snapshot(name="allowance request box with allowance not requested")
 
@@ -909,7 +957,10 @@ class TestAssessmentContractsDetails:
                 parse_response_to_soup(
                     response,
                     selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                    replace_in_attr=[("action", str(contract.pk), "[PK of EmployeeContract]")],
+                    replace_in_attr=[
+                        ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                        ("action", str(assessment.pk), "[PK of Assessment]"),
+                    ],
                 )
             ) == snapshot(name="allowance request box with allowance requested")
             assertNotContains(response, JUSTIFICATION_TAB_LI, html=True)
@@ -926,7 +977,9 @@ class TestAssessmentContractsDetails:
                     selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
                     replace_in_attr=[
                         ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                        ("action", str(assessment.pk), "[PK of Assessment]"),
                         ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                        ("href", str(assessment.pk), "[PK of Assessment]"),
                     ],
                 )
             ) == snapshot(name="allowance request box with allowance requested, missing reason, common tab")
@@ -960,7 +1013,7 @@ class TestAssessmentContractsDetails:
                     "allowance_request_details": "C’est un cas particulier…",
                 },
             )
-            assertRedirects(response, details_contract_url)
+            assertRedirects(response, f"{details_contract_url}?back_url={contracts_list_url}")
             contract.refresh_from_db()
             assert contract.allowance_requested is True
             assert contract.allowance_request_justification_reason is not None
@@ -972,7 +1025,9 @@ class TestAssessmentContractsDetails:
                     selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
                     replace_in_attr=[
                         ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                        ("action", str(assessment.pk), "[PK of Assessment]"),
                         ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                        ("href", str(assessment.pk), "[PK of Assessment]"),
                     ],
                 )
             ) == snapshot(name="allowance request box with allowance requested, filled reason, common tab")
@@ -1034,6 +1089,7 @@ class TestAssessmentContractsDetails:
                 "tab": AssessmentContractDetailsTab.ALLOWANCE_REQUEST_JUSTIFICATION.value,
             },
         )
+        contracts_list_url = reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk})
 
         client.force_login(geiq_membership.user)
         response = client.get(details_url)
@@ -1041,7 +1097,10 @@ class TestAssessmentContractsDetails:
             parse_response_to_soup(
                 response,
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                replace_in_attr=[("action", str(contract.pk), "[PK of EmployeeContract]")],
+                replace_in_attr=[
+                    ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("action", str(assessment.pk), "[PK of Assessment]"),
+                ],
             )
         ) == snapshot(name="allowance request box with allowance not requested after contract selection")
 
@@ -1073,6 +1132,7 @@ class TestAssessmentContractsDetails:
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
                 replace_in_attr=[
                     ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("action", str(assessment.pk), "[PK of Assessment]"),
                 ],
             )
         ) == snapshot(name="allowance request box with allowance not requested after contract selection")
@@ -1109,7 +1169,9 @@ class TestAssessmentContractsDetails:
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
                 replace_in_attr=[
                     ("action", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("action", str(assessment.pk), "[PK of Assessment]"),
                     ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("href", str(assessment.pk), "[PK of Assessment]"),
                 ],
             )
         ) == snapshot(name="allowance request box with allowance requested after contract selection")
@@ -1123,7 +1185,7 @@ class TestAssessmentContractsDetails:
                     "allowance_request_details": "Nouveaux détails",
                 },
             )
-            assertRedirects(response, details_contract_url)
+            assertRedirects(response, f"{details_contract_url}?back_url={contracts_list_url}")
             assertMessages(
                 response,
                 [
@@ -1176,15 +1238,16 @@ class TestAssessmentContractsDetails:
                 "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
             },
         )
+        contracts_list_url = reverse("geiq_assessments_views:assessment_contracts_list", kwargs={"pk": assessment.pk})
         JUSTIFICATION_TAB_LI = f"""
         <li class="nav-item">
-            <a class="nav-link" href="{details_justification_url}">
+            <a class="nav-link" href="{details_justification_url}?back_url={contracts_list_url}">
                 Motif de refus
             </a>
         </li>"""
         JUSTIFICATION_TAB_WITH_ICON_LI = f"""
         <li class="nav-item">
-            <a class="nav-link" href="{details_justification_url}">
+            <a class="nav-link" href="{details_justification_url}?back_url={contracts_list_url}">
                 Motif de refus <i class="ri-error-warning-line ri-xl text-warning ms-2"></i>
             </a>
         </li>"""
@@ -1199,7 +1262,7 @@ class TestAssessmentContractsDetails:
 
         # User refuses the allowance and gets redirected to the justification form tab
         response = client.post(details_url, data={"action": InstitutionAction.REFUSE_ALLOWANCE})
-        assertRedirects(response, details_justification_url)
+        assertRedirects(response, f"{details_justification_url}?back_url={contracts_list_url}")
         contract.refresh_from_db()
         assert contract.allowance_granted is False
 
@@ -1210,7 +1273,10 @@ class TestAssessmentContractsDetails:
             parse_response_to_soup(
                 response,
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+                replace_in_attr=[
+                    ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("href", str(assessment.pk), "[PK of Assessment]"),
+                ],
             )
         ) == snapshot(name="contract detail side box with refused allowance, missing reason, common tab")
 
@@ -1268,7 +1334,10 @@ class TestAssessmentContractsDetails:
             parse_response_to_soup(
                 response,
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+                replace_in_attr=[
+                    ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("href", str(assessment.pk), "[PK of Assessment]"),
+                ],
             )
         ) == snapshot(name="contract detail side box with refused allowance, filled reason, common tab")
 
@@ -1279,7 +1348,8 @@ class TestAssessmentContractsDetails:
             reverse(
                 "geiq_assessments_views:assessment_contracts_details",
                 kwargs={"contract_pk": contract.pk, "tab": AssessmentContractDetailsTab.EMPLOYEE},
-            ),
+            )
+            + f"?back_url={contracts_list_url}",
         )
         contract.refresh_from_db()
         assert contract.allowance_granted is True
@@ -1333,7 +1403,10 @@ class TestAssessmentContractsDetails:
             parse_response_to_soup(
                 response,
                 selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
-                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+                replace_in_attr=[
+                    ("href", str(contract.pk), "[PK of EmployeeContract]"),
+                    ("href", str(assessment.pk), "[PK of Assessment]"),
+                ],
             )
         ) == snapshot(name="contract detail side box with refused allowance and validated selection")
 


### PR DESCRIPTION
Note du ~~mardi 23 juin~~ ~~lundi 20 juillet~~ lundi 31 août : ~~Je n'oublie pas cette PR~~ 🙏 C'est terminé. Je la passe en review maintenant ou... j'attends que quelqu'un touche à nouveau à cette partie du code ? [Finalement, je rouvre la PR mais dites-moi si elle vous paraît trop lointaine / s'il vaut mieux la laisser de côté pour le moment.]
## :thinking: Pourquoi ?

Permet aux utilisateurs qui s'appuient sur les filtres pour leur travail de ne pas perdre la _configuration_ faite de ceux-ci (depuis la liste des contrats) lors de la consultation d'un contrat, c'est-à-dire lors d'un changement de page.

## :cake: Comment ? <!-- optionnel -->

Les paramètres de l'URL qui contrôlent les filtres appliqués sont simplement rajoutés à l'URL du détail du contrat.

On utilise `back_url` afin de préserver les (paramètres de l'URL qui contrôlent) les filtres appliqués lorsqu'on quitte la liste des contrats.

## :desert_island: Comment tester ?

Appliquer des filtres à l'affichage des contrats ; consulter un contrat ; revenir en arrière avec `Retour`.

## :computer: Captures d'écran

.