### PR TITLE
Connexion : Autoriser les méthodes MFA dépréciées de ProConnect pour la transition

### DIFF
--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -105,8 +105,12 @@ def _generate_pro_params_from_session(pc_data):
                         "acr": {
                             "essential": False,
                             "values": [
+                                "eidas0-mfa",
+                                "eidas1-mfa",
                                 "eidas2",
                                 "eidas3",
+                                "https://proconnect.gouv.fr/assurance/self-asserted-2fa",
+                                "https://proconnect.gouv.fr/assurance/consistency-checked-2fa",
                             ],
                         },
                     },


### PR DESCRIPTION
## :thinking: Pourquoi ?

Felix from ProConnect :
> les utilisateurs seront bloqués avec [vos] ACR. Voici la liste des ACR MFA :
>  • "eidas0-mfa" (arrive demain)
>  • "eidas1-mfa" (arrive demain)
>  • "eidas2"
>  • "eidas3"
>  • "https://proconnect.gouv.fr/assurance/self-asserted-2fa" (part demain, encore en activité jusqu'à demain)
>  • "https://proconnect.gouv.fr/assurance/consistency-checked-2fa" (part demain, encore en activité jusqu'à demain)
> Je vous conseille de mettre la liste complète, puis de retirer les ACR legacy quand vous voulez à partir de demain aprèm.

## :cake: Comment ? <!-- optionnel -->

Défait partiellement https://github.com/gip-inclusion/les-emplois/commit/fbf35f09664aa56510ab110f1e7b0e915ef892dc, pour aider à la migration.
