### PR TITLE
Tech : Purge automatique des matériels TOTP désactivés

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -53,6 +53,7 @@
   "0 0 * * MON CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 1 * * MON $ROOT/clevercloud/run_management_command.sh delete_unused_files",
   "0 2 * * MON $ROOT/clevercloud/run_management_command.sh populate_metabase_matomo --wet-run",
+  "10 5 * * MON $ROOT/clevercloud/run_management_command.sh purge_disabled_otp_devices --wet-run",
 
   "0 0 1 * * $ROOT/clevercloud/run_management_command.sh sync_cities --wet-run",
   "0 0 3 * * $ROOT/clevercloud/run_management_command.sh delete_old_nir_modification_requests --wet-run",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -851,6 +851,9 @@ SERIALIZATION_MODULES = {
 OTP_TOTP_ISSUER = f"Les Emplois de l'inclusion ({ITOU_ENVIRONMENT})"
 OTP_ADMIN_HIDE_SENSITIVE_DATA = True
 REQUIRE_OTP_FOR_STAFF = os.getenv("REQUIRE_OTP_FOR_STAFF", "True") == "True"
+OTP_DEVICES_GRACE_PERIOD_BEFORE_DELETION = datetime.timedelta(
+    days=int(os.getenv("OTP_DEVICES_GRACE_PERIOD_BEFORE_DELETION_DAYS", 90))
+)
 
 # anonymize users
 # ------------------------------------------------------------------------------

--- a/itou/otp/management/commands/purge_disabled_otp_devices.py
+++ b/itou/otp/management/commands/purge_disabled_otp_devices.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.utils import timezone
+
+from itou.otp.models import ItouTOTPDevice
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete OTP devices that have been disabled long ago (we keep them for a grace period for auditing purposes)."
+    )
+
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
+    def add_arguments(self, parser):
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    def handle(self, *, wet_run, **options):
+        threshold = timezone.now() - settings.OTP_DEVICES_GRACE_PERIOD_BEFORE_DELETION
+
+        devices = ItouTOTPDevice.objects.filter(disabled_at__lt=threshold)
+        if wet_run:
+            count, _ = devices.delete()
+            self.logger.info("%d disabled TOTP devices have been purged", count)
+        else:
+            self.logger.info("%d disabled TOTP devices would be purged", devices.count())

--- a/itou/otp/models.py
+++ b/itou/otp/models.py
@@ -44,7 +44,6 @@ class ItouTOTPDevice(
         related_name="itou_totp_devices",
         on_delete=models.CASCADE,
     )
-    # FIXME (dbaty): add cronjob to purge disabled devices after 3 months
     disabled_at = models.DateTimeField(verbose_name="date de désactivation", null=True)
 
     class Meta:

--- a/tests/otp/test_purge_disabled_otp_devices.py
+++ b/tests/otp/test_purge_disabled_otp_devices.py
@@ -1,0 +1,32 @@
+import datetime
+
+from django.test.testcases import call_command
+from django.utils import timezone
+from pytest_django.asserts import assertQuerySetEqual
+
+from itou.otp.models import ItouTOTPDevice
+from tests.otp.factories import ItouTOTPDeviceFactory
+
+
+class TestCommand:
+    def setup_method(self):
+        self.not_disabled = ItouTOTPDeviceFactory(disabled_at=None)
+        self.disabled_too_recently = ItouTOTPDeviceFactory(disabled_at=timezone.now() - datetime.timedelta(days=30))
+        self.disabled_long_ago = ItouTOTPDeviceFactory(disabled_at=timezone.now() - datetime.timedelta(days=91))
+
+    def test_wet_run(self, caplog):
+        assert ItouTOTPDevice.objects.count() == 3
+        call_command("purge_disabled_otp_devices", wet_run=True)
+        assert ItouTOTPDevice.objects.count() == 2
+        assertQuerySetEqual(
+            ItouTOTPDevice.objects.all(),
+            [self.not_disabled, self.disabled_too_recently],
+            ordered=False,
+        )
+        assert caplog.messages[0] == "1 disabled TOTP devices have been purged"
+
+    def test_dry_run(self, caplog):
+        assert ItouTOTPDevice.objects.count() == 3
+        call_command("purge_disabled_otp_devices", wet_run=False)
+        assert ItouTOTPDevice.objects.count() == 3
+        assert caplog.messages[0] == "1 disabled TOTP devices would be purged"


### PR DESCRIPTION
On conserve les matériels TOTP désactivés pendant un certain temps (pour audit si besoin), puis on les supprime par cette nouvellement management command.

