### PR TITLE
GEIQ : Préciser que motif le commentaire de refus ne sont pas transmis au GEIQ

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -72,6 +72,15 @@
                 </div>
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                     <h2>{{ active_tab.label }}</h2>
+                    {% if request.from_institution and active_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
+                        {% component_alert content=refusal_confidentiality_notice variant="info" icon=False extra_classes="mb-3 mb-md-4" %}
+                            {% fragment as refusal_confidentiality_notice %}
+                                <p class="mb-0">
+                                    Le motif et le commentaire de refus sont réservés à la DDETS/DREETS et ne sont pas transmis au GEIQ.
+                                </p>
+                            {% endfragment %}
+                        {% endcomponent_alert %}
+                    {% endif %}
                     {% if active_tab == AssessmentContractDetailsTab.EMPLOYEE %}
                         <div class="c-box mb-3 mb-md-4">
                             <ul class="list-data">

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -1215,6 +1215,10 @@ class TestAssessmentContractsDetails:
         ) == snapshot(name="contract detail side box with refused allowance, missing reason, common tab")
 
         response = client.get(details_justification_url)
+        assertContains(
+            response,
+            "Le motif et le commentaire de refus sont réservés à la DDETS/DREETS et ne sont pas transmis au GEIQ.",
+        )
         assert pretty_indented(
             parse_response_to_soup(response, selector="div.s-section__row > div.s-section__col.order-1 > div.c-box")
         ) == snapshot(name="contract detail side box with refused allowance, missing reason, justification tab")


### PR DESCRIPTION

## :thinking: Pourquoi ?

[WORDING à modifier pour indiquer à la DDETS/DREETS que le motif et le commentaire de refus ne sont pas partagés](https://app.notion.com/p/gip-inclusion/URGENT-WORDING-modifier-pour-indiquer-la-DDETS-DREETS-que-le-motif-et-le-commentaire-de-refus-ne-3905f321b604803ca256da2baba71b90)

## :cake: Comment ? <!-- optionnel -->

Ajouter un encart de texte pour clarifier/insister sur le fait que les commentaires ne seront pas transmis au CEIQ (et que donc ça ne sert à rien de rentrer des messages en pensant s'adresser aux GIEQ).

À l'origine on voulait changer l'enum mais ça aurait changé le titre des onglets du composant.
