### PR TITLE
Corrections sur le parcours de 2FA interne Emplois pour les professionnels

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -87,6 +87,9 @@ if os.getenv("DEBUG_SQL_SNAPSHOT"):
 FORCE_PROCONNECT_LOGIN = True  # default behaviour in tests
 
 REQUIRE_OTP_FOR_STAFF = False
+REQUIRE_MFA_FOR_PROS = False
+REQUIRE_MFA_ON_COMPANY_IDS = set()
+REQUIRE_MFA_ON_ORGANIZATION_IDS = set()
 
 BREVO_API_URL = "https://mailer.test.com"
 

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -348,7 +348,7 @@ def pro_connect_callback(request):
     amr = ()
     idp_id = None
     try:
-        amr = id_token_data.get("amr", ())
+        amr = id_token_data.get("amr") or ()
         idp_id = user_data.get("idp_id", "")
         ProConnectAuthentication.objects.create(
             user_public_id=user.public_id,

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -36,13 +36,10 @@ def notify_backup_code_has_been_used(user):
     email.send()
 
 
-def require_otp(user):
-    if not user.is_authenticated:
-        return False
-
-    if user.is_verified():  # user has already authenticated with MFA
-        return False
-
+def user_is_concerned_by_otp(user):
+    """Whether 2FA applies to this user, regardless of whether they have already
+    verified in the current session (unlike `require_otp`, which short-circuits on
+    `is_verified()`). Assumes an authenticated itou user."""
     if settings.REQUIRE_OTP_FOR_STAFF and user.is_itou_staff:
         return True
 
@@ -50,6 +47,16 @@ def require_otp(user):
         return True
 
     return False
+
+
+def require_otp(user):
+    if not user.is_authenticated:
+        return False
+
+    if user.is_verified():  # user has already authenticated with MFA
+        return False
+
+    return user_is_concerned_by_otp(user)
 
 
 def _require_otp_for_pro(user):

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -127,6 +127,8 @@ def load_placeholder_for_external_totp_device(persistent_id):
 
 
 class ExternalTOTPDevice:
+    """This placeholder is a session-only marker: verification already happened on ProConnect's side."""
+
     def __init__(self, user_id: int):
         self.user_id = user_id
 

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -49,6 +49,28 @@ def user_is_concerned_by_otp(user):
     return False
 
 
+def user_uses_external_mfa(user):
+    """Whether the current session was verified by the identity provider's own MFA.
+
+    See `create_placeholder_for_external_totp_device()`.
+    Only meaningful for the request user after OTPMiddleware.
+    """
+    return isinstance(getattr(user, "otp_device", None), ExternalTOTPDevice)
+
+
+def user_can_enroll_otp_device(user):
+    """Whether our own 2FA applies to this user and the identity provider does not already
+    handle it: enrolling a device is useful."""
+    return not user_uses_external_mfa(user) and (
+        user.show_upcoming_mfa_activation_banner or user_is_concerned_by_otp(user)
+    )
+
+
+def user_can_manage_otp_devices(user):
+    """Same as `user_can_enroll_otp_device`, plus at least one device to see, use or delete."""
+    return user_can_enroll_otp_device(user) and ItouTOTPDevice.objects.filter(user=user, disabled_at=None).exists()
+
+
 def require_otp(user):
     if not user.is_authenticated:
         return False
@@ -63,6 +85,11 @@ def _require_otp_for_pro(user):
     assert user.is_professional
     if not settings.REQUIRE_MFA_FOR_PROS:
         return False
+    # We tested the enrollment flow on some users who were not yet in
+    # the targeted batches that we check below. If they have enrolled
+    # a device, we should require them to use it.
+    if ItouTOTPDevice.objects.filter(user=user, disabled_at=None).exists():
+        return True
     org_ids = set(
         PrescriberMembership.objects.active().filter(user_id=user.id).values_list("organization_id", flat=True)
     )

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import transaction
 
 from itou.companies.models import CompanyMembership
 from itou.otp.models import ItouStaticDevice, ItouStaticToken, ItouTOTPDevice
@@ -15,6 +16,37 @@ def get_user_devices(user):
         ItouTOTPDevice.objects.filter(user=user, disabled_at=None),
         key=lambda device: device.name,
     )
+
+
+def verify_token_for_user(user, otp_token):
+    """Return the user's device that validates `otp_token`, or None.
+
+    django_otp's `verify_token` increments the per-device throttle counter of
+    every device it fails on. Since we cannot know upfront which device produced
+    the code, we try each one. But a correct code would then penalise every
+    device tried before the match. We roll back that collateral increment on
+    those earlier devices, preserving their genuine prior failures.
+
+    Devices are locked with `select_for_update()` so a concurrent verification
+    attempt cannot interleave with the throttle read/rollback (lost update).
+    """
+    with transaction.atomic():
+        devices = (
+            ItouTOTPDevice.objects.filter(user=user, disabled_at=None)
+            .select_for_update()
+            .order_by("name")  # deterministic lock order
+        )
+        tried = []
+        for device in devices:
+            prev_count, prev_timestamp = (device.throttling_failure_count, device.throttling_failure_timestamp)
+            if device.verify_token(otp_token):
+                # Roll back the collateral increment on every earlier (failed) device
+                ItouTOTPDevice.objects.bulk_update(tried, ["throttling_failure_count", "throttling_failure_timestamp"])
+                return device
+            device.throttling_failure_count = prev_count
+            device.throttling_failure_timestamp = prev_timestamp
+            tried.append(device)
+        return None
 
 
 def create_otp_backup_code(user) -> str:

--- a/itou/templates/layout/_header_user_dropdown_menu.html
+++ b/itou/templates/layout/_header_user_dropdown_menu.html
@@ -1,3 +1,4 @@
+{% load otp %}
 <ul class="list-unstyled">
     <li class="dropdown-item">
         <div class="d-flex align-items-center">
@@ -31,9 +32,10 @@
             <a class="dropdown-item" href="{% url 'dashboard:edit_user_email' %}">Modifier mon adresse e-mail</a>
         </li>
     {% endif %}
-    {% if user.is_staff %}
+    {% show_otp_configuration user as show_otp_config %}
+    {% if show_otp_config %}
         <li>
-            <a class="dropdown-item text-primary" href="{% url 'otp_views:otp_devices' %}">Configuration OTP</a>
+            <a class="dropdown-item text-primary" href="{% url 'otp_views:otp_devices' %}">Configuration 2FA</a>
         </li>
     {% endif %}
     <li class="dropdown-divider"></li>

--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -23,9 +23,9 @@
             {% endfragment %}
             {% fragment as content %}
                 <p class="mb-0">
-                    Il a été utilisé et ne peut plus servir. Si vous l’avez noté quelque part (document, gestionnaire de mots de passe, papier…), supprimez-le dès maintenant pour éviter toute confusion future.
+                    Il a été utilisé et <strong>ne peut plus servir</strong>. Si vous l’avez noté quelque part (document, gestionnaire de mots de passe, papier…), <strong>supprimez-le dès maintenant</strong> pour éviter toute confusion future.
                     <br>
-                    À l’issue de cette configuration, un nouveau code de récupération vous sera généré. Conservez-le soigneusement, il remplacera définitivement l’ancien.
+                    À l’issue de cette configuration, <strong>un nouveau code de récupération vous sera généré</strong>. Conservez-le soigneusement, il remplacera définitivement l’ancien.
                 </p>
             {% endfragment %}
         {% endcomponent_alert %}

--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -1,7 +1,9 @@
 {% extends "layout/base.html" %}
 {% load components %}
 
-{% block global_messages %}{% endblock %}
+{% block global_messages %}
+    {% include "includes/demo_accounts.html" %}
+{% endblock %}
 
 {% block title %}Configuration 2FA {{ block.super }}{% endblock %}
 

--- a/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
+++ b/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
@@ -1,7 +1,9 @@
 {% extends "layout/base.html" %}
 {% load components %}
 
-{% block global_messages %}{% endblock %}
+{% block global_messages %}
+    {% include "includes/demo_accounts.html" %}
+{% endblock %}
 
 {% block title %}Configuration 2FA {{ block.super }}{% endblock %}
 

--- a/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
+++ b/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
@@ -3,7 +3,9 @@
 {% load components %}
 {% load django_bootstrap5 %}
 
-{% block global_messages %}{% endblock %}
+{% block global_messages %}
+    {% include "includes/demo_accounts.html" %}
+{% endblock %}
 
 {% block title %}Sécurisez votre accès {{ block.super }}{% endblock %}
 

--- a/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
+++ b/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
@@ -24,14 +24,14 @@
                 Ne passez pas cette page sans avoir noté votre code de récupération.
             {% endfragment %}
             {% fragment as content %}
-                <p>Il est généré une seule fois et ne sera plus accessible ensuite.</p>
+                <p>Il est <strong>généré une seule fois</strong> et ne sera plus accessible ensuite.</p>
                 <ul class="mb-0">
-                    <li>Sans lui, vous ne pourrez plus accéder à votre compte si vous perdez ou changez votre appareil.</li>
+                    <li>Sans lui, <strong>vous ne pourrez plus accéder à votre compte</strong> si vous perdez ou changez votre appareil.</li>
                     <li>
-                        Conservez-le dans un endroit sécurisé : gestionnaire de mots de passe, document imprimé, coffre-fort numérique…
+                        <strong>Conservez-le dans un endroit sécurisé :</strong> gestionnaire de mots de passe, document imprimé, coffre-fort numérique…
                     </li>
                     <li>
-                        Si vous utilisez l’application mobile pour l’authentification forte, évitez de stocker ce code sur ce même téléphone, vous risqueriez de tout perdre en même temps.
+                        Si vous utilisez l’application mobile pour l’authentification forte, <strong>évitez de stocker ce code sur ce même téléphone</strong>, vous risqueriez de tout perdre en même temps.
                     </li>
                 </ul>
             {% endfragment %}

--- a/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
+++ b/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
@@ -78,6 +78,9 @@
                                                     <p class="mb-0">
                                                         <strong>Dans votre application, cliquez sur « + » ou sur « ajouter » puis scannez ce QR code depuis l’application.</strong>
                                                     </p>
+                                                    <p class="fs-sm fst-italic text-muted">
+                                                        Exemples d'application : Google Authenticator, Authy, Microsoft Authenticator
+                                                    </p>
                                                     <p>
                                                         <img src="{{ qrcode }}" width="250" alt="QR code pour la configuration de l’authentification à deux facteurs">
                                                     </p>

--- a/itou/templates/otp_views/login_with_backup_code.html
+++ b/itou/templates/otp_views/login_with_backup_code.html
@@ -31,7 +31,7 @@
                                 Vous n’avez pas non plus votre code de récupération ?
                             {% endfragment %}
                             {% fragment as content %}
-                                Sans code de récupération, il n’est pas possible d'accéder à votre compte de manière autonome. Veuillez contactez notre support.
+                                Sans code de récupération, il n’est pas possible d'accéder à votre compte de manière autonome. Veuillez contacter notre support.
                             {% endfragment %}
                             {% fragment as call_to_action %}
                                 <a href="{% zendesk_form_url request=request %}" target="_blank" rel="noopener" class="btn btn-block btn-primary has-external-link">Contacter le support</a>

--- a/itou/utils/auth.py
+++ b/itou/utils/auth.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import PermissionDenied
+from django.http import Http404
 
 
 def check_user(test_func, err_msg=""):
@@ -12,6 +13,22 @@ def check_user(test_func, err_msg=""):
             if test_pass:
                 return view_func(request, *args, **kwargs)
             raise PermissionDenied(err_msg)
+
+        return wraps(view_func)(_check_user_view_wrapper)
+
+    return decorator
+
+
+def check_user_or_404(test_func, err_msg=""):
+    """Same as `check_user`, but hides the existence of the view instead of denying access."""
+
+    def decorator(view_func):
+        def _check_user_view_wrapper(request, *args, **kwargs):
+            test_pass = test_func(request.user)
+
+            if test_pass:
+                return view_func(request, *args, **kwargs)
+            raise Http404(err_msg)
 
         return wraps(view_func)(_check_user_view_wrapper)
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -183,6 +183,20 @@ class ItouCurrentOrganizationMiddleware:
         if not user.is_authenticated and request.path.startswith("/admin"):
             return HttpResponseRedirect(reverse("account_login", query={REDIRECT_FIELD_NAME: request.get_full_path()}))
 
+        # Enforce internal OTP before the Nexus whitelist below, otherwise
+        # MFA-required professionals could reach the whitelisted views unverified
+        if require_otp(user):
+            logger.info("Requiring internal OTP for user %d", user.id)
+            login_verify_otp_url = reverse("otp_views:verify_otp")
+            login_with_backup_code_url = reverse("otp_views:login_with_backup_code")
+            if get_user_devices(user):
+                if request.path not in (login_verify_otp_url, login_with_backup_code_url):
+                    return HttpResponseRedirect(
+                        add_url_params(login_verify_otp_url, {REDIRECT_FIELD_NAME: request.get_full_path()})
+                    )
+            elif not request.path.startswith("/otp/enrollment"):
+                return HttpResponseRedirect(reverse("otp_views:enrollment_step_0_intro"))
+
         # Nexus : Whitelist for Nexus views
         # FIXME: Remove once we merge prescribers and employers
         if (
@@ -196,18 +210,6 @@ class ItouCurrentOrganizationMiddleware:
             )
         ):
             return self.get_response(request)
-
-        if require_otp(user):
-            logger.info("Requiring internal OTP for user %d", user.id)
-            login_verify_otp_url = reverse("otp_views:verify_otp")
-            login_with_backup_code_url = reverse("otp_views:login_with_backup_code")
-            if get_user_devices(user):
-                if request.path not in (login_verify_otp_url, login_with_backup_code_url):
-                    return HttpResponseRedirect(
-                        add_url_params(login_verify_otp_url, {REDIRECT_FIELD_NAME: request.get_full_path()})
-                    )
-            elif not request.path.startswith("/otp/enrollment"):
-                return HttpResponseRedirect(reverse("otp_views:enrollment_step_0_intro"))
 
         if logout_warning is not None:
             return HttpResponseRedirect(reverse("logout:warning", kwargs={"kind": logout_warning}))

--- a/itou/utils/templatetags/otp.py
+++ b/itou/utils/templatetags/otp.py
@@ -1,0 +1,11 @@
+from django import template
+
+from itou.otp.utils import user_is_concerned_by_otp
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def show_otp_configuration(user):
+    return user.is_authenticated and user_is_concerned_by_otp(user)

--- a/itou/utils/templatetags/otp.py
+++ b/itou/utils/templatetags/otp.py
@@ -1,6 +1,6 @@
 from django import template
 
-from itou.otp.utils import user_is_concerned_by_otp
+from itou.otp.utils import user_can_manage_otp_devices
 
 
 register = template.Library()
@@ -8,4 +8,5 @@ register = template.Library()
 
 @register.simple_tag
 def show_otp_configuration(user):
-    return user.is_authenticated and user_is_concerned_by_otp(user)
+    # Same predicate as the OTP views, so that the menu only shows what is reachable
+    return user.is_authenticated and user_can_manage_otp_devices(user)

--- a/itou/www/otp_views/forms.py
+++ b/itou/www/otp_views/forms.py
@@ -32,7 +32,7 @@ class ConfirmTOTPDeviceForm(forms.Form):
             {"placeholder": "Téléphone pro" if device_type == DeviceType.SMARTPHONE else "Ordinateur pro"}
         )
         self.fields["otp_token"].label = mark_safe(
-            "Une fois le service ajouté, un code à 6 chiffres s'affiche automatiquement "
+            "Une fois le service ajouté, un code à 6 chiffres s’affiche automatiquement "
             + (
                 "dans votre application."
                 if device_type == DeviceType.SMARTPHONE

--- a/itou/www/otp_views/forms.py
+++ b/itou/www/otp_views/forms.py
@@ -1,10 +1,14 @@
+import logging
 from base64 import b32encode
 
 from django import forms
 from django.utils.safestring import mark_safe
 
-from itou.otp.utils import get_user_devices
+from itou.otp.utils import verify_token_for_user
 from itou.www.otp_views.enums import DeviceType
+
+
+logger = logging.getLogger(__name__)
 
 
 class ConfirmTOTPDeviceForm(forms.Form):
@@ -97,12 +101,11 @@ class VerifyOTPForm(forms.Form):
     def clean_otp_token(self):
         otp_token = self.cleaned_data.get("otp_token")
 
-        device = next(
-            (d for d in get_user_devices(self.user) if d.verify_token(otp_token)),
-            None,
-        )
+        device = verify_token_for_user(self.user, otp_token)
         if device is None:
+            logger.info("User %s failed 2FA verification", self.user.id)
             raise forms.ValidationError("Le code de validation unique (OTP) n’est pas correct.")
-        self.user.otp_device = device
 
+        self.user.otp_device = device
+        logger.info("User %s authenticated with 2FA", self.user.id)
         return otp_token

--- a/itou/www/otp_views/forms.py
+++ b/itou/www/otp_views/forms.py
@@ -1,7 +1,7 @@
 from base64 import b32encode
 
 from django import forms
-from django.utils.html import mark_safe
+from django.utils.safestring import mark_safe
 
 from itou.otp.utils import get_user_devices
 from itou.www.otp_views.enums import DeviceType
@@ -18,7 +18,7 @@ class ConfirmTOTPDeviceForm(forms.Form):
 
     otp_token.widget.attrs.update(
         {
-            "max_length": 6,
+            "maxlength": 6,
             "autocomplete": "one-time-code",
         }
     )
@@ -84,7 +84,7 @@ class VerifyOTPForm(forms.Form):
 
     otp_token.widget.attrs.update(
         {
-            "max_length": 6,
+            "maxlength": 6,
             "autocomplete": "one-time-code",
             "autofocus": True,
         }

--- a/itou/www/otp_views/forms.py
+++ b/itou/www/otp_views/forms.py
@@ -1,6 +1,7 @@
 from base64 import b32encode
 
 from django import forms
+from django.utils.html import mark_safe
 
 from itou.otp.utils import get_user_devices
 from itou.www.otp_views.enums import DeviceType
@@ -11,7 +12,7 @@ class ConfirmTOTPDeviceForm(forms.Form):
         label="Choisissez un nom pour votre appareil",
         help_text="Ce nom vous aidera à retrouver cet appareil dans vos paramètres de sécurité.",
     )
-    otp_token = forms.CharField(label="Générez le code unique de validation (OTP) dans l’application et entrez-le ici")
+    otp_token = forms.CharField(label="")  # customized in `__init__()`
     key = forms.CharField(widget=forms.HiddenInput)
     device_type = forms.CharField(widget=forms.HiddenInput)
 
@@ -29,6 +30,15 @@ class ConfirmTOTPDeviceForm(forms.Form):
         self.fields["device_type"].initial = device_type
         self.fields["name"].widget.attrs.update(
             {"placeholder": "Téléphone pro" if device_type == DeviceType.SMARTPHONE else "Ordinateur pro"}
+        )
+        self.fields["otp_token"].label = mark_safe(
+            "Une fois le service ajouté, un code à 6 chiffres s'affiche automatiquement "
+            + (
+                "dans votre application."
+                if device_type == DeviceType.SMARTPHONE
+                else "dans votre gestionnaire de mots de passe."
+            )
+            + "<br>Reportez-le ici :"
         )
 
     def clean(self):

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -9,13 +9,20 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.views.generic.edit import FormView
 from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import default_key as generate_otp_key
 
 from itou.otp.models import ItouStaticDevice, ItouTOTPDevice
-from itou.otp.utils import create_otp_backup_code, get_user_devices, notify_backup_code_has_been_used
-from itou.utils.auth import check_user
+from itou.otp.utils import (
+    create_otp_backup_code,
+    get_user_devices,
+    notify_backup_code_has_been_used,
+    user_can_enroll_otp_device,
+    user_can_manage_otp_devices,
+)
+from itou.utils.auth import check_user_or_404
 from itou.utils.readonly import http_methods
 from itou.utils.urls import get_safe_url
 from itou.www.otp_views.enums import DeviceType
@@ -23,11 +30,13 @@ from itou.www.otp_views.forms import ConfirmTOTPDeviceForm, LoginWithBackupCodeF
 
 
 logger = logging.getLogger(__name__)
-check_user_for_otp = check_user(lambda user: user.is_staff or user.is_professional)
+
+check_user_can_enroll = check_user_or_404(user_can_enroll_otp_device)
+check_user_can_manage_devices = check_user_or_404(user_can_manage_otp_devices)
 
 
 @http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
-@check_user_for_otp
+@check_user_can_manage_devices
 def otp_devices(request, template_name="otp_views/otp_devices.html"):
     devices = get_user_devices(request.user)
     if request.method == "POST":
@@ -44,7 +53,7 @@ def otp_devices(request, template_name="otp_views/otp_devices.html"):
     return render(request, template_name, context)
 
 
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_0_intro(request, template_name="otp_views/enrollment_step_0_intro.html"):
     after_recovery = "after_recovery" in request.GET
     if after_recovery:
@@ -59,14 +68,14 @@ def enrollment_step_0_intro(request, template_name="otp_views/enrollment_step_0_
     return render(request, template_name, context)
 
 
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_1_choose_device_type(request, template_name="otp_views/enrollment_step_1_choose_device_type.html"):
     context = {"next_step_url": reverse("otp_views:enrollment_step_2_and_3_confirm_device")}
     return render(request, template_name, context)
 
 
 @http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_2_and_3_confirm_device(
     request, template_name="otp_views/enrollment_step_2_and_3_confirm_device.html"
 ):
@@ -122,6 +131,7 @@ def enrollment_step_2_and_3_confirm_device(
     return render(request, template_name, context)
 
 
+@method_decorator(check_user_can_manage_devices, name="dispatch")
 class VerifyOTPView(FormView):
     template_name = "otp_views/verify_otp.html"
     form_class = VerifyOTPForm
@@ -142,15 +152,10 @@ class VerifyOTPView(FormView):
         return get_safe_url(self.request, REDIRECT_FIELD_NAME, reverse("dashboard:index"))
 
 
-@check_user_for_otp
+@check_user_can_manage_devices
 def login_with_backup_code(request, template_name="otp_views/login_with_backup_code.html"):
     static_device = ItouStaticDevice.objects.filter(user=request.user).first()
     if not static_device:
-        if not get_user_devices(request.user):
-            # Direct access to this route without any enrolled device.
-            # Reject by redirecting to dashboard, user will be
-            # redirected if an OTP is required.
-            return HttpResponseRedirect(reverse("dashboard:index"))
         # If user enrolled a device after June 2026, they must have a
         # static device (backup code). If they enrolled before (which
         # is the case for most staff users), they don't have a static

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -165,7 +165,7 @@ def login_with_backup_code(request, template_name="otp_views/login_with_backup_c
         context = {"form": LoginWithBackupCodeForm(static_device=None)}
         messages.warning(
             request,
-            "Il semble que vous n’ayiez pas de code de récupération. Veuillez contacter le support.",
+            "Il semble que vous n’ayez pas de code de récupération. Veuillez contacter le support.",
         )
         return render(request, template_name, context)
 

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -44,7 +44,9 @@ def otp_devices(request, template_name="otp_views/otp_devices.html"):
             device = get_object_or_404(ItouTOTPDevice.objects.filter(user=request.user), pk=device_id)
             if device != request.user.otp_device:
                 messages.success(request, "L’appareil a été supprimé.")
-                device.delete()
+                # Soft delete for auditing purposes (see the command `purge_disabled_otp_devices`)
+                device.disabled_at = timezone.now()
+                device.save(update_fields=["disabled_at"])
                 devices = get_user_devices(request.user)
             else:
                 messages.error(request, "Impossible de supprimer l’appareil qui a été utilisé pour se connecter.")
@@ -186,7 +188,7 @@ def login_with_backup_code(request, template_name="otp_views/login_with_backup_c
         # done by `ItouStaticDevice.verify_token` (called by the
         # form). However, we need to delete all other TOTP devices,
         # since the user seems to have lost them.
-        ItouTOTPDevice.objects.filter(user=request.user).update(disabled_at=timezone.now())
+        ItouTOTPDevice.objects.filter(user=request.user, disabled_at=None).update(disabled_at=timezone.now())
         ItouStaticDevice.objects.filter(user=request.user).delete()
 
         notify_backup_code_has_been_used(request.user)

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -41,7 +41,9 @@ def otp_devices(request, template_name="otp_views/otp_devices.html"):
     devices = get_user_devices(request.user)
     if request.method == "POST":
         if device_id := request.POST.get("delete-device"):
-            device = get_object_or_404(ItouTOTPDevice.objects.filter(user=request.user), pk=device_id)
+            device = get_object_or_404(
+                ItouTOTPDevice.objects.filter(user=request.user, disabled_at=None), pk=device_id
+            )
             if device != request.user.otp_device:
                 messages.success(request, "L’appareil a été supprimé.")
                 # Soft delete for auditing purposes (see the command `purge_disabled_otp_devices`)
@@ -87,12 +89,17 @@ def enrollment_step_2_and_3_confirm_device(
         # should not happen, unless user manipulates the request
         return HttpResponseRedirect(previous_step_url)
 
-    device = ItouTOTPDevice(
-        user=request.user,
-        key=binascii.hexlify(base64.b32decode(request.POST["key"].encode())).decode()
-        if request.POST
-        else generate_otp_key(),
-    )
+    if request.POST:
+        if not request.POST.get("key"):
+            return HttpResponseRedirect(previous_step_url)
+        try:
+            key = binascii.hexlify(base64.b32decode(request.POST["key"].encode())).decode()
+        except (KeyError, binascii.Error):
+            return HttpResponseRedirect(previous_step_url)
+    else:
+        key = generate_otp_key()
+
+    device = ItouTOTPDevice(user=request.user, key=key)
 
     backup_code = None
     post_save_url = None

--- a/tests/insertion/test_models.py
+++ b/tests/insertion/test_models.py
@@ -1,7 +1,7 @@
 import random
 
 import pytest
-from allauth.account.adapter import AnonymousUser
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.gis.geos import Point
 from django.db import IntegrityError, transaction
 

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -682,6 +682,25 @@ class TestProConnectLoginWithRequiredMfa:
         response = client.post(verify_otp_url, data={"otp_token": otp})
         assertRedirects(response, dashboard_url)
 
+    def test_mfa_with_null_amr_claim(self, client, settings, pro_connect):
+        # ProConnect may return an explicit `null` for the `amr` claim, this
+        # must not crash (`"mfa" in None`) and should fall through to internal MFA
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = PrescriberFactory(
+            email=pro_connect.oidc_userinfo["email"],
+            membership=True,
+            has_completed_welcoming_tour=True,
+        )
+        settings.REQUIRE_MFA_ON_ORGANIZATION_IDS = {user.prescriberorganization_set.first().id}
+
+        response = pro_connect.mock_oauth_dance(
+            client,
+            expected_redirect_url=reverse("dashboard:index"),
+            id_token_data=ID_TOKEN_DATA | {"amr": None},
+        )
+        response = client.get(response.url)
+        assertRedirects(response, reverse("otp_views:enrollment_step_0_intro"))
+
 
 class TestProConnectLogout:
     def test_simple_logout(self, client, pro_connect):

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -1,10 +1,10 @@
 from django.utils import timezone
 
-from itou.otp.utils import _require_otp_for_pro, get_user_devices
+from itou.otp.utils import _require_otp_for_pro, get_user_devices, user_is_concerned_by_otp
 from tests.companies.factories import CompanyMembershipFactory
 from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
-from tests.users.factories import EmployerFactory, ItouStaffFactory, PrescriberFactory
+from tests.users.factories import EmployerFactory, ItouStaffFactory, JobSeekerFactory, PrescriberFactory
 
 
 def test_get_user_devices():
@@ -42,3 +42,39 @@ class TestRequireOtpForPro:
 
         settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
         assert _require_otp_for_pro(user)
+
+
+class TestUserIsConcernedByOtp:
+    def test_staff_depends_on_setting(self, settings):
+        user = ItouStaffFactory()
+
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        assert user_is_concerned_by_otp(user)
+
+    def test_professional_in_allowlisted_organization(self, settings):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = PrescriberFactory(membership=True)
+        org = user.prescriberorganization_set.get()
+
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_MFA_ON_ORGANIZATION_IDS = {org.id}
+        assert user_is_concerned_by_otp(user)
+
+    def test_professional_in_allowlisted_company(self, settings):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        company = user.company_set.get()
+
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
+        assert user_is_concerned_by_otp(user)
+
+    def test_job_seeker_is_never_concerned(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        settings.REQUIRE_MFA_FOR_PROS = True
+        assert not user_is_concerned_by_otp(JobSeekerFactory())

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -135,6 +135,13 @@ class TestRequireOtpForPro:
         settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
         assert _require_otp_for_pro(user)
 
+    def test_require_otp_if_user_has_already_enrolled(self, settings):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        assert not _require_otp_for_pro(user)
+        ItouTOTPDeviceFactory(user=user)
+        assert _require_otp_for_pro(user)
+
 
 class TestUserIsConcernedByOtp:
     def test_staff_depends_on_setting(self, settings):

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -1,5 +1,10 @@
+import datetime
+
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from django_otp.oath import TOTP
 
 from itou.otp.utils import (
     _require_otp_for_pro,
@@ -9,6 +14,7 @@ from itou.otp.utils import (
     user_can_manage_otp_devices,
     user_is_concerned_by_otp,
     user_uses_external_mfa,
+    verify_token_for_user,
 )
 from tests.companies.factories import CompanyMembershipFactory
 from tests.otp.factories import ItouTOTPDeviceFactory
@@ -25,6 +31,83 @@ def test_get_user_devices():
     ItouTOTPDeviceFactory(user=user2, disabled_at=None)
 
     assert get_user_devices(user1) == [deviceA, deviceB]
+
+
+class TestVerifyTokenForUser:
+    def test_matches_and_does_not_penalise_earlier_devices(self):
+        # `device_a` sorts before `device_b`, so it is tried (and fails) first
+        user = ItouStaffFactory()
+        device_a = ItouTOTPDeviceFactory(user=user, name="a")
+        device_b = ItouTOTPDeviceFactory(user=user, name="b")
+
+        matched = verify_token_for_user(user, TOTP(device_b.bin_key).token())
+
+        assert matched == device_b
+        device_a.refresh_from_db()
+        # The collateral increment from the failed try on `device_a` was rolled back
+        assert device_a.throttling_failure_count == 0
+
+    def test_preserves_prior_failures_on_earlier_devices(self):
+        user = ItouStaffFactory()
+        device_a = ItouTOTPDeviceFactory(user=user, name="a")
+        device_b = ItouTOTPDeviceFactory(user=user, name="b")
+        # `device_a` already has genuine prior failures, but the throttle window has
+        # elapsed (old timestamp), so `verify_token` will run and increment it again.
+        device_a.throttling_failure_count = 2
+        device_a.throttling_failure_timestamp = timezone.now() - datetime.timedelta(days=1)
+        device_a.save()
+
+        matched = verify_token_for_user(user, TOTP(device_b.bin_key).token())
+
+        assert matched == device_b
+        device_a.refresh_from_db()
+        assert device_a.throttling_failure_count == 2  # Restored to its prior count
+
+    def test_wrong_token_returns_none_and_throttles_every_device(self):
+        user = ItouStaffFactory()
+        device_a = ItouTOTPDeviceFactory(user=user, name="a")
+        device_b = ItouTOTPDeviceFactory(user=user, name="b")
+
+        assert verify_token_for_user(user, "000000") is None
+
+        for device in (device_a, device_b):
+            device.refresh_from_db()
+            assert device.throttling_failure_count == 1
+
+    def test_no_devices_returns_none(self):
+        user = ItouStaffFactory()
+        assert verify_token_for_user(user, "000000") is None
+
+    def test_verification_query_count_is_bounded(self, django_assert_num_queries):
+        """Guards against an N+1 in the rollback.
+
+        Matching the last of three devices runs a fixed set of queries, regardless of
+        how many earlier devices were tried:
+          2 SAVEPOINT + RELEASE SAVEPOINT  (the helper's transaction.atomic)
+          1 SELECT ... FOR UPDATE        (load + lock the user's devices)
+          2 UPDATEs                      (django_otp throttle_increment on devices a, b)
+          1 UPDATE                       (success: throttle_reset on device c)
+          1 UPDATE                       (single bulk_update rolling back a, b)
+        A per-device rollback would push this to 8.
+        """
+        user = ItouStaffFactory()
+        # `device_c` is the match, `device_a` and `device_b` are tried (and fail) first,
+        # so both get a collateral throttle increment that must be rolled back
+        ItouTOTPDeviceFactory(user=user, name="a")
+        ItouTOTPDeviceFactory(user=user, name="b")
+        device_c = ItouTOTPDeviceFactory(user=user, name="c")
+        token = TOTP(device_c.bin_key).token()
+
+        with django_assert_num_queries(7), CaptureQueriesContext(connection) as ctx:
+            assert verify_token_for_user(user, token) == device_c
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        # The user's devices are loaded once, under a row lock (race mitigation)
+        assert sum("FOR UPDATE" in sql for sql in sqls) == 1
+        # The two collateral increments are rolled back with one `bulk_update`
+        restore_updates = [
+            sql for sql in sqls if sql.startswith("UPDATE") and "throttling_failure_count" in sql and "WHEN" in sql
+        ]
+        assert len(restore_updates) == 1
 
 
 class TestRequireOtpForPro:

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -1,6 +1,15 @@
+import pytest
 from django.utils import timezone
 
-from itou.otp.utils import _require_otp_for_pro, get_user_devices, user_is_concerned_by_otp
+from itou.otp.utils import (
+    _require_otp_for_pro,
+    create_placeholder_for_external_totp_device,
+    get_user_devices,
+    user_can_enroll_otp_device,
+    user_can_manage_otp_devices,
+    user_is_concerned_by_otp,
+    user_uses_external_mfa,
+)
 from tests.companies.factories import CompanyMembershipFactory
 from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
@@ -78,3 +87,48 @@ class TestUserIsConcernedByOtp:
         settings.REQUIRE_OTP_FOR_STAFF = True
         settings.REQUIRE_MFA_FOR_PROS = True
         assert not user_is_concerned_by_otp(JobSeekerFactory())
+
+
+class TestUserCanUseOtp:
+    """`user_can_enroll_otp_device` and `user_can_manage_otp_devices` gate both the OTP
+    section and its menu link."""
+
+    def test_not_concerned_by_otp(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        user = ItouStaffFactory()
+        ItouTOTPDeviceFactory(user=user)
+
+        assert not user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)
+
+    def test_concerned_by_otp(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+
+        # Without a device, there is nothing to manage yet
+        assert user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)
+
+        ItouTOTPDeviceFactory(user=user)
+        assert user_can_manage_otp_devices(user)
+
+    def test_disabled_device_is_ignored(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        ItouTOTPDeviceFactory(user=user, disabled_at=timezone.now())
+
+        assert not user_can_manage_otp_devices(user)
+
+    @pytest.mark.parametrize("with_device", [True, False])
+    def test_mfa_handled_by_identity_provider(self, settings, with_device):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        if with_device:
+            ItouTOTPDeviceFactory(user=user)
+        # Mimic `OtpMiddleware` for a session verified through ProConnect
+        user.otp_device = create_placeholder_for_external_totp_device(user)
+
+        assert user_uses_external_mfa(user)
+        # It would only confuse the user and our support team
+        assert not user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -82,6 +82,7 @@ from tests.institutions.factories import (
     InstitutionMembershipFactory,
 )
 from tests.job_applications.factories import JobApplicationFactory
+from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationFactory
 from tests.users.factories import (
     EmployerFactory,
@@ -1631,7 +1632,7 @@ def test_geiq_eligibility_badge(snapshot, is_eligible, for_job_seeker):
     assert badges.geiq_eligibility_badge(is_eligible=is_eligible, for_job_seeker=for_job_seeker) == snapshot
 
 
-def test_active_announcement_campaign_context_processor(client, empty_active_announcements_cache):
+def test_active_announcement_campaign_context_processor(client, settings, empty_active_announcements_cache):
     AnnouncementCampaignFactory(with_item=True, start_date=date.today().replace(day=1), live=True)
 
     response = client.get(reverse("search:employers_results"))
@@ -1643,7 +1644,12 @@ def test_active_announcement_campaign_context_processor(client, empty_active_ann
     assert response.status_code == 200
     assert response.context["display_campaign_announce"] is True
 
-    client.force_login(ItouStaffFactory())
+    # The OTP verification page is only reachable by a user who must use our own 2FA
+    settings.REQUIRE_OTP_FOR_STAFF = True
+    staff_user = ItouStaffFactory()
+    ItouTOTPDeviceFactory(user=staff_user)
+    client.force_login(staff_user)
+
     response = client.get(reverse("otp_views:verify_otp") + "?next=%2Fadmin%2F")
     assert response.status_code == 200
     assert response.context["display_campaign_announce"] is False

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -3,8 +3,8 @@ from functools import partial
 from unittest.mock import patch
 
 import pytest
-from allauth.account.adapter import AnonymousUser
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 from itoutils.django.decoupage_administratif.models import Department, Region
 from itoutils.django.testing import assertSnapshotQueries

--- a/tests/www/otp_views/__snapshots__/tests.ambr
+++ b/tests/www/otp_views/__snapshots__/tests.ambr
@@ -44,7 +44,7 @@
                   <label class="form-label" for="id_otp_token">
                       Entrez le code de validation unique (OTP)
                   </label>
-                  <input aria-describedby="id_otp_token_helptext" autocomplete="one-time-code" autofocus="" class="form-control" id="id_otp_token" max_length="6" name="otp_token" required="" type="text"/>
+                  <input aria-describedby="id_otp_token_helptext" autocomplete="one-time-code" autofocus="" class="form-control" id="id_otp_token" maxlength="6" name="otp_token" required="" type="text"/>
                   <div class="form-text" id="id_otp_token_helptext">
                       Code à 6 chiffres généré par votre application mobile ou votre gestionnaire de mot de passe sur votre ordinateur
                   </div>

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -62,6 +62,42 @@ def test_permissions(client, factory, expected_status):
     assert response.status_code == expected_status
 
 
+class TestConfigurationOtpMenuLink:
+    """The "Configuration OTP" item in the "Mon espace" dropdown is shown to every user
+    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff."""
+
+    OTP_CONFIG_MARKUP = ">Configuration OTP</a>"
+
+    def _get_dashboard(self, client, user, verified=False):
+        client.force_login(user)
+        if verified:
+            # Mark the session verified so the OTP middleware does not redirect a concerned
+            # user to enrollment: the menu link must still show for a verified concerned user.
+            attach_device_to_user_session(client, ItouTOTPDeviceFactory(user=user))
+        return client.get(reverse("dashboard:index"), follow=True)
+
+    def test_hidden_for_job_seeker(self, client):
+        response = self._get_dashboard(client, JobSeekerFactory(with_address=True))
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    @pytest.mark.parametrize("is_concerned", [True, False])
+    def test_professional_depends_on_allowlist(self, client, settings, is_concerned):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        if is_concerned:
+            settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        response = self._get_dashboard(client, user, verified=is_concerned)
+        if is_concerned:
+            assertContains(response, self.OTP_CONFIG_MARKUP)
+        else:
+            assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    def test_visible_for_staff(self, client, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        response = self._get_dashboard(client, ItouStaffFactory(), verified=True)
+        assertContains(response, self.OTP_CONFIG_MARKUP)
+
+
 @freeze_time("2025-03-11 05:18:56")
 def test_device_list(client, snapshot):
     user = ItouStaffFactory()

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -268,12 +268,36 @@ def test_delete_devices(client, snapshot, settings):
             ],
         )
 
-        # The user removes his other device
+        # The user removes his other device: it is soft-deleted (temporary kept for auditing)
         response = client.post(url, data={"delete-device": str(device_2.pk)})
-        assertQuerySetEqual(ItouTOTPDevice.objects.all(), [device_1])
+        assertQuerySetEqual(ItouTOTPDevice.objects.all(), [device_1, device_2], ordered=False)
+        assertQuerySetEqual(ItouTOTPDevice.objects.filter(disabled_at=None), [device_1])
+        device_2.refresh_from_db()
+        assert device_2.disabled_at is not None
         assertContains(response, device_1.name)
         assertNotContains(response, device_2.name)
         assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
+
+
+def test_delete_last_device_when_verified_by_external_mfa(client, settings):
+    # A user verified through the ProConnect MFA sidestep has an `ExternalTOTPDevice` placeholder
+    # as `otp_device`. It never matches a real device, so they may delete all their internal
+    # devices (no lockout: they will be asked to enroll again if internal MFA becomes required).
+    settings.REQUIRE_OTP_FOR_STAFF = True
+    user = ItouStaffFactory()
+    device = ItouTOTPDeviceFactory(user=user, name="only-device")
+    client.force_login(user)
+
+    placeholder = create_placeholder_for_external_totp_device(user)
+    session = client.session
+    session[DEVICE_ID_SESSION_KEY] = placeholder.persistent_id
+    session.save()
+
+    response = client.post(reverse("otp_views:otp_devices"), data={"delete-device": str(device.pk)})
+
+    assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
+    device.refresh_from_db()
+    assert device.disabled_at is not None
 
 
 def test_otp_enforced_before_nexus_whitelist(client, settings):
@@ -593,6 +617,34 @@ class TestItouStaffLogin:
         assert device.disabled_at is not None
         [email] = mailoutbox
         assert "Utilisation d'un code de récupération" in email.subject
+
+    def test_login_with_backup_code_preserves_existing_disabled_at(self, client, settings):
+        # Logging in with a backup code soft-deletes the user's *active* TOTP
+        # devices, but must not overwrite the `disabled_at` of devices that were
+        # already disabled earlier (see `purge_disabled_otp_devices`)
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+
+        with freeze_time("2025-01-01") as frozen_time:
+            old_disabled_device = ItouTOTPDeviceFactory(user=user, name="old")
+            old_disabled_device.disabled_at = timezone.now()
+            old_disabled_device.save()
+            already_disabled_at = old_disabled_device.disabled_at
+
+            frozen_time.move_to("2026-07-09")
+            active_device = ItouTOTPDeviceFactory(user=user, name="active")
+            backup_code = create_otp_backup_code(user)
+
+            client.force_login(user)
+            response = client.post(reverse("otp_views:login_with_backup_code"), data={"code": backup_code})
+            assertRedirects(response, reverse("otp_views:enrollment_step_0_intro") + "?after_recovery=1")
+
+        active_device.refresh_from_db()
+        old_disabled_device.refresh_from_db()
+        # The active device is soft-deleted at login time
+        assert active_device.disabled_at == datetime.datetime(2026, 7, 9, tzinfo=datetime.UTC)
+        # The already-disabled device keeps its original timestamp
+        assert old_disabled_device.disabled_at == already_disabled_at
 
     def test_login_otp_not_required(self, client):
         user = ItouStaffFactory(with_verified_email=True, is_superuser=True)

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -276,6 +276,18 @@ def test_delete_devices(client, snapshot, settings):
         assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
 
 
+def test_otp_enforced_before_nexus_whitelist(client, settings):
+    """An MFA-required professional must not reach the whitelisted Nexus views (/portal, ...) without OTP."""
+    settings.REQUIRE_MFA_FOR_PROS = True
+    user = EmployerFactory(membership=True)
+    company = user.company_set.get()
+    settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
+    client.force_login(user)
+
+    response = client.get(reverse("nexus:homepage"))
+    assertRedirects(response, reverse("otp_views:enrollment_step_0_intro"), fetch_redirect_response=False)
+
+
 def test_enrollment_step_0_intro(client, settings):
     settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -360,6 +360,30 @@ class TestEnrollmentSteps2And3ConfirmDevice:
         backup_token = ItouStaticToken.objects.get()
         assert backup_token.check_token("secret-backup-code")
 
+    def test_unverified_user_with_device_cannot_enroll_another(self, client):
+        # Security regression (2FA bypass): a user who knows the password (first factor) but has
+        # NOT passed 2FA must not be able to enroll a brand-new device and be silently verified by
+        # `otp_login()`. The OTP middleware redirects them to `verify_otp` before the view runs.
+        user = ItouStaffFactory()
+        existing_device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)  # authenticated but NOT OTP-verified: no device attached to session
+
+        url = reverse("otp_views:enrollment_step_2_and_3_confirm_device")
+        fake_device = ItouTOTPDevice(key="8fe0a9983c7dddb4acb0146c5507553371e9f211")
+        data = {
+            "name": "attacker device",
+            "device_type": "smartphone",
+            "key": "R7QKTGB4PXO3JLFQCRWFKB2VGNY6T4QR",
+            "otp_token": TOTP(fake_device.bin_key).token(),
+        }
+        response = client.post(url, data)
+
+        # Redirected to verification instead of enrolling the new device...
+        assertRedirects(response, add_url_params(reverse("otp_views:verify_otp"), {"next": url}))
+        # ...no new device was created and the session is still unverified.
+        assert user.itou_totp_devices.exclude(pk=existing_device.pk).count() == 0
+        assert DEVICE_ID_SESSION_KEY not in client.session
+
     def test_post_invalid_totp(self, client):
         user = ItouStaffFactory()
         client.force_login(user)

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from functools import partial
 from unittest import mock
 
@@ -531,6 +532,39 @@ class TestItouStaffLogin:
         device.save()
         response = client.post(next_url, data=post_data)
         assertRedirects(response, admin_url)
+
+    def test_verify_with_wrong_token_throttles_every_device(self, client, settings, caplog):
+        # `VerifyOTPForm` tries every enrolled device, so a single wrong code counts against each of them
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory(with_verified_email=True)
+        device_1 = ItouTOTPDeviceFactory(name="1", user=user)
+        device_2 = ItouTOTPDeviceFactory(name="2", user=user)
+        client.force_login(user)
+        verify_otp_url = reverse("otp_views:verify_otp")
+
+        with caplog.at_level(logging.INFO):
+            response = client.post(verify_otp_url, data={"otp_token": "000000"})
+        assert response.context["form"].errors == {
+            "otp_token": ["Le code de validation unique (OTP) n’est pas correct."]
+        }
+        assert f"User {user.id} failed 2FA verification" in caplog.messages
+        for device in (device_1, device_2):
+            device.refresh_from_db()
+            assert device.throttling_failure_count == 1
+
+    def test_verify_with_valid_token_logs_success(self, client, settings, caplog):
+        # Throttle-rollback behaviour is tested in tests/otp/test_utils.py, here we
+        # cover the view wiring: a valid code verifies the user and logs the success
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory(with_verified_email=True)
+        device = ItouTOTPDeviceFactory(name="1", user=user)
+        client.force_login(user)
+        verify_otp_url = reverse("otp_views:verify_otp")
+
+        with caplog.at_level(logging.INFO):
+            response = client.post(verify_otp_url, data={"otp_token": TOTP(device.bin_key).token()})
+        assert response.status_code == 302
+        assert f"User {user.id} authenticated with 2FA" in caplog.messages
 
     def test_login_with_backup_code(self, client, settings, mailoutbox):
         settings.REQUIRE_OTP_FOR_STAFF = True

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -19,7 +19,7 @@ from pytest_django.asserts import (
 )
 
 from itou.otp.models import ItouStaticDevice, ItouStaticToken, ItouTOTPDevice
-from itou.otp.utils import create_otp_backup_code
+from itou.otp.utils import create_otp_backup_code, create_placeholder_for_external_totp_device
 from itou.www.login.constants import ITOU_SESSION_LOGIN_EMAIL_KEY
 from itou.www.otp_views.forms import ConfirmTOTPDeviceForm
 from tests.otp.factories import ItouTOTPDeviceFactory
@@ -42,31 +42,106 @@ def attach_device_to_user_session(client, device):
     session.save()
 
 
-@pytest.mark.parametrize(
-    "factory,expected_status",
-    [
-        (JobSeekerFactory, 403),
-        (partial(EmployerFactory, membership=True), 200),
-        (partial(PrescriberFactory, membership=True), 200),
-        (partial(LaborInspectorFactory, membership=True), 200),
-        (ItouStaffFactory, 200),
-    ],
-)
-def test_permissions(client, factory, expected_status):
-    user = factory()
-    client.force_login(user)
-    response = client.get(reverse("otp_views:otp_devices"))
-    assert response.status_code == expected_status
+def attach_external_device_to_user_session(client, user):
+    # Mimic a ProConnect login through an identity provider that already implements MFA.
+    session = client.session
+    session[DEVICE_ID_SESSION_KEY] = create_placeholder_for_external_totp_device(user).persistent_id
+    session.save()
 
-    response = client.get(reverse("otp_views:enrollment_step_1_choose_device_type"))
-    assert response.status_code == expected_status
+
+OTP_URL_NAMES = [
+    "otp_devices",
+    "enrollment_step_0_intro",
+    "enrollment_step_1_choose_device_type",
+    "enrollment_step_2_and_3_confirm_device",
+    "verify_otp",
+    "login_with_backup_code",
+]
+ENROLLMENT_URL_NAMES = [
+    "enrollment_step_0_intro",
+    "enrollment_step_1_choose_device_type",
+]
+
+
+class TestPermissions:
+    """Pages of the OTP section are hidden (404) from users for whom our own 2FA is not
+    required: job seekers, users of an organization that is not in the allowlist, and users
+    whose identity provider already handled MFA for this session."""
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            JobSeekerFactory,
+            partial(EmployerFactory, membership=True),
+            partial(PrescriberFactory, membership=True),
+            partial(LaborInspectorFactory, membership=True),
+            ItouStaffFactory,
+        ],
+    )
+    def test_hidden_when_otp_is_not_required(self, client, factory, url_name, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        settings.REQUIRE_MFA_FOR_PROS = False
+        client.force_login(factory())
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_visible_for_a_concerned_user_with_a_device(self, client, settings, url_name):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        client.force_login(user)
+        attach_device_to_user_session(client, ItouTOTPDeviceFactory(user=user))
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        if url_name == "enrollment_step_2_and_3_confirm_device":
+            # without a `device_type` query param it redirects to step-1
+            assert response.status_code == 302
+        else:
+            assert response.status_code == 200
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_hidden_without_a_device_but_for_enrollment(self, client, settings, url_name):
+        # A concerned user without any enabled device is sent to enrollment by the middleware:
+        # the other pages have nothing to show
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)
+        attach_device_to_user_session(client, device)  # avoid the middleware redirection
+        device.disabled_at = timezone.now()
+        device.save(update_fields=["disabled_at"])
+
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        if url_name == "enrollment_step_2_and_3_confirm_device":
+            # without a `device_type` query param it redirects to step-1
+            assert response.status_code == 302
+        elif url_name in ENROLLMENT_URL_NAMES:
+            assert response.status_code == 200
+        else:
+            assert response.status_code == 404
+
+    @pytest.mark.parametrize("with_device", [True, False])
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_hidden_when_mfa_comes_from_identity_provider(self, client, settings, url_name, with_device):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        if with_device:
+            ItouTOTPDeviceFactory(user=user)  # shouldn't happen anyway
+        client.force_login(user)
+        attach_external_device_to_user_session(client, user)
+
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        assert response.status_code == 404
 
 
 class TestConfigurationOtpMenuLink:
-    """The "Configuration OTP" item in the "Mon espace" dropdown is shown to every user
-    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff."""
+    """The "Configuration 2FA" item in the "Mon espace" dropdown is shown to every user
+    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff, provided they enrolled
+    at least one device of ours (users whose identity provider handles MFA have nothing to
+    configure here)."""
 
-    OTP_CONFIG_MARKUP = ">Configuration OTP</a>"
+    OTP_CONFIG_MARKUP = ">Configuration 2FA</a>"
 
     def _get_dashboard(self, client, user, verified=False):
         client.force_login(user)
@@ -97,9 +172,34 @@ class TestConfigurationOtpMenuLink:
         response = self._get_dashboard(client, ItouStaffFactory(), verified=True)
         assertContains(response, self.OTP_CONFIG_MARKUP)
 
+    def test_hidden_when_mfa_comes_from_identity_provider(self, client, settings):
+        # The user is concerned by 2FA but was verified by ProConnect: they never enroll
+        # a TOTP device on our side, so there is nothing to configure
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        client.force_login(user)
+        attach_external_device_to_user_session(client, user)
+        response = client.get(reverse("dashboard:index"), follow=True)
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    def test_hidden_when_only_device_is_disabled(self, client, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)
+        attach_device_to_user_session(client, device)
+        device.disabled_at = timezone.now()
+        device.save(update_fields=["disabled_at"])
+        response = client.get(reverse("dashboard:index"), follow=True)
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+        # anyway, the user is redirected to enrollment by the middleware,
+        # they cannot reach the dashboard with a disabled device
+
 
 @freeze_time("2025-03-11 05:18:56")
-def test_device_list(client, snapshot):
+def test_device_list(client, snapshot, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
     device = ItouTOTPDeviceFactory(user=user, name="Mon appareil")
 
@@ -176,7 +276,8 @@ def test_delete_devices(client, snapshot, settings):
         assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
 
 
-def test_enrollment_step_0_intro(client):
+def test_enrollment_step_0_intro(client, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
 
     client.force_login(user)
@@ -185,7 +286,8 @@ def test_enrollment_step_0_intro(client):
     assertContains(response, "Nous vous guidons étape par étape")
 
 
-def test_enrollment_step_1_choose_device_type(client):
+def test_enrollment_step_1_choose_device_type(client, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
 
     client.force_login(user)
@@ -195,6 +297,11 @@ def test_enrollment_step_1_choose_device_type(client):
 
 
 class TestEnrollmentSteps2And3ConfirmDevice:
+    @pytest.fixture(autouse=True)
+    def require_otp_for_staff(self, settings):
+        # Enrollment pages are only reachable when our own 2FA applies to the user
+        settings.REQUIRE_OTP_FOR_STAFF = True
+
     @pytest.mark.parametrize(
         "device_type,should_show_qr_code",
         (
@@ -280,6 +387,8 @@ class TestEnrollmentSteps2And3ConfirmDevice:
             name="existing",
             user=user,
         )
+        # The user already enrolled a device: they must be verified to add another one.
+        attach_device_to_user_session(client, existing_user_device)
         new_devices = user.itou_totp_devices.exclude(pk=existing_user_device.pk)
         fake_device = ItouTOTPDevice(key="8fe0a9983c7dddb4acb0146c5507553371e9f211")
 

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -279,27 +279,6 @@ def test_delete_devices(client, snapshot, settings):
         assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
 
 
-def test_delete_last_device_when_verified_by_external_mfa(client, settings):
-    # A user verified through the ProConnect MFA sidestep has an `ExternalTOTPDevice` placeholder
-    # as `otp_device`. It never matches a real device, so they may delete all their internal
-    # devices (no lockout: they will be asked to enroll again if internal MFA becomes required).
-    settings.REQUIRE_OTP_FOR_STAFF = True
-    user = ItouStaffFactory()
-    device = ItouTOTPDeviceFactory(user=user, name="only-device")
-    client.force_login(user)
-
-    placeholder = create_placeholder_for_external_totp_device(user)
-    session = client.session
-    session[DEVICE_ID_SESSION_KEY] = placeholder.persistent_id
-    session.save()
-
-    response = client.post(reverse("otp_views:otp_devices"), data={"delete-device": str(device.pk)})
-
-    assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
-    device.refresh_from_db()
-    assert device.disabled_at is not None
-
-
 def test_otp_enforced_before_nexus_whitelist(client, settings):
     """An MFA-required professional must not reach the whitelisted Nexus views (/portal, ...) without OTP."""
     settings.REQUIRE_MFA_FOR_PROS = True
@@ -358,14 +337,6 @@ class TestEnrollmentSteps2And3ConfirmDevice:
             assertContains(response, qr_code_text)
         else:
             assertNotContains(response, qr_code_text)
-
-    def test_get_unknown_device_type(self, client):
-        user = ItouStaffFactory()
-        client.force_login(user)
-        url = reverse("otp_views:enrollment_step_2_and_3_confirm_device")
-
-        response = client.get(url, query_params={"device_type": "unknown"})
-        assertRedirects(response, reverse("otp_views:enrollment_step_1_choose_device_type"))
 
     def test_post_valid_totp(self, client):
         user = ItouStaffFactory()
@@ -473,6 +444,20 @@ class TestEnrollmentSteps2And3ConfirmDevice:
         device = new_devices.get()
         assert device.key == fake_device.key
         assert device.name == data["name"]
+
+    @pytest.mark.parametrize("key", ["", "not-base32!", None])
+    def test_post_invalid_key_redirects(self, client, key):
+        user = ItouStaffFactory()
+        client.force_login(user)
+        url = reverse("otp_views:enrollment_step_2_and_3_confirm_device")
+
+        data = {"name": "whatever", "device_type": "smartphone", "otp_token": "123456"}
+        if key is not None:
+            data["key"] = key
+        response = client.post(url, data)
+
+        assertRedirects(response, reverse("otp_views:enrollment_step_1_choose_device_type"))
+        assert user.itou_totp_devices.count() == 0
 
 
 class TestItouStaffLogin:


### PR DESCRIPTION
Pull request pour la recette des modifications relatives au "2FA interne Emplois" pour les professionnels. Certains commits (préfixés par `___ wip: DO NOT MERGE`) ne DEVRONT PAS être mergés, ils ne servent qu'à configurer la recette jetable.

---

Recette jetable (configuré pour se connecter à la sandbox ProConnect) : https://les-emplois-recette-pro-connect.cleverapps.io

On a activé le MFA pour : 
- l'ETTI Nouvelle chance
- France Travail - Arles

Cas de test :

1. Utilisateur avec MFA externe : [pdi-pro-1@yopmail.com](mailto:pdi-prescripteur-1@yopmail.com) [*] (mot de passe et secret TOTP sur ProConnect : [ici](https://vault.bitwarden.com/#/vault?search=tempor&itemId=dace7e55-db4c-43fa-b880-b47800ec08ab&action=view)) : Les Emplois détecte le MFA externe et permet la navigation.
2. Utilisateur sans MFA externe : modale "Changer de compte" puis sélectionner "ETTI" ou "Prescripteur" (les 2 sont liés à des organisation/entreprise sélectionnées pour requérir le MFA) : Les Emplois demande d'enrôler un matériel TOTP avant de permettre la navigation.
3. Utilisateur dont le fournisseur d'identité implémente le MFA, sans le mentionner à ProConnect : [prenom.nom@pole-emploi.fr](mailto:prenom.nom@pole-emploi.fr) (cf. [ici dans Bitwarden](https://vault.bitwarden.com/#/vault?search=test&itemId=b6c3dbaa-6364-4453-a7a4-afb20106bea8&action=view) pour le mot de passe) : une fois allowlisté (cf. 2ee339d4d66a789f50cf0ddcacd783953fdcada3 sur le dépôt des secrets), Les Emplois détecte le MFA externe et permet la navigation.
4. Utilisateur qui n'est pas lié à une organisation pour laquelle on requiert le 2FA : modale "Changer de compte" puis sélectionner "EI".

[*] Il est probable que la [sandbox ProConnect](https://identite-sandbox.proconnect.gouv.fr/) soit réinitialisée régulièrement. Si le compte ProConnect n'existe plus, il suffit de le recréer.