### PR TITLE
Fiches salarié : Désactivation temporaire de l'envoi à l'ASP -- À DÉPLOYER MERCREDI 8 JUILLET

### DIFF
--- a/clevercloud/transfer_employee_records.sh
+++ b/clevercloud/transfer_employee_records.sh
@@ -18,6 +18,12 @@ if [[ "$INSTANCE_NUMBER" != "0" ]]; then
     exit 0
 fi
 
+# TEMPORARILY disable cronjobs.
+# FIXME: restore when ASP has deployed their changes.
+exit 0
+
 cd "$APP_HOME" || exit
+ # shellcheck disable=SC2317
 django-admin transfer_employee_records --wet-run "$@"
+ # shellcheck disable=SC2317
 django-admin transfer_employee_records_updates --wet-run "$@"

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -178,6 +178,9 @@ class Command(EmployeeRecordTransferCommand):
             self._upload_batch_file(sftp, batch, dry_run)
 
     def handle(self, *, upload, download, parse_file=None, preflight, wet_run, asp_test=False, debug=False, **options):
+        # TEMPORARILY disable cronjob
+        # FIXME: restore when ASP has deployed their changes.
+        return
         if preflight:
             self.logger.info("Preflight activated, checking for possible serialization errors...")
             self.preflight(EmployeeRecord)

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -156,6 +156,9 @@ class Command(EmployeeRecordTransferCommand):
             self._upload_batch_file(sftp, batch, dry_run)
 
     def handle(self, *, upload, download, parse_file=None, preflight, wet_run, asp_test=False, debug=False, **options):
+        # TEMPORARILY disable cronjob
+        # FIXME: restore when ASP has deployed their changes.
+        return
         if preflight:
             self.logger.info("Preflight activated, checking for possible serialization errors...")
             self.preflight(EmployeeRecordUpdateNotification)

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -17,6 +17,9 @@ from tests.approvals.factories import ProlongationFactory, SuspensionFactory
 from tests.employee_record.factories import EmployeeRecordFactory, EmployeeRecordUpdateNotificationFactory
 
 
+pytest.skip(allow_module_level=True)
+
+
 @pytest.fixture(name="command")
 def command_fixture(mocker, settings, sftp_directory, sftp_client_factory):
     # Set required settings

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -12,6 +12,9 @@ from itou.utils.asp import REMOTE_DOWNLOAD_DIR, REMOTE_UPLOAD_DIR
 from tests.employee_record.factories import EmployeeRecordUpdateNotificationFactory
 
 
+pytest.skip(allow_module_level=True)
+
+
 @pytest.fixture(name="command")
 def command_fixture(mocker, settings, sftp_directory, sftp_client_factory):
     # Set required settings


### PR DESCRIPTION
## :thinking: Pourquoi ?

cf. #8309.

**À DÉPLOYER ~JEUDI 25~ MERCREDI 8 JUILLET vers 18h-18h30. Pas avant et SURTOUT PAS APRÈS.**

Puis à revert (pour réactiver les cronjobs) **APRÈS** le déploiement de #8309.