### PR TITLE
Page d’accueil : stabilisation d'un test flaky

### DIFF
--- a/tests/www/dashboard/test_edit_user_notifications.py
+++ b/tests/www/dashboard/test_edit_user_notifications.py
@@ -32,7 +32,11 @@ def test_labor_inspector_not_allowed(client):
 
 
 def test_employer_allowed(client, snapshot):
-    employer = EmployerFactory(membership=True)
+    employer = EmployerFactory(
+        membership=True,
+        # Fixed company kind as query count differs (in snapshots) whether SIAE or not.
+        membership__company__subject_to_iae_rules=True,
+    )
     client.force_login(employer)
     url = reverse("dashboard:edit_user_notifications")
     with assertSnapshotQueries(snapshot(name="view queries")):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le choix aléatoire d'un type d'entreprise rendait ce petit test flaky : il plantait ~une fois sur trois car le nombre de requêtes (dans le snapshot) vaut un de plus lorsque l'entreprise est **non SIAE** (GEIQ ou OPS).

Puisqu'on a ce bloc conditionnel dans le template de base :
```python
{% if request.from_employer and request.current_organization.is_subject_to_iae_rules %}
      ... bannière fiches salariés ...
{% elif request.from_employer and request.current_organization and request.current_organization.has_job_descriptions_not_updated_recently %}
```
i.e. à cause du `has_job_descriptions_not_updated_recently`.

## :cake: Comment ? <!-- optionnel -->

Ajout de `membership__company__subject_to_iae_rules=True`.

## :desert_island: Comment tester ?

AVANT cette PR :
```shell
pytest -q "tests/www/dashboard/test_edit_user_notifications.py::test_employer_allowed" -p randomly --randomly-seed=3
# Ça plante
```
ou bien trouver un seed chez vous en relançant le test jusqu'à ce qu'il échoue :
```bash
for s in $(seq 1 15); do python -m pytest "tests/www/dashboard/test_edit_user_notifications.py::test_employer_allowed" -q -p randomly --randomly-seed=$s; done
```

APRÈS :
```shell
pytest -q "tests/www/dashboard/test_edit_user_notifications.py::test_employer_allowed" -p randomly --randomly-seed=3
# Ça ne plante plus :-)
```

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
