### PR TITLE
Tech: ajoute une méthode `search_sps_services` au DataInclusionApiClient

### DIFF
--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -94,3 +94,27 @@ class DataInclusionApiClient:
 
     def doc(self, kind, **params) -> list[dict]:
         return self._request(f"/doc/{kind}", params).json()
+
+    def search_sps_services(self, *, code_commune: str) -> list[dict]:
+        """Return SPS services for a given INSEE city code.
+
+        Fetches in-person, free services from DORA and filters on the SPS networks
+        (reseaux_porteurs), which is not a supported query param on the API side (yet).
+        """
+
+        services = self.search_services(
+            code_commune=code_commune,
+            sources=["dora"],  # filter applied on services DI-sides
+            modes_accueil=["en-presentiel"],  # filter applied on structures DI-side
+            frais=["gratuit"],  # filter applied on services DI-sides
+        )
+
+        # Networks qualifying as structured pathway solutions (SPS / solutions de parcours structurées)
+        sps_networks = {
+            "epide",
+            "ecoles-de-la-deuxieme-chance",
+            "plie",
+            "alliance-villes-emploi",
+            "apprentis-dauteuil",
+        }
+        return [s for s in services if sps_networks & set(s["structure"].get("reseaux_porteurs") or [])]

--- a/tests/utils/apis/test_data_inclusion.py
+++ b/tests/utils/apis/test_data_inclusion.py
@@ -1,0 +1,25 @@
+import pytest
+
+from itou.utils import constants as global_constants
+from itou.utils.apis.data_inclusion import DataInclusionApiClient
+
+
+BASE_URL = global_constants.API_DATA_INCLUSION_BASE_URL
+SEARCH_URL = BASE_URL + "/api/v1/search/services"
+
+
+@pytest.mark.parametrize(
+    "reseaux_porteurs,expected",
+    [
+        (["plie"], True),
+        (["epide"], True),
+        ([], False),
+        (None, False),  # reseaux_porteurs can be null in the API response
+    ],
+)
+# tests the client-side filtering on the SPS networks
+def test_search_sps_services_filter(respx_mock, reseaux_porteurs, expected):
+    structure = {"reseaux_porteurs": reseaux_porteurs}
+    respx_mock.get(SEARCH_URL).respond(200, json={"items": [{"service": {"id": "s1", "structure": structure}}]})
+    results = DataInclusionApiClient(BASE_URL, "test-token").search_sps_services(code_commune="59350")
+    assert (len(results) == 1) == expected


### PR DESCRIPTION
## :thinking: Pourquoi ?
[2.1 - Construire les fondations pour appeler le référentiel des SPS](https://app.notion.com/p/gip-inclusion/2-1-Construire-les-fondations-pour-appeler-le-r-f-rentiel-des-SPS-34f5f321b60480aeb6f9fdc0a3a28353)

TLDR: il fallait juste implémenter la recherche de service selon les critères contenus dans le ticket

## :cake: Comment ? <!-- optionnel -->

Les paramètres `source`, `modes_accueil` et `frais` sont filtrables au niveau serveur (query-strings filtrant pour la recherche de services). `reseaux_porteurs` n'est pas disponible en filtre pour la recherche de services (il l'est pour l'endpoint des structures, néanmoins), donc ce filtrage est fait niveau client. `source` est un paramètre présent à la fois sur les services et les structures. Il semble être le même à chaque fois sur les deux, donc je choisis de ne pas re-procéder pas à un filtre client-side derrière.

Le `DataInclusionApiClient` est un très simple wrapper de requête vide de vraie logique, mais comme avec le filtrage client-side on introduit un peu de « vrai » logique, j'ai écrit un petit bout de test pour tester juste cette « vraie » logique.

J'ai été lire le code de data-inclusion pour être sûr de quoi et comment retournait data-inclusion. La carte notion semble dire que les paramètre recherchés s'appliquent uniquement aux structure des services, mais en fait deux s'appliquent aux services, deux s'appliquent au structures.

