### PR TITLE
tech: Développer les bases des filtres pour recommander les SPS

### DIFF
--- a/itou/recommendations/criteria.py
+++ b/itou/recommendations/criteria.py
@@ -1,0 +1,64 @@
+import enum
+from dataclasses import dataclass, field
+
+from django.contrib.gis.geos import Point
+
+
+class StructuredSolutionKind(enum.StrEnum):
+    PLIE = "plie"
+    EPIDE = "epide"
+    E2C = "ecoles-de-la-deuxieme-chance"
+    APPRENTIS_DAUTEUIL_ACCOMPAGNEMENT_INTENSIF = "apprentis-dauteuil-accompagnement-intensif"
+    APPRENTIS_DAUTEUIL_SKOLA = "apprentis-dauteuil-skola"
+    APPRENTIS_DAUTEUIL_BOOST_INSERTION = "apprentis-dauteuil-boost-insertion"
+    APPRENTIS_DAUTEUIL_POTENTIELLES = "apprentis-dauteuil-potentielles"
+    SIAE = "siae"
+    EA = "ea"
+    GEIQ = "geiq"
+
+
+class CriterionStatus(enum.StrEnum):
+    MET = "met"
+    NOT_MET = "not_met"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class CriterionEvaluation:
+    code: str
+    label: str
+    status: CriterionStatus
+    is_mandatory: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityResult:
+    kind: StructuredSolutionKind
+    is_eligible: bool
+    criteria: tuple[CriterionEvaluation, ...] = field(default_factory=tuple)
+
+    @property
+    def matched_criteria_count(self) -> int:
+        return sum(criterion.status is CriterionStatus.MET for criterion in self.criteria)
+
+    @property
+    def unknown_criteria_count(self) -> int:
+        return sum(criterion.status is CriterionStatus.UNKNOWN for criterion in self.criteria)
+
+    def reasons(self) -> list[str]:
+        return [criterion.label for criterion in self.criteria if criterion.status is CriterionStatus.MET]
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredSolutionCandidate:
+    """
+    Lightweight value object consumed by the eligibility rules.
+
+    In production, built from an ``insertion.models.Service`` instance via
+    ``from_service()``.  Kept as a thin dataclass so the rules stay decoupled
+    from the ORM and tests can run without a database.
+    """
+
+    kind: StructuredSolutionKind
+    coordinates: Point | None = None
+    eligibility_zones: tuple[str, ...] = field(default_factory=tuple)

--- a/itou/recommendations/engine.py
+++ b/itou/recommendations/engine.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from itou.geo.utils import distance_in_km
+from itou.recommendations.criteria import EligibilityResult, StructuredSolutionCandidate, StructuredSolutionKind
+from itou.recommendations.profile import BeneficiaryProfile
+from itou.recommendations.rules import (
+    AccompagnementIntensifRule,
+    BoostInsertionRule,
+    E2CRule,
+    EARule,
+    EligibilityRule,
+    EPIDERule,
+    GEIQRule,
+    PLIERule,
+    PotentiellesRule,
+    SIAERule,
+    SkolaRule,
+)
+
+
+_ALL_RULES: dict[StructuredSolutionKind, EligibilityRule] = {
+    rule.kind: rule
+    for rule in (
+        PLIERule(),
+        EPIDERule(),
+        E2CRule(),
+        AccompagnementIntensifRule(),
+        SkolaRule(),
+        BoostInsertionRule(),
+        PotentiellesRule(),
+        SIAERule(),
+        EARule(),
+        GEIQRule(),
+    )
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendationResult:
+    candidate: StructuredSolutionCandidate
+    eligibility: EligibilityResult
+
+
+def recommend(
+    profile: BeneficiaryProfile,
+    candidates: list[StructuredSolutionCandidate],
+) -> list[RecommendationResult]:
+    """
+    Return the list of eligible structured solutions for the given beneficiary,
+    sorted by:
+      1. Number of matched criteria descending (best match first).
+      2. Distance from the beneficiary's address ascending (closest first),
+         when coordinates are available.
+    """
+    results = []
+    for candidate in candidates:
+        rule = _ALL_RULES.get(candidate.kind)
+        if rule is None:
+            continue
+        eligibility = rule.evaluate(profile, candidate)
+        if eligibility.is_eligible:
+            results.append(RecommendationResult(candidate=candidate, eligibility=eligibility))
+
+    results.sort(key=_sort_key(profile))
+    return results
+
+
+def _sort_key(profile: BeneficiaryProfile):
+    def key(r: RecommendationResult):
+        if profile.coords is None or r.candidate.coordinates is None:
+            dist = float("inf")
+        else:
+            dist = distance_in_km(profile.coords, r.candidate.coordinates)
+        return (-r.eligibility.matched_criteria_count, dist)
+
+    return key

--- a/itou/recommendations/helpers.py
+++ b/itou/recommendations/helpers.py
@@ -142,9 +142,10 @@ class Constraint:
     """Data structure for "contrainte" objects from Diagnostic Usager - dossier agrégé"""
 
     # NB: Each item in details is a "objectif" or a "situation" from the API.
-    # These have their own author, value, and imptact
+    # These have their own author, value, and impact
     # but we chose not to use them for now (too much information to display)
 
+    code: str
     label: str
     details: list[str]
     author: Author
@@ -154,6 +155,7 @@ class Constraint:
     @classmethod
     def from_dict(cls, agent, data):
         return cls(
+            code=data["code"],
             label=data["libelle"],
             impact=data.get("impact", ""),  # This field is missing in one of the examples from the doc.
             details=[o["libelle"] for o in data["objectifs"] + data["situations"]],

--- a/itou/recommendations/profile.py
+++ b/itou/recommendations/profile.py
@@ -1,0 +1,62 @@
+import datetime
+from dataclasses import dataclass, field
+
+from django.contrib.gis.geos import Point
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticConstraint:
+    code: str
+    impact: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BeneficiaryProfile:
+    """
+    Consolidated beneficiary profile built from France Travail APIs.
+
+    Field names follow internal naming; mapping from FT API payloads
+    is handled in `france_travail.py`.
+    """
+
+    france_travail_id: str
+
+    # API Informations administratives usagers
+    birthdate: datetime.date | None = None
+    civility: str | None = None
+    address_line: str | None = None
+    city: str | None = None
+    post_code: str | None = None
+    code_insee: str | None = None
+    coords: Point | None = None
+    is_qpv_resident: bool | None = None
+
+    # API Statut usager
+    is_registered_at_france_travail: bool | None = None
+    status_effective_date: datetime.date | None = None
+    registration_duration_months: int | None = None
+
+    # API Orientation usager
+    education_level: str | None = None
+    is_rsa_beneficiary: bool | None = None
+    is_rqth_beneficiary: bool | None = None
+    professional_situation: str | None = None
+
+    # API Diagnostic usager
+    has_declared_constraints: bool | None = None
+    diagnostic_constraints: tuple[DiagnosticConstraint, ...] = field(default_factory=tuple)
+
+    def age(self) -> int | None:
+        # "age from birthdate in python" https://stackoverflow.com/a/9754466
+        if self.birthdate is None:
+            return None
+        today = datetime.date.today()
+        return (
+            today.year - self.birthdate.year - ((today.month, today.day) < (self.birthdate.month, self.birthdate.day))
+        )
+
+    def months_since_registration(self) -> int | None:
+        if self.status_effective_date is None:
+            return self.registration_duration_months
+        today = datetime.date.today()
+        return (today.year - self.status_effective_date.year) * 12 + (today.month - self.status_effective_date.month)

--- a/itou/recommendations/rules.py
+++ b/itou/recommendations/rules.py
@@ -1,0 +1,771 @@
+import enum
+from abc import ABC, abstractmethod
+
+from itou.geo.utils import distance_in_km
+from itou.recommendations.criteria import (
+    CriterionEvaluation,
+    CriterionStatus,
+    EligibilityResult,
+    StructuredSolutionCandidate,
+    StructuredSolutionKind,
+)
+from itou.recommendations.profile import BeneficiaryProfile
+
+
+# ---------------------------------------------------------------------------
+# France Travail education level codes (from API Orientation Usager)
+# ---------------------------------------------------------------------------
+
+
+class FTEducationLevel(enum.StrEnum):
+    NO_SCHOOLING = "AFS"
+    PRIMARY_TO_4TH = "CP4"
+    COMPLETED_4TH = "CFG"
+    COMPLETED_3RD = "C3A"
+    COMPLETED_2ND_OR_1ST = "C12"
+    CAP_BEP = "NV5"
+    BAC = "NV4"
+    BAC_PLUS_2 = "NV3"
+    BAC_PLUS_3_4 = "NV2"
+    BAC_PLUS_5_AND_ABOVE = "NV1"
+
+
+# ---------------------------------------------------------------------------
+# Education level sets
+# ---------------------------------------------------------------------------
+
+# Level V or below: CAP/BEP and lower.
+EDUCATION_LEVEL_V_OR_BELOW = frozenset(
+    [
+        FTEducationLevel.NO_SCHOOLING,
+        FTEducationLevel.PRIMARY_TO_4TH,
+        FTEducationLevel.COMPLETED_4TH,
+        FTEducationLevel.COMPLETED_3RD,
+        FTEducationLevel.CAP_BEP,
+    ]
+)
+
+# Level IV or below: up to bac (inclusive).
+EDUCATION_LEVEL_IV_OR_BELOW = frozenset(
+    [
+        *EDUCATION_LEVEL_V_OR_BELOW,
+        FTEducationLevel.COMPLETED_2ND_OR_1ST,
+        FTEducationLevel.BAC,
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Diagnostic constraint code sets
+# ---------------------------------------------------------------------------
+
+HOUSING_DIFFICULTY_CODES = frozenset(["24", "2707", "2708", "2712", "2713", "2715", "2716"])
+LITERACY_DIFFICULTY_CODES = frozenset(["20", "21", "22"])
+MOBILITY_DIFFICULTY_CODES = frozenset(["6", "7", "8", "40", "2314", "2316"])
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _criterion(code: str, label: str, value: bool | None, *, is_mandatory: bool = True) -> CriterionEvaluation:
+    if value is None:
+        status = CriterionStatus.UNKNOWN
+    else:
+        status = CriterionStatus.MET if value else CriterionStatus.NOT_MET
+    return CriterionEvaluation(code=code, label=label, status=status, is_mandatory=is_mandatory)
+
+
+def _n_met(criteria: list[CriterionEvaluation]) -> int:
+    return sum(c.status is CriterionStatus.MET for c in criteria)
+
+
+def evaluate_bool(*, code: str, label: str, value: bool | None, is_mandatory: bool = True) -> CriterionEvaluation:
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_age_range(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    min_age: int | None = None,
+    max_age: int | None = None,
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    age = profile.age()
+    value = None if age is None else ((min_age is None or age >= min_age) and (max_age is None or age <= max_age))
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_distance(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    candidate: StructuredSolutionCandidate,
+    max_distance_km: int,
+) -> CriterionEvaluation:
+    if profile.coords is None or candidate.coordinates is None:
+        return _criterion(code, label, None)
+    return _criterion(code, label, distance_in_km(profile.coords, candidate.coordinates) <= max_distance_km)
+
+
+def evaluate_eligibility_zone(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    candidate: StructuredSolutionCandidate,
+) -> CriterionEvaluation:
+    if profile.code_insee is None:
+        return _criterion(code, label, None)
+    value = not candidate.eligibility_zones or profile.code_insee in candidate.eligibility_zones
+    return _criterion(code, label, value)
+
+
+def evaluate_education_level(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    accepted_levels: frozenset[str],
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    value = None if profile.education_level is None else profile.education_level in accepted_levels
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_registration_months(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    min_months: int,
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    months = profile.months_since_registration()
+    value = None if months is None else months >= min_months
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_has_housing_difficulty(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    if not profile.diagnostic_constraints:
+        return _criterion(code, label, None, is_mandatory=is_mandatory)
+    value = any(c.code in HOUSING_DIFFICULTY_CODES for c in profile.diagnostic_constraints)
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_no_literacy_difficulty(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    if not profile.diagnostic_constraints:
+        return _criterion(code, label, None, is_mandatory=is_mandatory)
+    value = not any(c.code in LITERACY_DIFFICULTY_CODES for c in profile.diagnostic_constraints)
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def evaluate_no_strong_mobility_difficulty(
+    *,
+    code: str,
+    label: str,
+    profile: BeneficiaryProfile,
+    is_mandatory: bool = True,
+) -> CriterionEvaluation:
+    if not profile.diagnostic_constraints:
+        return _criterion(code, label, None, is_mandatory=is_mandatory)
+    value = not any(c.code in MOBILITY_DIFFICULTY_CODES or c.impact == "FORT" for c in profile.diagnostic_constraints)
+    return _criterion(code, label, value, is_mandatory=is_mandatory)
+
+
+def all_mandatory_met(criteria: list[CriterionEvaluation]) -> bool:
+    return all(c.status is CriterionStatus.MET or not c.is_mandatory for c in criteria)
+
+
+def at_least_one_met(criteria: list[CriterionEvaluation]) -> bool:
+    return any(c.status is CriterionStatus.MET for c in criteria)
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+
+class EligibilityRule(ABC):
+    kind: StructuredSolutionKind
+
+    @abstractmethod
+    def evaluate(
+        self,
+        profile: BeneficiaryProfile,
+        candidate: StructuredSolutionCandidate,
+    ) -> EligibilityResult:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# PLIE
+# ---------------------------------------------------------------------------
+
+
+class PLIERule(EligibilityRule):
+    kind = StructuredSolutionKind.PLIE
+    max_distance_km = 10
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {self.max_distance_km} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=self.max_distance_km,
+            ),
+            evaluate_eligibility_zone(
+                code="zone_eligibilite",
+                label="Domicilié sur le territoire couvert par le PLIE",
+                profile=profile,
+                candidate=candidate,
+            ),
+            evaluate_age_range(code="age_min", label="Plus de 25 ans", profile=profile, min_age=26),
+        ]
+        situations = [
+            evaluate_registration_months(
+                code="deld",
+                label="Demandeur d'emploi de longue durée (12 mois minimum)",
+                profile=profile,
+                min_months=12,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="qpv",
+                label="Habitant QPV",
+                value=profile.is_qpv_resident,
+                is_mandatory=False,
+            ),
+        ]
+        criteria = mandatory + situations
+        is_eligible = all_mandatory_met(mandatory) and at_least_one_met(situations)
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(criteria))
+
+
+# ---------------------------------------------------------------------------
+# EPIDE
+# ---------------------------------------------------------------------------
+
+
+class EPIDERule(EligibilityRule):
+    kind = StructuredSolutionKind.EPIDE
+    max_distance_km = 100
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {self.max_distance_km} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=self.max_distance_km,
+            ),
+            evaluate_age_range(
+                code="age_range",
+                label="Jeune de 17 à 25 ans",
+                profile=profile,
+                min_age=17,
+                max_age=25,
+            ),
+            # French nationality or legal foreign resident is approximated by
+            # FT registration (implies right to work).
+            evaluate_bool(
+                code="right_to_work",
+                label="Inscrit à France Travail (autorisation de travailler)",
+                value=profile.is_registered_at_france_travail,
+            ),
+            evaluate_education_level(
+                code="education_level",
+                label="Niveau de formation inférieur ou égal au niveau V (CAP/BEP)",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_V_OR_BELOW,
+            ),
+        ]
+        optional = [
+            evaluate_registration_months(
+                code="unemployment_duration",
+                label="Inscrit depuis plus de 6 mois",
+                profile=profile,
+                min_months=6,
+                is_mandatory=False,
+            ),
+        ]
+        is_eligible = all_mandatory_met(mandatory)
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(mandatory + optional))
+
+
+# ---------------------------------------------------------------------------
+# E2C
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_age_e2c(profile: BeneficiaryProfile) -> CriterionEvaluation:
+    """16–25 ans, OR 26–30 with RQTH."""
+    age = profile.age()
+    if age is None:
+        status = CriterionStatus.UNKNOWN
+    elif 16 <= age <= 25:
+        status = CriterionStatus.MET
+    elif 26 <= age <= 30 and profile.is_rqth_beneficiary:
+        status = CriterionStatus.MET
+    else:
+        status = CriterionStatus.NOT_MET
+    return CriterionEvaluation(
+        code="age_range",
+        label="16–25 ans, ou 26–30 ans avec RQTH",
+        status=status,
+        is_mandatory=False,
+    )
+
+
+class E2CRule(EligibilityRule):
+    kind = StructuredSolutionKind.E2C
+    max_distance_km = 10
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {self.max_distance_km} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=self.max_distance_km,
+            ),
+            evaluate_bool(
+                code="registered_ft",
+                label="Inscrit à France Travail",
+                value=profile.is_registered_at_france_travail,
+            ),
+            evaluate_education_level(
+                code="education_level",
+                label="Sans qualification ou premier diplôme jusqu'au bac",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_IV_OR_BELOW,
+            ),
+        ]
+        age_criteria = [_evaluate_age_e2c(profile)]
+        is_eligible = all_mandatory_met(mandatory) and at_least_one_met(age_criteria)
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(mandatory + age_criteria))
+
+
+# ---------------------------------------------------------------------------
+# Apprentis d'Auteuil
+# ---------------------------------------------------------------------------
+
+_AD_MAX_DISTANCE_KM = 10
+
+
+class AccompagnementIntensifRule(EligibilityRule):
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_ACCOMPAGNEMENT_INTENSIF
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {_AD_MAX_DISTANCE_KM} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=_AD_MAX_DISTANCE_KM,
+            ),
+            evaluate_bool(code="rsa", label="Bénéficiaire du RSA", value=profile.is_rsa_beneficiary),
+            evaluate_age_range(code="age_range", label="16 à 30 ans", profile=profile, min_age=16, max_age=30),
+        ]
+        return EligibilityResult(kind=self.kind, is_eligible=all_mandatory_met(mandatory), criteria=tuple(mandatory))
+
+
+class SkolaRule(EligibilityRule):
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_SKOLA
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {_AD_MAX_DISTANCE_KM} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=_AD_MAX_DISTANCE_KM,
+            ),
+            evaluate_age_range(code="age_range", label="16 à 30 ans", profile=profile, min_age=16, max_age=30),
+            evaluate_education_level(
+                code="education_level",
+                label="Peu ou pas qualifié",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_IV_OR_BELOW,
+            ),
+            evaluate_bool(
+                code="precarious_situation",
+                label="Situation sociale, économique, familiale précaire",
+                value=profile.has_declared_constraints,
+            ),
+        ]
+        return EligibilityResult(kind=self.kind, is_eligible=all_mandatory_met(mandatory), criteria=tuple(mandatory))
+
+
+class BoostInsertionRule(EligibilityRule):
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_BOOST_INSERTION
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {_AD_MAX_DISTANCE_KM} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=_AD_MAX_DISTANCE_KM,
+            ),
+            evaluate_age_range(code="age_range", label="16 à 29 ans", profile=profile, min_age=16, max_age=29),
+        ]
+        return EligibilityResult(kind=self.kind, is_eligible=all_mandatory_met(mandatory), criteria=tuple(mandatory))
+
+
+def _evaluate_potentielles_gender_or_qpv(profile: BeneficiaryProfile) -> CriterionEvaluation:
+    """Femme OU résidente QPV."""
+    is_woman = profile.civility == "MME" if profile.civility is not None else None
+    if is_woman is None and profile.is_qpv_resident is None:
+        return CriterionEvaluation(
+            code="gender_or_qpv",
+            label="Femme ou résidente QPV",
+            status=CriterionStatus.UNKNOWN,
+            is_mandatory=False,
+        )
+    met = bool(is_woman) or bool(profile.is_qpv_resident)
+    return CriterionEvaluation(
+        code="gender_or_qpv",
+        label="Femme ou résidente QPV",
+        status=CriterionStatus.MET if met else CriterionStatus.NOT_MET,
+        is_mandatory=False,
+    )
+
+
+class PotentiellesRule(EligibilityRule):
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_POTENTIELLES
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_distance(
+                code="distance",
+                label=f"Service à moins de {_AD_MAX_DISTANCE_KM} km",
+                profile=profile,
+                candidate=candidate,
+                max_distance_km=_AD_MAX_DISTANCE_KM,
+            ),
+            evaluate_age_range(code="age_range", label="16 à 30 ans", profile=profile, min_age=16, max_age=30),
+        ]
+        optional = [_evaluate_potentielles_gender_or_qpv(profile)]
+        is_eligible = all_mandatory_met(mandatory) and at_least_one_met(optional)
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(mandatory + optional))
+
+
+# ---------------------------------------------------------------------------
+# SIAE
+# ---------------------------------------------------------------------------
+
+
+class SIAERule(EligibilityRule):
+    """
+    At least 1 level-1 criterion, OR at least `level2_threshold` level-2 criteria.
+    Default threshold is 3 (ETTI/AI use 2, but sub-type is not tracked in the catalog yet).
+    """
+
+    kind = StructuredSolutionKind.SIAE
+    level2_threshold: int = 3
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        level1 = [
+            evaluate_bool(
+                code="rsa",
+                label="Bénéficiaire du RSA",
+                value=profile.is_rsa_beneficiary,
+                is_mandatory=False,
+            ),
+            # ASS and AAH are not available from FT APIs — omitted.
+            evaluate_registration_months(
+                code="detld",
+                label="Demandeur d'emploi de très longue durée (24 mois+)",
+                profile=profile,
+                min_months=24,
+                is_mandatory=False,
+            ),
+        ]
+        level2 = [
+            evaluate_education_level(
+                code="education_level",
+                label="Niveau d'étude 3 (CAP, BEP) ou infra",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_V_OR_BELOW,
+                is_mandatory=False,
+            ),
+            evaluate_age_range(
+                code="senior",
+                label="Senior (50 ans et plus)",
+                profile=profile,
+                min_age=50,
+                is_mandatory=False,
+            ),
+            evaluate_age_range(
+                code="young",
+                label="Jeune (moins de 26 ans)",
+                profile=profile,
+                max_age=25,
+                is_mandatory=False,
+            ),
+            # ASE: not available from FT APIs — omitted.
+            evaluate_registration_months(
+                code="deld",
+                label="Demandeur d'emploi de longue durée (12 mois+)",
+                profile=profile,
+                min_months=12,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="rqth",
+                label="Travailleur handicapé (RQTH)",
+                value=profile.is_rqth_beneficiary,
+                is_mandatory=False,
+            ),
+            # Parent isolé: not available from FT APIs — omitted.
+            evaluate_has_housing_difficulty(
+                code="housing",
+                label="Sans hébergement ou hébergé ou parcours de rue",
+                profile=profile,
+                is_mandatory=False,
+            ),
+            # Réfugié, ZRR, détention: not available from FT APIs — omitted.
+            evaluate_bool(
+                code="qpv",
+                label="Résident QPV",
+                value=profile.is_qpv_resident,
+                is_mandatory=False,
+            ),
+            evaluate_no_literacy_difficulty(
+                code="literacy",
+                label="Maîtrise de la langue française",
+                profile=profile,
+                is_mandatory=False,
+            ),
+            evaluate_no_strong_mobility_difficulty(
+                code="mobility",
+                label="Pas de frein fort à la mobilité",
+                profile=profile,
+                is_mandatory=False,
+            ),
+        ]
+        is_eligible = at_least_one_met(level1) or _n_met(level2) >= self.level2_threshold
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(level1 + level2))
+
+
+# ---------------------------------------------------------------------------
+# EA (Entreprise adaptée)
+# ---------------------------------------------------------------------------
+
+
+class EARule(EligibilityRule):
+    kind = StructuredSolutionKind.EA
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        mandatory = [
+            evaluate_bool(
+                code="rqth",
+                label="Bénéficiaire d'une RQTH (BOETH)",
+                value=profile.is_rqth_beneficiary,
+            ),
+        ]
+        additional = [
+            evaluate_registration_months(
+                code="long_term_unemployment",
+                label="Sans emploi depuis au moins 24 mois",
+                profile=profile,
+                min_months=24,
+                is_mandatory=False,
+            ),
+            # Réfugié, sortant ESAT/ULIS/CFA, détention: not available — omitted.
+            evaluate_education_level(
+                code="education_level",
+                label="Niveau de formation infra 3 ou 3",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_V_OR_BELOW,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="rsa",
+                label="Bénéficiaire de minima sociaux (RSA)",
+                value=profile.is_rsa_beneficiary,
+                is_mandatory=False,
+            ),
+        ]
+        is_eligible = all_mandatory_met(mandatory) and at_least_one_met(additional)
+        return EligibilityResult(kind=self.kind, is_eligible=is_eligible, criteria=tuple(mandatory + additional))
+
+
+# ---------------------------------------------------------------------------
+# GEIQ
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_geiq_young_criterion(profile: BeneficiaryProfile) -> CriterionEvaluation:
+    """
+    Annex 1: under 26, qualification ≤ level 4, no relevant experience (24+ months
+    without employment). We approximate "no experience" by long-term unemployment.
+    """
+    age = profile.age()
+    months = profile.months_since_registration()
+    if age is None:
+        status = CriterionStatus.UNKNOWN
+    else:
+        status = CriterionStatus.MET if age < 26 and (months is None or months >= 24) else CriterionStatus.NOT_MET
+    return CriterionEvaluation(
+        code="annex1_young_no_experience",
+        label="Jeune de moins de 26 ans sans expérience professionnelle (2 ans+)",
+        status=status,
+        is_mandatory=False,
+    )
+
+
+class GEIQRule(EligibilityRule):
+    """
+    GEIQ has no strict eligibility gate: all applicants are eligible if there
+    is a matching ROME code (not enforced here — left to the catalog layer).
+    Criteria determine the public aid tier:
+      - ≥1 annex-1 criterion → 814 €
+      - ≥1 annex-2 level-1 criterion AND ≥2 annex-2 level-2 criteria → 1 400 €
+    The result is always is_eligible=True; matched_criteria_count drives ranking.
+    """
+
+    kind = StructuredSolutionKind.GEIQ
+
+    def evaluate(self, profile: BeneficiaryProfile, candidate: StructuredSolutionCandidate) -> EligibilityResult:
+        annex1 = [
+            evaluate_registration_months(
+                code="annex1_deld",
+                label="Éloigné du marché du travail (12 mois+)",
+                profile=profile,
+                min_months=12,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="annex1_rsa",
+                label="Bénéficiaire de minima sociaux (RSA)",
+                value=profile.is_rsa_beneficiary,
+                is_mandatory=False,
+            ),
+            # Personnes bénéficiant/sortant d'un dispositif d'insertion: not available — omitted.
+            evaluate_bool(
+                code="annex1_rqth",
+                label="Personne en situation de handicap (RQTH)",
+                value=profile.is_rqth_beneficiary,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="annex1_qpv",
+                label="Issue de quartier ou zone prioritaire (QPV)",
+                value=profile.is_qpv_resident,
+                is_mandatory=False,
+            ),
+            evaluate_age_range(
+                code="annex1_senior",
+                label="Demandeur d'emploi de 45 ans et plus",
+                profile=profile,
+                min_age=45,
+                is_mandatory=False,
+            ),
+            # Sortant prison, réfugié, reconversion contrainte: not available — omitted.
+            _evaluate_geiq_young_criterion(profile),
+        ]
+        annex2_level1 = [
+            evaluate_bool(
+                code="annex2_l1_rsa",
+                label="Bénéficiaire du RSA",
+                value=profile.is_rsa_beneficiary,
+                is_mandatory=False,
+            ),
+            # ASS, AAH: not available — omitted.
+            evaluate_registration_months(
+                code="annex2_l1_detld",
+                label="Demandeur d'emploi de très longue durée (24 mois+)",
+                profile=profile,
+                min_months=24,
+                is_mandatory=False,
+            ),
+        ]
+        annex2_level2 = [
+            evaluate_education_level(
+                code="annex2_l2_education",
+                label="Niveau d'étude 3 ou infra",
+                profile=profile,
+                accepted_levels=EDUCATION_LEVEL_V_OR_BELOW,
+                is_mandatory=False,
+            ),
+            evaluate_age_range(
+                code="annex2_l2_senior",
+                label="Senior (50 ans et plus)",
+                profile=profile,
+                min_age=50,
+                is_mandatory=False,
+            ),
+            evaluate_age_range(
+                code="annex2_l2_young",
+                label="Jeune (moins de 26 ans)",
+                profile=profile,
+                max_age=25,
+                is_mandatory=False,
+            ),
+            # ASE: not available — omitted.
+            evaluate_registration_months(
+                code="annex2_l2_deld",
+                label="Demandeur d'emploi de longue durée (12 mois+)",
+                profile=profile,
+                min_months=12,
+                is_mandatory=False,
+            ),
+            evaluate_bool(
+                code="annex2_l2_rqth",
+                label="Travailleur handicapé (RQTH)",
+                value=profile.is_rqth_beneficiary,
+                is_mandatory=False,
+            ),
+            # Parent isolé: not available — omitted.
+            evaluate_has_housing_difficulty(
+                code="annex2_l2_housing",
+                label="Sans hébergement ou hébergé",
+                profile=profile,
+                is_mandatory=False,
+            ),
+            # Réfugié, ZRR, détention: not available — omitted.
+            evaluate_bool(
+                code="annex2_l2_qpv",
+                label="Résident QPV",
+                value=profile.is_qpv_resident,
+                is_mandatory=False,
+            ),
+            evaluate_no_literacy_difficulty(
+                code="annex2_l2_literacy",
+                label="Maîtrise de la langue française",
+                profile=profile,
+                is_mandatory=False,
+            ),
+            evaluate_no_strong_mobility_difficulty(
+                code="annex2_l2_mobility",
+                label="Pas de frein fort à la mobilité",
+                profile=profile,
+                is_mandatory=False,
+            ),
+        ]
+        criteria = annex1 + annex2_level1 + annex2_level2
+        return EligibilityResult(kind=self.kind, is_eligible=True, criteria=tuple(criteria))

--- a/tests/recommendations/factories.py
+++ b/tests/recommendations/factories.py
@@ -1,9 +1,52 @@
+import datetime
 import string
 
 import factory
 import factory.fuzzy
+from django.contrib.gis.geos import Point
 
 from itou.recommendations import models
+from itou.recommendations.criteria import StructuredSolutionCandidate, StructuredSolutionKind
+from itou.recommendations.profile import BeneficiaryProfile
+
+
+_PARIS = Point(2.3488, 48.8534, srid=4326)
+_CLOSE_TO_PARIS = Point(2.35, 48.86, srid=4326)  # ~1 km
+_MARSEILLE = Point(5.37, 43.30, srid=4326)  # Marseille, ~660 km
+_90KM_NORTH_OF_PARIS = Point(2.35, 49.63, srid=4326)  # ~90 km, within EPIDE range
+
+
+class BeneficiaryProfileFactory(factory.Factory):
+    france_travail_id = factory.Sequence(lambda n: f"{n:011d}")
+
+    class Meta:
+        model = BeneficiaryProfile
+        exclude = ["age"]
+
+    age = None
+
+    @factory.lazy_attribute
+    def birthdate(self):
+        if self.age is not None:
+            today = datetime.date.today()
+            return today.replace(year=today.year - self.age)
+        return None
+
+    class Params:
+        in_paris = factory.Trait(coords=_PARIS, code_insee="75056")
+
+
+class StructuredSolutionCandidateFactory(factory.Factory):
+    kind = StructuredSolutionKind.PLIE
+    coordinates = _CLOSE_TO_PARIS
+
+    class Meta:
+        model = StructuredSolutionCandidate
+
+    class Params:
+        in_marseille = factory.Trait(coordinates=_MARSEILLE)
+        within_epide_range = factory.Trait(coordinates=_90KM_NORTH_OF_PARIS)
+        without_coordinates = factory.Trait(coordinates=None)
 
 
 class BeneficiaryFactory(factory.django.DjangoModelFactory):

--- a/tests/recommendations/test_helpers.py
+++ b/tests/recommendations/test_helpers.py
@@ -113,6 +113,7 @@ class TestFetchAndParseUserData:
                             "organization": "CDG Alpes Haute Provence",
                             "timestamp": datetime.datetime(2021, 5, 17, 14, 47, 11, tzinfo=datetime.UTC),
                         },
+                        "code": "23",
                         "details": [
                             "Faire un point complet sur sa mobilité",
                             "Accéder à un véhicule",
@@ -170,6 +171,7 @@ class TestFetchAndParseUserData:
                         "organization": "CDG Alpes Haute Provence",
                         "timestamp": datetime.datetime(2021, 5, 17, 14, 47, 11, tzinfo=datetime.UTC),
                     },
+                    "code": "22",
                     "details": [
                         "Acquérir un équipement",
                         "Accéder à  une connexion internet",

--- a/tests/recommendations/test_rules.py
+++ b/tests/recommendations/test_rules.py
@@ -1,0 +1,307 @@
+import datetime
+
+from itou.recommendations.criteria import CriterionStatus, StructuredSolutionKind
+from itou.recommendations.profile import DiagnosticConstraint
+from itou.recommendations.rules import (
+    AccompagnementIntensifRule,
+    BoostInsertionRule,
+    E2CRule,
+    EARule,
+    EPIDERule,
+    FTEducationLevel,
+    GEIQRule,
+    PLIERule,
+    PotentiellesRule,
+    SIAERule,
+    SkolaRule,
+)
+from tests.recommendations.factories import BeneficiaryProfileFactory, StructuredSolutionCandidateFactory
+
+
+class TestPLIERule:
+    rule = PLIERule()
+    kind = StructuredSolutionKind.PLIE
+
+    def _eligible_profile(self):
+        return BeneficiaryProfileFactory(age=30, in_paris=True, is_qpv_resident=True)
+
+    def test_eligible(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind),
+        )
+        assert result.is_eligible
+
+    def test_too_young(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=24, is_qpv_resident=True)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_too_far(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind, in_marseille=True),
+        )
+        assert not result.is_eligible
+
+    def test_no_situation_criterion(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=30,
+            is_qpv_resident=False,
+            status_effective_date=datetime.date.today() - datetime.timedelta(days=30),
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_unknown_coords_gives_unknown_distance(self):
+        profile = BeneficiaryProfileFactory(age=30, is_qpv_resident=True)
+        result = self.rule.evaluate(
+            profile, StructuredSolutionCandidateFactory(kind=self.kind, without_coordinates=True)
+        )
+        distance_criterion = next(c for c in result.criteria if c.code == "distance")
+        assert distance_criterion.status is CriterionStatus.UNKNOWN
+
+    def test_inside_eligibility_zone(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind, eligibility_zones=("75056",)),
+        )
+        assert result.is_eligible
+
+    def test_outside_eligibility_zone(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind, eligibility_zones=("93001",)),
+        )
+        zone_criterion = next(c for c in result.criteria if c.code == "zone_eligibilite")
+        assert zone_criterion.status is CriterionStatus.NOT_MET
+        assert not result.is_eligible
+
+
+class TestEPIDERule:
+    rule = EPIDERule()
+    kind = StructuredSolutionKind.EPIDE
+
+    def _eligible_profile(self):
+        return BeneficiaryProfileFactory(
+            age=20,
+            in_paris=True,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+        )
+
+    def test_eligible(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind),
+        )
+        assert result.is_eligible
+
+    def test_too_old(self):
+        profile = BeneficiaryProfileFactory(
+            age=26,
+            in_paris=True,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_within_100km(self):
+        result = self.rule.evaluate(
+            self._eligible_profile(),
+            StructuredSolutionCandidateFactory(kind=self.kind, within_epide_range=True),
+        )
+        assert result.is_eligible
+
+
+class TestE2CRule:
+    rule = E2CRule()
+    kind = StructuredSolutionKind.E2C
+
+    def test_eligible_young(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=20,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_eligible_26_to_30_with_rqth(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=28,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+            is_rqth_beneficiary=True,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_not_eligible_26_without_rqth(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=28,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+            is_rqth_beneficiary=False,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_not_eligible_too_old(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=31,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_registered_at_france_travail=True,
+            is_rqth_beneficiary=True,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestAccompagnementIntensifRule:
+    rule = AccompagnementIntensifRule()
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_ACCOMPAGNEMENT_INTENSIF
+
+    def test_eligible(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25, is_rsa_beneficiary=True)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_no_rsa(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25, is_rsa_beneficiary=False)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_too_old(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=31, is_rsa_beneficiary=True)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestSkolaRule:
+    rule = SkolaRule()
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_SKOLA
+
+    def test_eligible(self):
+        profile = BeneficiaryProfileFactory(
+            in_paris=True,
+            age=22,
+            education_level=FTEducationLevel.CAP_BEP,
+            has_declared_constraints=True,
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+
+class TestBoostInsertionRule:
+    rule = BoostInsertionRule()
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_BOOST_INSERTION
+
+    def test_eligible(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_too_old(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=30)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestPotentiellesRule:
+    rule = PotentiellesRule()
+    kind = StructuredSolutionKind.APPRENTIS_DAUTEUIL_POTENTIELLES
+
+    def test_eligible_woman(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25, civility="MME")
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_eligible_qpv(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25, civility="M", is_qpv_resident=True)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_not_eligible_man_not_qpv(self):
+        profile = BeneficiaryProfileFactory(in_paris=True, age=25, civility="M", is_qpv_resident=False)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestSIAERule:
+    rule = SIAERule()
+    kind = StructuredSolutionKind.SIAE
+
+    def test_eligible_via_level1_rsa(self):
+        profile = BeneficiaryProfileFactory(is_rsa_beneficiary=True)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_eligible_via_level1_detld(self):
+        profile = BeneficiaryProfileFactory(status_effective_date=datetime.date.today() - datetime.timedelta(days=800))
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_eligible_via_3_level2_criteria(self):
+        profile = BeneficiaryProfileFactory(
+            age=22, education_level=FTEducationLevel.CAP_BEP, is_rqth_beneficiary=True, is_rsa_beneficiary=False
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_not_eligible_only_2_level2_criteria(self):
+        profile = BeneficiaryProfileFactory(
+            age=22,
+            education_level=FTEducationLevel.CAP_BEP,
+            is_rsa_beneficiary=False,
+            is_rqth_beneficiary=False,
+            is_qpv_resident=False,
+            has_declared_constraints=True,
+            diagnostic_constraints=(
+                DiagnosticConstraint(code="20"),
+                DiagnosticConstraint(code="6", impact="FORT"),
+            ),
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestEARule:
+    rule = EARule()
+    kind = StructuredSolutionKind.EA
+
+    def test_eligible(self):
+        profile = BeneficiaryProfileFactory(is_rqth_beneficiary=True, education_level=FTEducationLevel.CAP_BEP)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible
+
+    def test_not_eligible_without_rqth(self):
+        profile = BeneficiaryProfileFactory(is_rqth_beneficiary=False, education_level=FTEducationLevel.CAP_BEP)
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+    def test_not_eligible_rqth_but_no_additional_criterion(self):
+        profile = BeneficiaryProfileFactory(
+            is_rqth_beneficiary=True,
+            is_rsa_beneficiary=False,
+            education_level=FTEducationLevel.BAC_PLUS_5_AND_ABOVE,
+            status_effective_date=datetime.date.today() - datetime.timedelta(days=30),
+        )
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert not result.is_eligible
+
+
+class TestGEIQRule:
+    rule = GEIQRule()
+    kind = StructuredSolutionKind.GEIQ
+
+    def test_always_eligible(self):
+        profile = BeneficiaryProfileFactory()
+        result = self.rule.evaluate(profile, StructuredSolutionCandidateFactory(kind=self.kind))
+        assert result.is_eligible


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Développer les bases des filtres pour recommander les SPS](https://app.notion.com/p/gip-inclusion/3-1-D-velopper-les-bases-des-filtres-pour-recommander-les-SPS-34b5f321b604805a8539d2ba2a57b7ab)

TLDR: faire un moteur de matching pour les différentes conditions d'accès aux différentes aides SPS disponibles.

## :cake: Comment ? <!-- optionnel -->
Le premier commit rajoute les codes de contraintes, parce que il y a en a besoin pour certaines règles (ex: SIAE).

Le moteur de règles est implémenté comme un ensemble de fonctions opérant sur des dataclasses immutables. Un BeneficiaryProfile (construit depuis les données FT) est évalué contre un StructuredSolutionCandidate (construit depuis un insertion.models.Service) par une ensemble de règles par dispositif. Chaque critère est évalué individuellement avec un tri-état (rempli / non rempli / donnée indisponible) pour gérer les données manquantes côté API FT. L'orchestrateur (`engine.recommend`) reçoit profil et candidats en paramètre, applique la règle correspondante au `kind` de chaque candidat, et trie les résultats par nombre de critères remplis puis par proximité géographique.

C'est le moteur de matching pur + les règles, non-relié au reste, comme demandé dans le ticket.

J'ai fait générer les rules par Claude à partir d'un export de la carte markdown parce que ça aurait trop de travail (et trop d'erreurs ?) de les recopier à la main.

Pour les dataclasses, j'aime bien `frozen=True,slots=True`:
* frozen parce qu' elles représentent des DTO fixes, un snapshot, changer les valeurs une fois créé n'a pas de sens
* slots, empèche de rajouer un membre pas défini à l'avance. frozen sans slot a peu de sens

~La CI est rouge, c'est un test flaky lié au temps, c'est corrigé ici : https://github.com/gip-inclusion/les-emplois/pull/8339.~
