### PR TITLE
Pilotage : Suppression d’une bannière expirée

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -14,7 +14,6 @@ make sure that the correct filters are "Verrouillé".
 
 """
 
-import datetime
 import re
 
 from django.conf import settings
@@ -22,7 +21,6 @@ from django.contrib.auth.decorators import login_not_required
 from django.http import HttpResponseNotFound, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils import timezone
 
 from itou.analytics.models import StatsDashboardVisit
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS, REGIONS
@@ -320,15 +318,7 @@ def render_stats_cd(request, page_title, *, extra_context=None, with_department_
         "page_title": f"{page_title} de mon département : {DEPARTMENTS[department]}",
         "department": department,
         "tally_hidden_fields": {"type_prescripteur": request.current_organization.kind},
-        "pilotage_webinar_banners": [
-            {
-                "title": "Créez de l’emploi inclusif sans financement public supplémentaire",
-                "description": "Le Marché de l’inclusion transforme la commande privée et publique en leviers d’emploi. Suivez les retombées économiques locales des marchés inclusifs et identifiez combien d’ETP sont financés sur votre territoire grâce à la commande privée et publique.",  # noqa: E501
-                "call_to_action": "Je prends un rdv de démonstration",
-                "url": "https://calendar.app.google/cQ1PDKKezS1Yt1FE7",
-                "is_displayable": lambda: timezone.localdate() <= datetime.date(2026, 2, 10),
-            }
-        ],
+        "pilotage_webinar_banners": [],
     }
     if extra_context:
         context.update(extra_context)


### PR DESCRIPTION
## :thinking: Pourquoi ?

La carte qui l’a introduite : [Notion](https://app.notion.com/p/gip-inclusion/Ajouter-un-bandeau-D-mo-March-pour-les-utilisateurs-du-Pilotage-de-l-inclusion-rattach-s-des-d--2aa5f321b604806cb572e0724770fbdd?v=2715f321b60480088826000c5284ddfce)

Expirée depuis février 2026.

