### PR TITLE
tech: correction d'un test flaky

### DIFF
--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -5,6 +5,7 @@ import factory
 import factory.fuzzy
 from dateutil.relativedelta import relativedelta
 from django.core.files.storage import default_storage
+from django.utils import timezone
 
 from itou.companies.enums import CompanyKind
 from itou.companies.models import JobDescription
@@ -158,8 +159,8 @@ class JobApplicationFactory(AutoNowOverrideMixin, factory.django.DjangoModelFact
     to_company = factory.SubFactory(CompanyFactory, with_membership=True)
     message = factory.Faker("sentence", nb_words=40)
     answer = factory.Faker("sentence", nb_words=40)
-    hiring_start_at = factory.LazyFunction(lambda: datetime.now(UTC).date())
-    hiring_end_at = factory.LazyFunction(lambda: datetime.now(UTC).date() + relativedelta(years=2))
+    hiring_start_at = factory.LazyFunction(timezone.localdate)
+    hiring_end_at = factory.LazyFunction(lambda: timezone.localdate() + relativedelta(years=2))
     resume = factory.SubFactory(FileFactory)
     sender_kind = None  # Force all calls to use a sent_by_xxx trait as the db doesn't allow null values
     processed_at = factory.LazyAttribute(
@@ -245,8 +246,8 @@ class PriorActionFactory(factory.django.DjangoModelFactory):
     action = factory.fuzzy.FuzzyChoice(Prequalification.values + ProfessionalSituationExperience.values)
     dates = factory.LazyFunction(
         lambda: InclusiveDateRange(
-            datetime.now(UTC).date(),
-            datetime.now(UTC).date() + relativedelta(years=2),
+            timezone.localdate(),
+            timezone.localdate() + relativedelta(years=2),
         )
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Alors que je travaillais sur une autre PR vers minuit, un test non lié à ce que je faisais échouait régulièrement et ça m’embêtait fortement. Je connais ce genre de problèmes typique des tests lancés vers minuit : c'est un problème de mélange de comparaison de fuseau horaire naïf vs UTC. À minuit, le fuseau français est déjà au jour "actuel" que alors l'UTC est encore à "hier", donc les tests qui testent « est-ce le même jour ? » cassent.

En l'occurence ici le bug est un peu subtil : l'auteur prend bien une datetime conscient (_bravo_), mais sans vérifier que c'est le même fuseau que celui active (_aouch, risqué mais admissible_), mais ensuite le tronque en date, perdant le fuseau horaire (💥) [^1]. Du coup on a un date au jour J et un date au jour J-1.

[^1]: les `date` python n'ont pas de fuseau horaire

## :cake: Comment ? <!-- optionnel -->

J'ai dit à Claude « corrige cette CI qui est rouge », et il a corrigé ça. Les premier commit est un commit vide qui prouve l'existence du problème, le deuxième est le commit de correction. Les deux dans une fenêtre de temps de 5 minutes, sinon c'est pas du jeu, évidemment.

<img width="922" height="133" alt="Capture d’écran 2026-06-29 à 09 42 08" src="https://github.com/user-attachments/assets/0d49fb59-a946-4b58-91e0-521d9cb615ab" />
