### PR TITLE
Tableau de bord: Suppression de l'alerte info webinaire

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -41,22 +41,6 @@
                 <div class="col-12">
                     <div class="tab-content">
                         <h2 class="mb-3 mb-md-4">Salariés et PASS IAE</h2>
-                        {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible=True extra_classes="mb-3" %}
-                            {% fragment as title %}
-                                Webinaire thématique
-                            {% endfragment %}
-                            {% fragment as content %}
-                                <p class="mb-0">
-                                    1 heure pour tout comprendre sur le PASS IAE : simplifiez la gestion de vos PASS IAE (étapes clés, bonnes pratiques et réponses à vos questions en direct).
-                                </p>
-                            {% endfragment %}
-                            {% fragment as call_to_action %}
-                                <a class="btn btn-sm btn-primary has-external-link"
-                                   target="_blank"
-                                   rel="noopener"
-                                   href="https://tally.so/r/b55KY0?event_id=orientation-vers-l-iae-2026-07-06-1779450573403&titre_event=Orientation%20vers%20l%E2%80%99IAE&date_event=06%20juillet%202026%20-%2011h00">Je m'inscris</a>
-                            {% endfragment %}
-                        {% endcomponent_alert %}
                         {% include "includes/mon_recap_banner.html" with request=request mon_recap_banner_departments=mon_recap_banner_departments only %}
                         <form hx-get="{% url 'approvals:list' %}"
                               hx-trigger="change delay:.5s, change from:#id_job_seeker"


### PR DESCRIPTION
## :thinking: Pourquoi ?
https://www.notion.so/gip-inclusion/Bandeau-d-info-webinaire-sur-la-page-salari-s-et-PASS-IAE-34c5f321b60480c8a91be193ed08cc37


## :rotating_light: Attention
Date de publication du bandeau : du 19 mai 2026 **jusqu’au 15 juin 2026**

