### PR TITLE
Tech : Meilleure interface admin pour ItouTOTPDevice

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -856,7 +856,6 @@ SERIALIZATION_MODULES = {
 # OTP
 # ------------------------------------------------------------------------------
 OTP_TOTP_ISSUER = f"Les Emplois de l'inclusion ({ITOU_ENVIRONMENT})"
-OTP_ADMIN_HIDE_SENSITIVE_DATA = True
 REQUIRE_OTP_FOR_STAFF = os.getenv("REQUIRE_OTP_FOR_STAFF", "True") == "True"
 REQUIRE_MFA_FOR_PROS = os.getenv("REQUIRE_MFA_FOR_PROS", "False") == "True"
 OTP_DEVICES_GRACE_PERIOD_BEFORE_DELETION = datetime.timedelta(

--- a/itou/otp/admin.py
+++ b/itou/otp/admin.py
@@ -7,7 +7,16 @@ from itou.utils.admin import ItouModelAdmin, ReadonlyMixin
 
 @admin.register(ItouTOTPDevice)
 class ItouTOTPDeviceAdmin(ReadonlyMixin, ItouModelAdmin):
-    pass  # FIXME
+    list_display = (
+        "user",
+        "last_used_at",
+    )
+    list_select_related = ("user",)
+
+    def get_fields(self, request, obj=None):
+        fields = super().get_fields(request, obj=obj)
+        fields.remove("key")
+        return fields
 
 
 admin.site.unregister(TOTPDevice)

--- a/itou/otp/migrations/0002_itoutotpdevice.py
+++ b/itou/otp/migrations/0002_itoutotpdevice.py
@@ -99,6 +99,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 "constraints": [models.UniqueConstraint(fields=("user", "name"), name="unique_name_per_user")],
+                "verbose_name": "appareil d’authentification (TOTP)",
+                "verbose_name_plural": "appareils d’authentification (TOTP)",
             },
         ),
     ]

--- a/itou/otp/models.py
+++ b/itou/otp/models.py
@@ -47,6 +47,8 @@ class ItouTOTPDevice(
     disabled_at = models.DateTimeField(verbose_name="date de désactivation", null=True)
 
     class Meta:
+        verbose_name = "appareil d’authentification (TOTP)"
+        verbose_name_plural = "appareils d’authentification (TOTP)"
         constraints = [
             models.UniqueConstraint(
                 fields=["user", "name"],

--- a/tests/otp/test_admin.py
+++ b/tests/otp/test_admin.py
@@ -1,0 +1,14 @@
+from django.urls import reverse
+from pytest_django.asserts import assertNotContains
+
+from tests.otp.factories import ItouTOTPDeviceFactory
+
+
+def test_admin_details(admin_client):
+    key = "8fe0a9983c7dddb4acb0146c5507553371e9f211"
+    device = ItouTOTPDeviceFactory(key=key)
+
+    url = reverse("admin:otp_itoutotpdevice_change", args=(device.pk,))
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    assertNotContains(response, key)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que c'était très vide... Alors que maintenant c'est (un peu) moins vide.

Liste :

<img width="985" height="363" alt="liste" src="https://github.com/user-attachments/assets/b9062da7-0f17-4a5a-b8fc-d4124803e9e9" />

Détails : 

<img width="707" height="972" alt="détails" src="https://github.com/user-attachments/assets/c7540c26-ad7a-4ff9-a39b-6884b75d5b11" />

Je n'ai pas pris la peine de modifier le verbose_name de tous les champs (qui est en anglais, fourni par la classe de `django_otp` dont on dérive), car ça ne me semble pas nécessaire.


Et une PR arrive pour ajouter la date de création (qui n'existe pas dans le modèle qu'on sous-classe).