### PR TITLE
Admin : tuiles OpenStreetMap bloquées sur les cartes QPV

### DIFF
--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -67,6 +67,21 @@ class ItouGISMixin:
             field.widget = OSMWidget(attrs={"map_width": 800, "map_height": 500})
         return field
 
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        """Relax the site-wide `Referrer-Policy: same-origin` for this view only.
+
+        The GeoDjango map widget loads OpenStreetMap tiles cross-origin. The
+        site-wide `Referrer-Policy: same-origin` strips the Referer, which OSM
+        now rejects with an "Access blocked" tile. Relax the policy to send the
+        bare origin as Referer ON THIS ADMIN PAGE ONLY, so tiles load without
+        weakening the global default.
+
+        See also: https://wiki.openstreetmap.org/wiki/Blocked_tiles#If_you_are_the_owner/a_developer_of_the_application/website
+        """
+        response = super().changeform_view(request, object_id, form_url, extra_context=extra_context)
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
 
 class ItouTabularInline(TabularInline):
     list_select_related = None

--- a/tests/geo/factories.py
+++ b/tests/geo/factories.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from random import sample
 
 import factory
@@ -45,8 +46,10 @@ class ZRRFactory(factory.django.DjangoModelFactory):
         return _params_for_zrr_status(ZRRStatus.IN_ZRR)
 
 
+QPVData = namedtuple("QPVData", ["code", "name", "communes_info", "geometry"])
+
 QPVS = [
-    (
+    QPVData(
         "QP075019",
         "Les Portes Du Vingtième",
         "Paris 20ème arrondissement",
@@ -152,7 +155,7 @@ QPVS = [
         "2.411452124268841 48.87371563163225, "
         "2.4128913231573907 48.874084057785005)))",
     ),
-    (
+    QPVData(
         "QP094025",
         "L'Egalité",
         "Champigny-sur-Marne",
@@ -173,7 +176,7 @@ QPVS = [
         "2.5201064741585313 48.81813500626882, "
         "2.5203776956356165 48.818104418744454)))",
     ),
-    (
+    QPVData(
         "QP093028",
         "Franc Moisin - Cosmonautes - Cristino Garcia - Landy",
         "Aubervilliers, La Courneuve, Saint-Denis",
@@ -726,29 +729,15 @@ QPVS = [
 ]
 
 
-def _format_qpv_tuple(qpv):
-    code, name, infos, spec = qpv
-    return {
-        "code": code,
-        "name": name,
-        "communes_info": infos,
-        "geometry": multipolygon_to_geometry(spec),
-    }
+def _create_qpv(data: QPVData) -> QPV:
+    return QPV.objects.create(
+        code=data.code,
+        name=data.name,
+        communes_info=data.communes_info,
+        geometry=multipolygon_to_geometry(data.geometry),
+    )
 
 
-def _params_for_random_qpv() -> dict:
-    return _format_qpv_tuple(sample(QPVS, 1))
-
-
-class QPVFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = QPV
-
-    code = name = communes_info = geometry = None
-
-    @classmethod
-    def _adjust_kwargs(cls, **kwargs):
-        if code := kwargs["code"]:
-            [qpv] = filter(lambda qpv: qpv[0] == code, QPVS)
-            return _format_qpv_tuple(qpv)
-        return _params_for_random_qpv()
+def create_qpv(code: str) -> QPV:
+    [data] = (qpv for qpv in QPVS if qpv.code == code)
+    return _create_qpv(data)

--- a/tests/geo/test_admin.py
+++ b/tests/geo/test_admin.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+
+from tests.geo.factories import create_qpv
+from tests.users.factories import ItouStaffFactory
+
+
+@pytest.fixture
+def admin_client(client, db):
+    admin = ItouStaffFactory(is_staff=True, is_superuser=True)
+    client.force_login(admin)
+    return client
+
+
+@pytest.mark.parametrize(
+    "url_name,policy",
+    [
+        ("admin:geo_qpv_change", "strict-origin-when-cross-origin"),
+        ("admin:geo_qpv_changelist", "same-origin"),
+    ],
+)
+def test_referrer_policy_for_map_tiles(admin_client, url_name, policy):
+    """The QPV change page render the GeoDjango OpenStreetMap map widget, whose tiles are loaded cross-origin.
+
+    This specific page must override the site-wide `same-origin` policy so the browser sends a `Referer` to OSM
+    (else the tiles are blocked). Other pages like the changelist have no map and must keep the strict global default,
+    proving the relaxation is scoped to the GIS change form page only.
+
+    See also: https://wiki.openstreetmap.org/wiki/Blocked_tiles#If_you_are_the_owner/a_developer_of_the_application/website
+    """
+    qpv = create_qpv("QP075019")
+    args = [qpv.pk] if url_name == "admin:geo_qpv_change" else []
+    response = admin_client.get(reverse(url_name, args=args))
+    assert response.status_code == 200
+    assert response.headers["Referrer-Policy"] == policy

--- a/tests/geo/test_qpv.py
+++ b/tests/geo/test_qpv.py
@@ -5,7 +5,7 @@ import pytest
 
 from itou.geo.models import QPV
 from itou.geo.utils import coords_to_geometry
-from tests.geo.factories import QPVFactory
+from tests.geo.factories import create_qpv
 
 
 @dataclass
@@ -26,7 +26,7 @@ class _GoodCoordsType:
 @pytest.fixture(autouse=True)
 def qpv():
     for code in ["QP093028", "QP075019"]:
-        QPVFactory(code=code)
+        create_qpv(code)
 
 
 def test_user_in_qpv():

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -31,7 +31,7 @@ from tests.approvals.factories import (
 )
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, JobDescriptionFactory
 from tests.eligibility.factories import IAEEligibilityDiagnosisFactory
-from tests.geo.factories import QPVFactory
+from tests.geo.factories import create_qpv
 from tests.gps.factories import FollowUpGroupFactory, FollowUpGroupMembershipFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory
 from tests.job_applications.factories import JobApplicationFactory
@@ -131,7 +131,7 @@ def test_populate_analytics(snapshot):
 # return datetime.date objects that are not equal...
 @pytest.mark.django_db(transaction=True)
 def test_populate_job_seekers(snapshot):
-    QPVFactory(code="QP075019")
+    create_qpv("QP075019")
 
     # Importing this file makes a query so we need to do it inside a test
     # and before the assertNumQueries

--- a/tests/metabase/test_utils.py
+++ b/tests/metabase/test_utils.py
@@ -3,13 +3,13 @@ import pytest
 from itou.geo.utils import coords_to_geometry
 from itou.metabase.tables.utils import get_code_commune, get_qpv_job_seeker_pks, get_zrr_status_for_insee_code
 from tests.cities.factories import create_test_cities
-from tests.geo.factories import QPVFactory, ZRRFactory
+from tests.geo.factories import ZRRFactory, create_qpv
 from tests.prescribers.factories import PrescriberOrganizationFactory
 from tests.users.factories import JobSeekerFactory
 
 
 def test_get_qpv_job_seeker_pks():
-    QPVFactory(code="QP093028")
+    create_qpv("QP093028")
 
     # Somewhere in QPV QP093028 (Aubervilliers)
     job_seeker_in_qpv = JobSeekerFactory(coords=coords_to_geometry("48.917735", "2.387311"), geocoding_score=0.9)

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -22,7 +22,7 @@ from itou.utils.mocks.address_format import (
 )
 from itou.utils.validators import validate_nir
 from tests.cities.factories import create_city_in_zrr, create_city_partially_in_zrr
-from tests.geo.factories import QPVFactory, ZRRFactory
+from tests.geo.factories import ZRRFactory, create_qpv
 from tests.utils.factory_boy import AutoNowOverrideMixin
 
 
@@ -280,7 +280,7 @@ class JobSeekerFactory(UserFactory):
         # Using ZRR or QPV means that we must have some factories / data ready beforehand
         # Did not find a better way to do Traits additional setup...
         if kwargs.get("with_address_in_qpv"):
-            QPVFactory(code="QP093028")  # Aubervilliers : in QPV
+            create_qpv("QP093028")  # Aubervilliers : in QPV
 
         if kwargs.get("with_city_in_zrr"):
             ZRRFactory(insee_code="12018")

--- a/tests/utils/test_admin.py
+++ b/tests/utils/test_admin.py
@@ -29,7 +29,7 @@ from tests.companies.factories import SiaeFinancialAnnexFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.files.factories import FileFactory
 from tests.geiq_assessments.factories import AssessmentCampaignFactory
-from tests.geo.factories import QPVFactory
+from tests.geo.factories import create_qpv
 from tests.institutions.factories import (
     InstitutionFactory,
     InstitutionMembershipFactory,
@@ -129,7 +129,7 @@ def test_all_admin(admin_client, mocker, subtests):
     )
 
     # Call factories that need parameters
-    QPVFactory(code="QP093028")
+    create_qpv("QP093028")
     GEIQEligibilityDiagnosisFactory(from_employer=True)
     IAEEligibilityDiagnosisFactory(from_employer=True)
 
@@ -157,7 +157,6 @@ def test_all_admin(admin_client, mocker, subtests):
             JobSeekerFactory,  # Already used above
             LaborInspectorInvitationFactory,  # Already used above
             NexusRessourceSyncStatusFactory,  # Already used above
-            QPVFactory,  # Already used above
             SanctionsFactory,  # Called by EvaluatedJobApplicationSanctionFactory
             SiaeFinancialAnnexFactory,  # Called by SiaeConventionFactory
             UserFactory,  # A lot of subfactories, no need to use it


### PR DESCRIPTION
## :thinking: Pourquoi ?

Depuis fin mars 2026, les serveurs d'OpenStreetMap refusent les requêtes sans en-tête `Referer` (image "Access blocked - Referer is required"). Or notre `Referrer-Policy: same-origin` (défaut Django depuis `3.1`) supprime le `Referer` sur les requêtes cross-origin. Résultat : la carte du modèle QPV dans l'admin (widget `GeoDjango`/`OpenLayers`) n'affiche plus correctement le fond de carte.

Voir aussi : https://community.openstreetmap.org/t/error-403-when-using-local-files-referer-missing-can-i-use-user-agent-and-what-should-it-contain/142447

## :cake: Comment ?

`ItouGISMixin.changeform_view` pose `Referrer-Policy: strict-origin-when-cross-origin` sur cette seule page d'admin. Le navigateur envoie alors l'origine comme `Referer` à OSM (sans fuiter le chemin ni les paramètres), et les tuiles se chargent à nouveau. Le widget GeoDjango n'est pas modifié, et le défaut `same-origin` reste inchangé sur tout le reste du site.

Test ajouté (`tests/geo/test_admin.py`) : vérifie l'en-tête sur la page de modification QPV, et qu'une page admin sans carte (changelist) conserve bien `same-origin`.

## :computer: Captures d'écran

### AVANT

<img width="1836" height="1590" alt="Screenshot from 2026-06-15 10-16-23" src="https://github.com/user-attachments/assets/11f475bb-e92e-4452-be87-84b9efd8f8ac" />

### APRÈS

<img width="1836" height="1590" alt="Screenshot from 2026-06-15 10-15-44" src="https://github.com/user-attachments/assets/b88ce3a8-39af-420a-b13a-a1aa1877c1cb" />