### PR TITLE
Inscription : résolution d'un bug empêchant certains utilisateurs venant de certains fournisseurs d'identité de s'inscrire

### DIFF
--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -20,11 +20,17 @@ class SSOReadonlyMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance.has_sso_provider:
-            # When users log in with a SSO, the fields should be disabled
-            # (that’s a requirement on FranceConnect’s side).
+            # When users log in with a SSO, the fields populated by the provider should be
+            # disabled (that’s a requirement on FranceConnect’s side). A field left empty by
+            # the SSO (e.g. the 'title', not provided by PE Connect) must stay editable:
+            # a disabled + required + empty field makes the form impossible to submit.
+
+            # We use "the field has an initial value" as a proxy for "the provider supplied it".
+            # Known limitation: once a user fills an initially-empty field (e.g. 'title') and
+            # saves, it becomes non-empty and will be disabled on the next edit.
             disabled_fields = ["first_name", "last_name", "email", "birthdate", "title"]
-            for name in self.fields.keys():
-                if name in disabled_fields:
+            for name in disabled_fields:
+                if name in self.fields and self.get_initial_for_field(self.fields[name], name):
                     self.fields[name].disabled = True
 
 

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -879,3 +879,57 @@ class TestEditJobSeekerInfo:
             assert getattr(refreshed_job_seeker, attr) == getattr(job_seeker, attr)
         for attr in profile_fields:
             assert getattr(refreshed_job_seeker.jobseeker_profile, attr) == getattr(job_seeker.jobseeker_profile, attr)
+
+    def test_pe_connect_empty_title_is_editable(self, client, mocker):
+        mocker.patch(
+            "itou.utils.apis.geocoding.get_geocoding_data",
+            side_effect=mock_get_geocoding_data_by_ban_api_resolved,
+        )
+        org = prescribers_factories.PrescriberOrganizationFactory()
+        member = prescribers_factories.PrescriberMembershipFactory(organization=org).user
+        birthdate = datetime.date(1978, 12, 1)
+        job_seeker = JobSeekerFactory(
+            identity_provider=IdentityProvider.PE_CONNECT,
+            title="",
+            created_by=member,
+            jobseeker_profile__nir="178121111111151",
+            jobseeker_profile__birthdate=birthdate,
+        )
+
+        client.force_login(member)
+        url = reverse(
+            "dashboard:edit_job_seeker_info",
+            kwargs={"job_seeker_public_id": job_seeker.public_id},
+        )
+
+        # The 'civilité' field, being empty, should NOT be disabled...
+        response = client.get(url)
+        form = response.context["form"]
+        assert form["title"].field.disabled is False
+        # ... but the fields provided by the SSO stay disabled
+        for name in ["first_name", "last_name", "email", "birthdate"]:
+            assert form[name].field.disabled is True
+
+        # ... and submitting with a 'civilité' should succeed
+        birth_place = Commune.objects.by_insee_code_and_period(self.city.code_insee, birthdate)
+        response = client.post(
+            url,
+            {
+                "title": Title.M,
+                "first_name": job_seeker.first_name,
+                "last_name": job_seeker.last_name,
+                "email": job_seeker.email,
+                "birthdate": birthdate.isoformat(),
+                "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
+                "birth_place": birth_place.pk,
+                "confirm": True,
+                **self.address_form_fields,
+            },
+        )
+        assertRedirects(response, reverse("dashboard:index"))
+        job_seeker.refresh_from_db()
+        assert job_seeker.title == Title.M
+
+        # Once filled in, the civilité is no longer empty -> it is now disabled
+        response = client.get(url)
+        assert response.context["form"]["title"].field.disabled is True


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Bug remonté par le support](https://gip-inclusion.slack.com/archives/C01181Y04LT/p1781681268299829). Sur la page d'édition des informations d'un candidat, `SSOReadonlyMixin` désactivait **tous** les champs d'identité dès qu'un candidat s'était connecté via un SSO. Or certains `IdentityProvider`s ne fournissent pas la civilité (`title`). Le champ se retrouvait donc à la fois désactivé, obligatoire et vide. Cela rendait le formulaire impossible à soumettre.

## :cake: Comment ?

Dans ce `Mixin`, on ne désactive désormais un champ de la liste `["first_name", "last_name", "email", "birthdate", "title"]` que s'il a déjà une valeur initiale. Un champ laissé vide par le SSO, comme la civilité pour PE Connect, peut encore être rempli.

Cette approche a un défaut : elle suppose qu'une valeur est "_fournie par le SSO_" quand elle est non nulle. Ce parti pris implique qu'il n'est plus possible pour certains utilisateurs de modifier leur civilité sans solliciter le support. Le problème devrait être restreint puisqu'il n'affecte que les demandeurs d'emplois n'ayant pas de NIR qui souhaitent changer leur civilité (le premier chiffre du NIR contraignant déjà la civilité qui peut être choisie).

## :desert_island: Comment tester ?

Un test de non-régression vérifie que la civilité vide reste éditable, que les champs fournis par le SSO restent bien désactivés, et qu'une fois la civilité renseignée elle est verrouillée.