### PR TITLE
Tech: Fix d'un test bagottant

### DIFF
--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -325,15 +325,22 @@ def test_detail_orientation_url_without_jwt_for_regular_prescriber(client, db):
     client.force_login(user)
 
     response = client.get(detail_url(service))
+    dora_url = f"https://dora.inclusion.gouv.fr/services/di--{service.uid}/orienter?mtm_campaign=lesemplois&mtm_kwd=service-professional"
 
     assert response.status_code == 200
     # Regular prescribers get direct DORA URL without nexus auto_login
     assertContains(
         response,
-        f"https://dora.inclusion.gouv.fr/services/di--{service.uid}/orienter?mtm_campaign=lesemplois&amp;mtm_kwd=service-professional",
+        f"""
+            <a class="btn btn-lg btn-white btn-block justify-content-center" rel="noopener" target="_blank"
+                href="{dora_url}"
+                data-matomo-event="true" data-matomo-category="fiche-service"
+                data-matomo-action="clic" data-matomo-option="orienter-un-bénéficiaire">
+                Orienter le bénéficiaire
+           </a>
+        """,
+        html=True,
     )
-    assertNotContains(response, "/portal/auto-login?next_url")
-    assertNotContains(response, "op=")
 
 
 def test_detail_credential_documents_empty(client, db):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si l'organisation créée a le malheur de se trouver dans un département concerné par Nexus (`NEXUS_MVP_DEPARTMENTS`), `assertNotContains(response, "/portal/auto-login?next_url")` est `False`.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
