### PR TITLE
SPS - Prescripteur : carte pour visualiser les solutions recommandées

### DIFF
--- a/itou/recommendations/_mock_data.py
+++ b/itou/recommendations/_mock_data.py
@@ -97,6 +97,8 @@ HARDCODED_RECOMMENDATIONS = [
                     "socio-professionnelle."
                 ),
                 "show_map": True,
+                "lat": 45.8326,
+                "lon": 4.7719,
                 "jobs": [],
                 "pk": "77739d9b-2fe3-4a41-a57d-d8e0ebc44ff8",
             },
@@ -113,6 +115,8 @@ HARDCODED_RECOMMENDATIONS = [
                 "distance_km": "2,7",
                 "address": "513 Rue Sans Souci, 69760 Limonest",
                 "show_map": False,
+                "lat": 45.8201,
+                "lon": 4.7853,
                 "jobs": [
                     {"label": "Exploitant / Exploitante agricole", "city": "Le Bouscat - 33"},
                 ],
@@ -130,7 +134,7 @@ HARDCODED_RECOMMENDATIONS = [
                 "subtitle": "(Régie De Quartier Tremblay)",
                 "distance_km": "2,7",
                 "address": "513 Rue Sans Souci, 69760 Limonest",
-                "show_map": False,
+                "show_map": True,
                 "jobs": [
                     {"label": "Aide maçon/maçonne Voirie et réseaux divers", "city": "Le Bouscat - 33"},
                     {
@@ -141,6 +145,8 @@ HARDCODED_RECOMMENDATIONS = [
                     {"label": "Aide plombier / plombière", "city": "Le Bouscat - 33"},
                     *_SIAE_MORE_JOBS,
                 ],
+                "lat": 45.8410,
+                "lon": 4.7601,
                 "pk": "820a949d-7c81-4250-921c-87b1255510b1",
             },
             {
@@ -149,7 +155,7 @@ HARDCODED_RECOMMENDATIONS = [
                 "subtitle": "(Régie De Quartier Tremblay)",
                 "distance_km": "2,7",
                 "address": "513 Rue Sans Souci, 69760 Limonest",
-                "show_map": False,
+                "show_map": True,
                 "jobs": [
                     {"label": "Aide maçon/maçonne Voirie et réseaux divers", "city": "Le Bouscat - 33"},
                     {
@@ -160,6 +166,8 @@ HARDCODED_RECOMMENDATIONS = [
                     {"label": "Aide plombier / plombière", "city": "Le Bouscat - 33"},
                     *_SIAE_MORE_JOBS,
                 ],
+                "lat": 45.8152,
+                "lon": 4.7902,
                 "pk": "a72e4c09-3fd4-45c0-8477-bb85f17c5da9",
             },
         ],

--- a/itou/recommendations/services.py
+++ b/itou/recommendations/services.py
@@ -86,3 +86,19 @@ def beneficiary_diagnostic_for(*, beneficiary):
 def recommendations_for(*, beneficiary, filters=None):
     # FIXME llalba: hardcoded
     return _mock_data.HARDCODED_RECOMMENDATIONS
+
+
+def map_points_for(recommendations):
+    """Flatten the recommendations into the marker list consumed by the OpenLayers map."""
+    return [
+        {
+            "name": provider["name"],
+            "kind_label": item["kind_label"],
+            "address": provider["address"],
+            "lat": provider["lat"],
+            "lon": provider["lon"],
+        }
+        for item in recommendations
+        for provider in item["providers"]
+        if provider["show_map"]
+    ]

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -435,3 +435,28 @@ table.table td > .modal .modal-content {
         display: none !important;
     }
 }
+
+/* Recommendations map (OpenLayers) */
+.c-box--recommendations-map {
+
+    overflow: hidden;
+
+    .c-box--recommendations-map__wrapper {
+        margin-left: -1.5rem;
+        margin-right: -1.5rem;
+        margin-bottom: -1.5rem;
+        aspect-ratio: 21 / 9;
+    }
+
+    #recommendations-map {
+        display: block;
+        height: 100%;
+        width: 100%;
+    }
+}
+
+@media (min-width: 1640px) {
+    .c-box--recommendations-map .c-box--recommendations-map__wrapper {
+        aspect-ratio: 1 / 1;
+    }
+}

--- a/itou/static/js/recommendations_map.js
+++ b/itou/static/js/recommendations_map.js
@@ -1,0 +1,134 @@
+// Renders an OpenLayers map of recommendations for a beneficiary, with a popup
+// on each marker showing the recommendation's kind, name, and address.
+// Data comes from the `#recommendations-map-points` JSON script tag emitted by
+// the `beneficiary_actions.html` template (see `map_points` in the view).
+document.addEventListener("DOMContentLoaded", function () {
+    const target = document.getElementById("recommendations-map");
+    const dataNode = document.getElementById("recommendations-map-points");
+    if (!target || !dataNode) {
+        return;
+    }
+
+    const points = JSON.parse(dataNode.textContent);
+
+    // https://openlayers.org/en/latest/apidoc/module-ol_style_Style-Style.html
+    const markerStyle = new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 7,
+            fill: new ol.style.Fill({ color: "#000091" }),
+            stroke: new ol.style.Stroke({ color: "#ffffff", width: 2 }),
+        }),
+    });
+
+    const features = points.map(function (point) {
+        // https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html
+        const feature = new ol.Feature({
+            geometry: new ol.geom.Point(ol.proj.fromLonLat([point.lon, point.lat])),
+            kind_label: point.kind_label,
+            name: point.name,
+            address: point.address,
+        });
+        feature.setStyle(markerStyle);
+        return feature;
+    });
+
+    // https://openlayers.org/en/latest/apidoc/module-ol_layer_Vector-VectorLayer.html
+    const vectorLayer = new ol.layer.Vector({
+        source: new ol.source.Vector({ features: features }),
+    });
+
+    // https://openlayers.org/en/latest/apidoc/module-ol_source_OSM-OSM.html
+    const osmSource = new ol.source.OSM({
+        // Relax the referrer policy for tile images only so a Referer is sent and
+        // OSM tiles load (see also itou/utils/admin.py), avoid 403 errors
+        tileLoadFunction: function (tile, src) {
+            const img = tile.getImage();
+            img.referrerPolicy = "strict-origin-when-cross-origin";
+            img.src = src;
+        },
+    });
+
+    // The overlay element is only a positioning anchor, the visible popup is a
+    // manually-triggered Bootstrap tooltip attached to it (see htmx_compat.js for the
+    // same manual-construction pattern)
+    const popupElement = document.getElementById("recommendations-map-popup");
+    // https://openlayers.org/en/latest/apidoc/module-ol_Overlay-Overlay.html
+    const popup = new ol.Overlay({
+        element: popupElement,
+        positioning: "bottom-center",
+        stopEvent: true,
+    });
+    // Bootstrap's Tooltip.show() bails unless `title` resolves to a non-empty value
+    // (its content guard only inspects the title, not setContent()), so feed the current
+    // marker's HTML through a `title` function that is re-resolved on each show
+    let popupContent = "";
+    const tooltip = new bootstrap.Tooltip(popupElement, {
+        html: true,
+        animation: false,
+        trigger: "manual", // 'show' and 'hide' are called explicitly in code
+        placement: "top",
+        title: () => popupContent,
+    });
+
+    // https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html
+    const map = new ol.Map({
+        target: target,
+        layers: [new ol.layer.Tile({ source: osmSource }), vectorLayer],
+        overlays: [popup],
+        view: new ol.View({
+            // Sensible default (Paris) used when no markers are available
+            center: ol.proj.fromLonLat([2.333, 48.866]),
+            zoom: 12,
+        }),
+    });
+
+    if (features.length) {
+        map.getView().fit(vectorLayer.getSource().getExtent(), {
+            padding: [40, 40, 40, 40],
+            maxZoom: 15,
+        });
+    }
+
+    function popupLine(text, className) {
+        const line = document.createElement("div");
+        line.textContent = text || "";
+        if (className) {
+            line.className = className;
+        }
+        return line;
+    }
+
+    // Show a marker's details on click, hide the popup when clicking elsewhere
+    map.on("singleclick", function (evt) {
+        const feature = map.forEachFeatureAtPixel(evt.pixel, (candidate) => candidate);
+        if (!feature) {
+            tooltip.hide();
+            popup.setPosition(undefined);
+            return;
+        }
+        const content = document.createElement("div");
+        content.append(
+            popupLine(feature.get("kind_label"), "fw-bold"),
+            popupLine(feature.get("name")),
+            popupLine(feature.get("address"), "text-muted"),
+        );
+        // `content` is built with textContent, so its serialized HTML is escaped (XSS-safe
+        // even though the tooltip renders it as HTML)
+        popupContent = content.innerHTML;
+        popup.setPosition(feature.getGeometry().getCoordinates());
+        // Re-show so the `title` function is re-resolved with the new marker's content
+        tooltip.hide();
+        tooltip.show();
+    });
+
+    // Dismiss the popup as soon as the map moves so it never drifts outside the map area
+    map.on("movestart", function () {
+        tooltip.hide();
+        popup.setPosition(undefined);
+    });
+
+    // Set a hand cursor over clickable markers in the map
+    map.on("pointermove", function (evt) {
+        map.getTargetElement().style.cursor = map.hasFeatureAtPixel(evt.pixel) ? "pointer" : "";
+    });
+});

--- a/itou/templates/recommendations/beneficiary_actions.html
+++ b/itou/templates/recommendations/beneficiary_actions.html
@@ -86,12 +86,23 @@
                 {% endpartialdef %}
             </div>
             <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
-                {# FIXME llalba: pas de leaflet pour le moment, juste un placeholder statique #}
-                <div class="c-box mb-3 mb-md-4">
+                <div class="c-box c-box--recommendations-map mb-3 mb-md-4">
                     <h3>Carte des solutions</h3>
-                    <p class="mb-0">Bientôt disponible.</p>
+                    <div class="c-box--recommendations-map__wrapper">
+                        {{ map_points|json_script:"recommendations-map-points" }}
+                        <div id="recommendations-map">
+                            <div id="recommendations-map-popup"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_script_files %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'vendor/ol/ol.css' %}">
+    <script src="{% static 'vendor/ol/ol.js' %}"></script>
+    <script src="{% static 'js/recommendations_map.js' %}"></script>
 {% endblock %}

--- a/itou/www/recommendations/views/beneficiary_views.py
+++ b/itou/www/recommendations/views/beneficiary_views.py
@@ -65,6 +65,7 @@ def beneficiary_actions(request, public_id, template_name="recommendations/benef
     )
     context["recommendations"] = services.recommendations_for(beneficiary=context["beneficiary"])
     context["recommendations_count"] = sum(len(item["providers"]) for item in context["recommendations"])
+    context["map_points"] = services.map_points_for(context["recommendations"])
     if request.htmx:
         template_name += "#actions-results"
     return render(request, template_name, context)

--- a/tests/www/recommendations/__snapshots__/test_views.ambr
+++ b/tests/www/recommendations/__snapshots__/test_views.ambr
@@ -1,4 +1,23 @@
 # serializer version: 1
+# name: TestBeneficiaryActions.test_map_assets_and_data_rendered
+  '''
+  <div class="c-box c-box--recommendations-map mb-3 mb-md-4">
+      <h3>
+          Carte des solutions
+      </h3>
+      <div class="c-box--recommendations-map__wrapper">
+          <script id="recommendations-map-points" type="application/json">
+              [{"name": "Lille Avenirs", "kind_label": "PLIE", "address": "513 Rue Sans Souci, 69760 Limonest", "lat": 45.8326, "lon": 4.7719}, {"name": "Une nouvelle chance", "kind_label": "emplois d\u2019insertion (SIAE)", "address": "513 Rue Sans Souci, 69760 Limonest", "lat": 45.841, "lon": 4.7601}, {"name": "Une nouvelle chance", "kind_label": "emplois d\u2019insertion (SIAE)", "address": "513 Rue Sans Souci, 69760 Limonest", "lat": 45.8152, "lon": 4.7902}]
+          </script>
+          <div id="recommendations-map">
+              <div id="recommendations-map-popup">
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
 # name: TestBeneficiaryProfile.test_renders_beneficiary_fields
   '''
   <div aria-labelledby="profile-tab" class="tab-pane fade show active" id="profile-tab-pane" role="tabpanel">

--- a/tests/www/recommendations/test_services.py
+++ b/tests/www/recommendations/test_services.py
@@ -167,3 +167,35 @@ class TestProfileHelpers:
         only_rsa = {ProfileFlag.RSA.value: True}
         labels = services.profile_criteria_labels(only_rsa)
         assert labels == [ProfileFlag.RSA.label]
+
+
+class TestMapPointsFor:
+    def test_keeps_only_show_map_providers_and_promotes_kind_label(self):
+        recommendations = [
+            {
+                "kind_label": "Formation",
+                "providers": [
+                    {"name": "Alpha", "address": "1 rue A", "lat": 45.0, "lon": 4.0, "show_map": True},
+                    {"name": "Beta", "address": "2 rue B", "lat": 45.1, "lon": 4.1, "show_map": False},
+                ],
+            },
+            {
+                "kind_label": "Emploi",
+                "providers": [
+                    {"name": "Gamma", "address": "3 rue C", "lat": 46.0, "lon": 5.0, "show_map": True},
+                ],
+            },
+        ]
+        assert services.map_points_for(recommendations) == [
+            {"name": "Alpha", "kind_label": "Formation", "address": "1 rue A", "lat": 45.0, "lon": 4.0},
+            {"name": "Gamma", "kind_label": "Emploi", "address": "3 rue C", "lat": 46.0, "lon": 5.0},
+        ]
+
+    def test_empty_when_no_provider_is_shown(self):
+        recommendations = [
+            {
+                "kind_label": "Formation",
+                "providers": [{"name": "Alpha", "address": "a", "lat": 1.0, "lon": 2.0, "show_map": False}],
+            },
+        ]
+        assert services.map_points_for(recommendations) == []

--- a/tests/www/recommendations/test_views.py
+++ b/tests/www/recommendations/test_views.py
@@ -2,6 +2,7 @@ import uuid
 from functools import partial
 
 import pytest
+from django.templatetags.static import static
 from django.test import override_settings
 from django.urls import reverse
 from itoutils.django.testing import assertSnapshotQueries
@@ -270,6 +271,39 @@ class TestBeneficiaryActions:
         assert response.context["recommendations_count"] == sum(
             len(item["providers"]) for item in _mock_data.HARDCODED_RECOMMENDATIONS
         )
+
+    def test_map_points_only_expose_show_map_true(self, client, advisor):
+        user, _ = advisor
+        beneficiary = BeneficiaryFactory(referent_email=user.email, organization_safir=SAFIR)
+        client.force_login(user)
+        response = client.get(
+            reverse("recommendations:beneficiary_actions", kwargs={"public_id": beneficiary.public_id})
+        )
+        shown = [
+            p["name"] for item in _mock_data.HARDCODED_RECOMMENDATIONS for p in item["providers"] if p["show_map"]
+        ]
+        hidden = sum(
+            1 for item in _mock_data.HARDCODED_RECOMMENDATIONS for p in item["providers"] if not p["show_map"]
+        )
+        assert [point["name"] for point in response.context["map_points"]] == shown
+        assert hidden > 0
+
+    def test_map_assets_and_data_rendered(self, client, advisor, snapshot):
+        user, _ = advisor
+        beneficiary = BeneficiaryFactory(referent_email=user.email, organization_safir=SAFIR)
+        client.force_login(user)
+        response = client.get(
+            reverse("recommendations:beneficiary_actions", kwargs={"public_id": beneficiary.public_id})
+        )
+        body = response.content.decode()
+        # OpenLayers loaded from the vendored bundle, not a CDN. static() resolves the
+        # ManifestStaticFilesStorage hash (CI) or the plain path (local) for us.
+        assert static("vendor/ol/ol.js") in body
+        assert static("vendor/ol/ol.css") in body
+        assert static("js/recommendations_map.js") in body
+        # Map container, its JSON data island, and the popup container
+        soup = parse_response_to_soup(response, ".c-box--recommendations-map")
+        assert pretty_indented(soup) == snapshot
 
 
 class TestMobilise:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite de [cette PR](https://github.com/gip-inclusion/les-emplois/pull/8162). La colonne de droite de la page "_Actions recommandées_" affichait un placeholder statique "_Bientôt disponible_" à la place d'une carte. Cette PR introduit cette carte. L'objectif est de visualiser géographiquement les parcours structurés recommandés pour un bénéficiaire.

## :cake: Comment ? <!-- optionnel -->

- Pour l'instant, tout repose toujours sur des données statiques factices.
- Le projet embarque déjà un bundle OpenLayers, utilisé par le widget GIS de l'admin (`itou/utils/widgets.py`, `itou/static/vendor/ol/ol.{js,css}`). Cette PR réutilise ce même bundle.
- Un nouveau service `map_points_for()` extrait depuis la liste des recommandations les solutions voulues, les regroupe dans liste de points `{name, kind_label, address, lat, lon}`. La vue `beneficiary_actions` injecte cette liste dans le contexte sous la clé `map_points`.
- Le template sérialise les points dans une balise `<script type="application/json">` via le filtre Django `json_script`, puis charge le bundle OpenLayers (déjà présent, aucune nouvelle dépendance) et le script `recommendations_map.js`. 
- `recommendations_map.js` lit ce JSON, crée un marqueur OpenLayers par point, ajuste automatiquement la vue pour englober tous les marqueurs, et affiche un _tooltip_ Bootstrap déclenché manuellement au clic sur un marqueur avec le type, le nom et l'adresse du parcours structuré.

## :desert_island: Comment tester ?

Des tests unitaires couvrent `map_points_for()` (filtrage, liste vide) et la vue (filtrage en contexte, présence des assets et du DOM dans la réponse HTML)... Mais faute de Playwright ou équivalent il n'y pas de tests e2e couvrant exhaustivement le JS.

## :computer: Captures d'écran

<img width="2544" height="1576" alt="image" src="https://github.com/user-attachments/assets/1991279a-3342-40c7-aa65-e3891d42931a" />
