### PR TITLE
tests: Retirer la redéfinition de la fixture admin_client

### DIFF
--- a/tests/geo/test_admin.py
+++ b/tests/geo/test_admin.py
@@ -2,14 +2,6 @@ import pytest
 from django.urls import reverse
 
 from tests.geo.factories import create_qpv
-from tests.users.factories import ItouStaffFactory
-
-
-@pytest.fixture
-def admin_client(client, db):
-    admin = ItouStaffFactory(is_staff=True, is_superuser=True)
-    client.force_login(admin)
-    return client
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Elle existe déjà ailleurs.
