### PR TITLE
Fiches salarié: bandeau d’info avant mise à jour emplois / asp

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -65,7 +65,13 @@
         <div class="global-messages-container">
             {% block global_messages %}
                 {% include "includes/demo_accounts.html" %}
-                {% if request.from_employer and request.current_organization and request.current_organization.has_job_descriptions_not_updated_recently %}
+                {% if request.from_employer and request.current_organization.is_subject_to_iae_rules %}
+                    {% component_alert_global content=content variant="warning" %}
+                        {% fragment as content %}
+                            <strong>Le service d’envoi des fiches salariés</strong> sera temporairement suspendu au cours de la journée du <strong>26/06/2026</strong>, en raison d’une opération de mise à jour de l’Extranet IAE 2.0 de l’ASP.
+                        {% endfragment %}
+                    {% endcomponent_alert_global %}
+                {% elif request.from_employer and request.current_organization and request.current_organization.has_job_descriptions_not_updated_recently %}
                     {% component_alert_global content=content variant="info" extra_id="deactivation-job-banner" %}
                         {% fragment as content %}
                             Une ou plusieurs de vos fiches de poste n’ont pas été actualisées depuis plus de 2 mois. Elles seront automatiquement dépubliées après 3 mois sans mise à jour. <a href="{% url "companies_views:job_description_list" %}">Pensez à les mettre à jour pour maintenir leur visibilité</a>.

--- a/tests/www/apply/__snapshots__/test_accept_views.ambr
+++ b/tests/www/apply/__snapshots__/test_accept_views.ambr
@@ -1051,7 +1051,7 @@
 # ---
 # name: TestAcceptConfirmation.test_as_iae[view queries]
   dict({
-    'num_queries': 23,
+    'num_queries': 22,
     'queries': list([
       dict({
         'origin': list([
@@ -2073,27 +2073,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_accept_base.html]',
-          'ExtendsNode[apply/process_accept_confirmation_step.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -3000,7 +2979,7 @@
 # ---
 # name: TestProcessAcceptViewsInWizard.test_select_job_description_for_job_application[accept view SQL queries]
   dict({
-    'num_queries': 26,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -4060,27 +4039,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_accept_base.html]',
-          'ExtendsNode[apply/process_accept_contract_infos_step.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([

--- a/tests/www/apply/__snapshots__/test_hire_views.ambr
+++ b/tests/www/apply/__snapshots__/test_hire_views.ambr
@@ -931,7 +931,7 @@
 # ---
 # name: TestCheckPreviousApplicationsForHireView.test_num_queries[get_with_previous_application]
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
       dict({
         'origin': list([
@@ -1859,26 +1859,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/hire_step_check_prev_applications.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([
@@ -4114,7 +4094,7 @@
 # ---
 # name: TestHireConfirmation.test_as_iae[view queries]
   dict({
-    'num_queries': 24,
+    'num_queries': 23,
     'queries': list([
       dict({
         'origin': list([
@@ -5074,26 +5054,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/submit/hire_confirmation_step.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([
@@ -5154,7 +5114,7 @@
 # ---
 # name: TestHireContract.test_as_company[view queries]
   dict({
-    'num_queries': 24,
+    'num_queries': 23,
     'queries': list([
       dict({
         'origin': list([
@@ -6102,26 +6062,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/submit/hire_contract_infos_step.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([
@@ -7990,7 +7930,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_job_seeker[queries - step 1]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -8447,26 +8387,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_1.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -8543,7 +8463,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_job_seeker[queries - step 2]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -8934,26 +8854,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_2.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -8985,7 +8885,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_job_seeker[queries - step 3]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -9422,26 +9322,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_3.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([
@@ -11284,7 +11164,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -11741,26 +11621,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_1.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -11837,7 +11697,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 2]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -12228,26 +12088,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_2.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -12279,7 +12119,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 3]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -12716,26 +12556,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_3.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -1994,7 +1994,7 @@
 # ---
 # name: TestProcessListSiae.test_list_for_siae[SQL queries in list mode]
   dict({
-    'num_queries': 26,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -3124,27 +3124,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/list_for_siae.html]',
-          'list_for_siae[www/apply/views/list_views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -3203,7 +3182,7 @@
 # ---
 # name: TestProcessListSiae.test_list_for_siae[SQL queries in table mode]
   dict({
-    'num_queries': 23,
+    'num_queries': 22,
     'queries': list([
       dict({
         'origin': list([
@@ -4259,27 +4238,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/list_for_siae.html]',
-          'list_for_siae[www/apply/views/list_views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -4312,7 +4270,7 @@
 # ---
 # name: TestProcessListSiae.test_list_for_siae_filters_query[SQL queries with all filters but job_seeker]
   dict({
-    'num_queries': 27,
+    'num_queries': 26,
     'queries': list([
       dict({
         'origin': list([
@@ -5535,27 +5493,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/list_for_siae.html]',
-          'list_for_siae[www/apply/views/list_views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -5737,7 +5674,7 @@
 # ---
 # name: TestProcessListSiae.test_list_for_siae_filters_query[SQL queries with only job_seeker filter]
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
       dict({
         'origin': list([
@@ -6752,27 +6689,6 @@
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
           ORDER BY "eligibility_administrativecriteria"."level" ASC,
                    "eligibility_administrativecriteria"."name" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/list_for_siae.html]',
-          'list_for_siae[www/apply/views/list_views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1288,7 +1288,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_approval[job application detail for company]
   dict({
-    'num_queries': 30,
+    'num_queries': 29,
     'queries': list([
       dict({
         'origin': list([
@@ -2417,28 +2417,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -2784,7 +2762,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_list[job application detail for company]
   dict({
-    'num_queries': 31,
+    'num_queries': 30,
     'queries': list([
       dict({
         'origin': list([
@@ -3928,28 +3906,6 @@
                  AND "prescribers_prescribermembership"."is_active"
                  AND "prescribers_prescribermembership"."user_id" = %s
                  AND "prescribers_prescribermembership"."organization_id" = %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/apply/__snapshots__/test_process_comments.ambr
+++ b/tests/www/apply/__snapshots__/test_process_comments.ambr
@@ -1244,7 +1244,7 @@
 # ---
 # name: test_display_in_sidebar_and_tab
   dict({
-    'num_queries': 26,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -2491,28 +2491,6 @@
           WHERE ("users_user"."is_active"
                  AND "gps_followupgroup"."beneficiary_id" = %s)
           ORDER BY "gps_followupgroup"."id" ASC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -2785,7 +2785,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_job_seeker[queries - step 1]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -3242,26 +3242,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_1.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -3338,7 +3318,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_job_seeker[queries - step 2]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -3729,26 +3709,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_2.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -3780,7 +3740,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_job_seeker[queries - step 3]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -4217,26 +4177,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_3.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([
@@ -6079,7 +6019,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -6536,26 +6476,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_1.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -6632,7 +6552,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 2]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -7023,26 +6943,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_2.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -7074,7 +6974,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 3]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -7511,26 +7411,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_base.html]',
-          'ExtendsNode[job_seekers_views/create_or_update_job_seeker/step_3.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -256,7 +256,7 @@
 # ---
 # name: TestApprovalDetailView.test_approval_detail_with_prolongations[Approval detail view with prolongations as employer]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -1133,26 +1133,6 @@
                                                     %s))
           ORDER BY 45 DESC,
                    "job_applications_jobapplication"."hiring_start_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/base_details.html]',
-          'ExtendsNode[approvals/details.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),
@@ -2813,7 +2793,7 @@
 # ---
 # name: TestApprovalDetailView.test_approval_detail_with_suspensions[Approval detail view with suspensions as employer]
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -3692,26 +3672,6 @@
           WHERE ("approvals_prolongationrequest"."approval_id" = %s
                  AND "approvals_prolongation"."id" IS NULL)
           ORDER BY "approvals_prolongationrequest"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/base_details.html]',
-          'ExtendsNode[approvals/details.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/approvals_views/__snapshots__/test_list.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_list.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestApprovalsListView.test_approval_contract_filters[approvals list ended contracts filter]
   dict({
-    'num_queries': 15,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -463,25 +463,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/list.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -650,7 +631,7 @@
 # ---
 # name: TestApprovalsListView.test_approval_contract_filters[approvals list ongoing contracts filter]
   dict({
-    'num_queries': 15,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -1112,25 +1093,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/list.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -1302,7 +1264,7 @@
 # ---
 # name: TestApprovalsListView.test_job_seeker_filters[approvals list]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -1728,25 +1690,6 @@
           INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "employee_record_employeerecord"."status" = %s)
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/list.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestApprovalSuspendActionChoiceView.test_context[view queries]
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -507,27 +507,6 @@
                                                     %s))
           ORDER BY 45 DESC,
                    "job_applications_jobapplication"."hiring_start_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/suspension_action_choice.html]',
-          'suspension_action_choice[www/approvals_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),
@@ -591,7 +570,7 @@
 # ---
 # name: TestApprovalSuspendUpdateEndDateView.test_context[view queries]
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -1097,27 +1076,6 @@
                                                     %s))
           ORDER BY 45 DESC,
                    "job_applications_jobapplication"."hiring_start_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/suspension_update_enddate.html]',
-          'suspension_update_enddate[www/approvals_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),
@@ -1282,7 +1240,7 @@
 # ---
 # name: TestApprovalSuspendView.test_delete_suspension[view queries]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -1796,26 +1754,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/suspension_delete.html]',
-          'suspension_delete[www/approvals_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -1879,7 +1817,7 @@
 # ---
 # name: TestApprovalSuspendView.test_update_suspension[view queries]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -2499,27 +2437,6 @@
                  AND "approvals_suspension"."end_at" < %s
                  AND NOT ("approvals_suspension"."id" = %s))
           ORDER BY "approvals_suspension"."start_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[approvals/suspension_update.html]',
-          'suspension_update[www/approvals_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -738,7 +738,7 @@
 # ---
 # name: TestJobDescriptionListView.test_response_content[job descriptions list]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -1089,27 +1089,6 @@
                            AND U0."is_admin"
                            AND U1."is_active"))
                  AND "users_user"."id" = %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[companies/job_description_list.html]',
-          'job_description_list[www/companies_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -895,7 +895,10 @@ def test_display_reminder_banner_not_updated_jobs_for_employer(client):
     Appellation.objects.create(code="I13042", name="Doer", rome=rome)
 
     # Spontaneous application recently updated
-    company = CompanyWith2MembershipsFactory(spontaneous_applications_open_since=RECENT_DATE)
+    company = CompanyWith2MembershipsFactory(
+        spontaneous_applications_open_since=RECENT_DATE,
+        kind=CompanyKind.GEIQ,  # FIXME: temporary pin on GEIQ as SIAEs have another banner temporarily
+    )
     client.force_login(company.members.first())
     response = client.get(reverse("dashboard:index"))
     assertNotContains(
@@ -915,7 +918,10 @@ def test_display_reminder_banner_not_updated_jobs_for_employer(client):
     )
 
     # Recently updated job application
-    company = CompanyWith2MembershipsFactory(spontaneous_applications_open_since=None)
+    company = CompanyWith2MembershipsFactory(
+        spontaneous_applications_open_since=None,
+        kind=CompanyKind.GEIQ,  # FIXME: temporary pin on GEIQ as SIAEs have another banner temporarily
+    )
     job_description = JobDescriptionFactory(
         company=company, created_at=RECENT_DATE, last_employer_update_at=RECENT_DATE
     )

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -50,7 +50,7 @@
 # ---
 # name: TestDashboardView.test_dashboard_siae_evaluation_campaign_notifications[view queries]
   dict({
-    'num_queries': 23,
+    'num_queries': 22,
     'queries': list([
       dict({
         'origin': list([
@@ -449,27 +449,6 @@
           WHERE ("siae_evaluations_evaluatedsiae"."siae_id" = %s
                  AND "siae_evaluations_sanctions"."suspension_dates" @> %s::date)
           ORDER BY UPPER("siae_evaluations_sanctions"."suspension_dates") DESC NULLS FIRST
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[dashboard/dashboard.html]',
-          'dashboard[www/dashboard/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
@@ -133,7 +133,7 @@
 # ---
 # name: TestEditJobSeekerInfo.test_edit_by_company_with_nir[view queries]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -571,28 +571,6 @@
           FROM "users_identitycertification"
           WHERE "users_identitycertification"."jobseeker_profile_id" = %s
           ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[dashboard/edit_job_seeker_info.html]',
-          'edit_job_seeker_info[www/dashboard/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-          'wrapper[utils/views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_employer_allowed[view queries]
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -337,26 +337,6 @@
                  AND "communications_notificationsettings"."structure_pk" = %s
                  AND "communications_notificationsettings"."structure_type_id" = %s)
           ORDER BY "communications_notificationsettings"."id" ASC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[dashboard/edit_user_notifications.html]',
-          'edit_user_notifications[www/dashboard/views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -26,7 +26,7 @@
 # ---
 # name: test_wizard[choose-approval-queries]
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -621,26 +621,6 @@
       }),
       dict({
         'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[employee_record/base_add.html]',
-          'ExtendsNode[employee_record/add.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Company.has_admin[common_apps/organizations/models.py]',
           'Company.convention_can_be_accessed_by[companies/models.py]',
           'nav[utils/templatetags/nav.py]',
@@ -794,7 +774,7 @@
 # ---
 # name: test_wizard[choose-employee-queries]
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -1225,26 +1205,6 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[employee_record/base_add.html]',
-          'ExtendsNode[employee_record/add.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
-        ''',
       }),
       dict({
         'origin': list([

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -67,7 +67,7 @@
 # ---
 # name: TestListEmployeeRecords.test_new_employee_records_sorted[employee records]
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -511,27 +511,6 @@
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "employee_record_employeerecord"."status" IN (%s))
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[employee_record/list.html]',
-          'list_employee_records[www/employee_record_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -16,7 +16,7 @@
 # ---
 # name: TestEmployeeDetailView.test_detail_view[employee detail view]
   dict({
-    'num_queries': 32,
+    'num_queries': 31,
     'queries': list([
       dict({
         'origin': list([
@@ -1096,25 +1096,6 @@
           WHERE ("users_user"."is_active"
                  AND "gps_followupgroup"."beneficiary_id" = %s)
           ORDER BY "gps_followupgroup"."id" ASC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[employees/detail.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -3047,7 +3047,7 @@
 # ---
 # name: test_job_application_tab_as_siae[SQL queries]
   dict({
-    'num_queries': 21,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -3915,25 +3915,6 @@
           FROM "companies_company"
           WHERE "companies_company"."id" = %s
           LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[job_seekers_views/job_applications.html]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestSiaeJobApplicationListView.test_access[view queries]
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
       dict({
         'origin': list([
@@ -389,27 +389,6 @@
           ORDER BY "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" ASC,
                    "eligibility_administrativecriteria"."level" ASC,
                    "eligibility_administrativecriteria"."ui_rank" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
-          'IfNode[layout/base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[siae_evaluations/siae_job_applications_list.html]',
-          'siae_job_applications_list[www/siae_evaluations_views/views.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "companies_jobdescription"
-          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
-          WHERE (NOT ("companies_company"."kind" IN (%s,
-                                                     %s))
-                 AND "companies_jobdescription"."company_id" = %s
-                 AND "companies_jobdescription"."is_active"
-                 AND "companies_jobdescription"."last_employer_update_at" < %s)
-          LIMIT 1
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://app.notion.com/p/gip-inclusion/Fiches-salari-bandeau-d-info-avant-mise-jour-emplois-asp-afficher-du-22-06-au-26-06-2026-09d5f321b6048213969b01ce38bbcf79

## :rotating_light: À vérifier

A afficher du **22 au 26/06/2026**


