### PR TITLE
Tech : Mise à jour des claims ACR MFA pour la standardisation ProConnect

### DIFF
--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -105,8 +105,12 @@ def _generate_pro_params_from_session(pc_data):
                         "acr": {
                             "essential": False,
                             "values": [
+                                "eidas0-mfa",
+                                "eidas1-mfa",
                                 "eidas2",
                                 "eidas3",
+                                "https://proconnect.gouv.fr/assurance/self-asserted-2fa",
+                                "https://proconnect.gouv.fr/assurance/consistency-checked-2fa",
                             ],
                         },
                     },


### PR DESCRIPTION
## :thinking: Pourquoi ?

ProConnect normalise ses claims ACR pour la double authentification (MFA).
Deux nouveaux claims `eidas0-mfa` et `eidas1-mfa` sont introduits à partir du 18/06/2026. Les claims legacy `self-asserted-2fa` et `consistency-checked-2fa` sont supprimés à la même date.

Suite au PR #8272 qui a déployé uniquement `eidas2` et `eidas3`, voici une PR qui permet l'éventail des ACR requis pour faire de la MFA.

## :cake: Comment ?

Ajout des 4 valeurs ACR manquantes dans la liste des `values` de la claim `acr` de la requête
d'autorisation ProConnect :
- `eidas0-mfa` (nouveau)
- `eidas1-mfa` (nouveau)
- `https://proconnect.gouv.fr/assurance/self-asserted-2fa` (legacy, encore actif jusqu'au déploiement de ProConnect)
- `https://proconnect.gouv.fr/assurance/consistency-checked-2fa` (legacy, encore actif jusqu'au déploiement de ProConnect)

Les deux claims legacy pourront être retirés dans une PR de suivi une fois la migration ProConnect du 18/06/2026 effectuée.

## :desert_island: Comment tester ?

En faisant un parcours de connexion en intégration.