### PR TITLE
Tech: Test de la commande `scan_s3_files`

### DIFF
--- a/itou/antivirus/management/commands/scan_s3_files.py
+++ b/itou/antivirus/management/commands/scan_s3_files.py
@@ -122,9 +122,17 @@ class Command(BaseCommand):
 
         viruses_keys = set(viruses)
         scans = []
-        for scan in Scan.objects.filter(file_id__in=viruses):
-            scan.clamav_signature = viruses.pop(scan.file_id)
+        for scan in Scan.objects.select_related("file").filter(file__key__in=viruses):
+            scan.clamav_signature = viruses.pop(scan.file.key)
             scans.append(scan)
         Scan.objects.bulk_update(scans, fields=["clamav_signature"])
-        Scan.objects.bulk_create(Scan(file_id=key, clamav_signature=signature) for key, signature in viruses.items())
+        new_infected_files = File.objects.filter(key__in=viruses.keys(), scan__isnull=True)
+        Scan.objects.bulk_create(
+            Scan(
+                file_id=id,
+                clamav_signature=signature,
+                infected=True,
+            )
+            for id, signature in [(file.id, viruses[file.key]) for file in new_infected_files]
+        )
         return viruses_keys

--- a/tests/antivirus/factories.py
+++ b/tests/antivirus/factories.py
@@ -1,0 +1,11 @@
+import factory
+
+from itou.antivirus.models import Scan
+from tests.files.factories import FileFactory
+
+
+class ScanFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Scan
+
+    file = factory.SubFactory(FileFactory)

--- a/tests/antivirus/test_scan_s3_files.py
+++ b/tests/antivirus/test_scan_s3_files.py
@@ -1,0 +1,85 @@
+import io
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.core.files.storage import default_storage
+from django.core.management import call_command
+from django.utils import timezone
+from pytest_django.asserts import assertQuerySetEqual
+
+from itou.antivirus.models import Scan
+from itou.files.models import File
+from tests.antivirus.factories import ScanFactory
+from tests.files.factories import FileFactory
+
+
+@pytest.mark.usefixtures("temporary_bucket")
+def test_scan_s3_files(mocker):
+    VIRUS = "GLaDOS-Signature"
+    now = timezone.now()
+    one_week_ago = now - relativedelta(days=7)
+    one_month_ago = now - relativedelta(months=1)
+
+    # clean file
+    file1 = FileFactory()
+    # infected file
+    file2 = FileFactory()
+    # clean file that was checked > 1 month ago
+    file3 = ScanFactory(clamav_completed_at=one_month_ago, infected=False).file
+    # clean file that was checked > 1 month ago and is now infected
+    file4 = ScanFactory(clamav_completed_at=one_month_ago, infected=False).file
+    # infected file that was checked > 1 month ago and is now clean
+    file5 = ScanFactory(clamav_completed_at=one_month_ago, clamav_signature=VIRUS, infected=True).file
+    # file that was checked in the last month
+    file6 = ScanFactory(clamav_completed_at=one_week_ago, infected=False).file
+
+    # save those files in s3 bucket with dummy content
+    for key in File.objects.values_list("key", flat=True):
+        with io.BytesIO() as content:
+            default_storage.save(key, content)
+
+    mocker.patch("itou.antivirus.management.commands.scan_s3_files.timezone.now").return_value = now
+
+    # we mock this function to avoid failures related to missing groups or permission errors
+    mocker.patch("itou.antivirus.management.commands.scan_s3_files.shutil.chown")
+
+    # we don't need to manipulate real files
+    mocker.patch("itou.antivirus.management.commands.scan_s3_files.os.chmod")
+
+    # files are retrieved from S3 and saved as temporary files
+    filepath_s3key = {
+        "/tmp/tmp_file1": file1.key,
+        "/tmp/tmp_file2": file2.key,
+        "/tmp/tmp_file3": file3.key,
+        "/tmp/tmp_file4": file4.key,
+        "/tmp/tmp_file5": file5.key,
+        "/tmp/tmp_file6": file6.key,
+    }
+    mocker.patch(
+        "itou.antivirus.management.commands.scan_s3_files.Command.download_files"
+    ).return_value = filepath_s3key
+
+    subprocess_mock = mocker.patch("itou.antivirus.management.commands.scan_s3_files.subprocess.run")
+    subprocess_mock.return_value.returncode = 1  # 1 means some files are infected
+    subprocess_mock.return_value.stdout = "\n".join(
+        [
+            f"/tmp/tmp_file2: {VIRUS} FOUND",
+            f"/tmp/tmp_file4: {VIRUS} FOUND",
+        ]
+    )
+
+    call_command("scan_s3_files")
+
+    assertQuerySetEqual(
+        Scan.objects.all(),
+        [
+            (file1.pk, now, "", False),
+            (file2.pk, now, VIRUS, True),
+            (file3.pk, now, "", False),
+            (file4.pk, now, VIRUS, False),
+            (file5.pk, now, VIRUS, True),
+            (file6.pk, one_week_ago, "", False),
+        ],
+        transform=lambda s: (s.file_id, s.clamav_completed_at, s.clamav_signature, s.infected),
+        ordered=False,
+    )


### PR DESCRIPTION
## :thinking: Pourquoi ?

La commande est utilisée en prod mais pas testée.

## :cake: Comment ? <!-- optionnel -->

J'ai comme l'impression que la commande ne fonctionne pas correctement. Tout du moins, je ne comprends pas pourquoi on y utilise le `file_id`. On peut soit corriger la commande ou ajuster le modèle `Scan` (ajouter `to_field="key"` pour le champ `file`, donner une valeur par défaut au champ `infected` aussi ?).

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
