### PR TITLE
Tech : pole_emploi: Revert to known good set of API scopes

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -385,20 +385,6 @@ class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
         "profil_accedant",
         "api_donnees-rqthv1",
         "h2a",
-        # Informations Administratives Usager
-        "api_informations-administrativesv1",
-        "informationsadministrativesusager",
-        "profil_accedant",
-        # Statut Usager
-        "api_contrat-usagerv2",
-        "statutcontratusager",
-        # again "profil_accedant",
-        # Orientation Usager
-        "api_orientationusagerv1",
-        "orientationusager",
-        # Diagnostic usager
-        "api_diagnosticargumentev4",
-        "diagnosticusageragent",
     ]
     REALM = "/agent"
     CACHE_API_TOKEN_KEY = "pole_emploi_api_agent_client_token"


### PR DESCRIPTION
Commit d60d556e19 added scopes to the API, but we get an error since then when trying to get an access token:

    >>> resp
    <Response [400 Bad Request]>
    >>> resp.json()
    {'error_description': 'Unknown/invalid scope(s).', 'error': 'invalid_scope'}

This commit reverts scopes to what they were before, until we can figure out which scopes to request.
