### PR TITLE
GEIQ: Modifier le titre du template d’impression de la page de décision

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_print.html
+++ b/itou/templates/geiq_assessments_views/assessment_print.html
@@ -1,7 +1,7 @@
 {% extends "layout/base_printable.html" %}
 {% load format_filters %}
 
-{% block title %}Décision - {{ assessment.label_geiq_name }} {{ block.super }}{% endblock %}
+{% block title %}Contrôle de service fait - {{ assessment.label_geiq_name }} {{ block.super }}{% endblock %}
 
 {% block content %}
     <div class="container py-4 px-5">
@@ -15,7 +15,7 @@
             </div>
         </div>
 
-        <h1 class="mt-5">Décision - {{ assessment.label_geiq_name }}</h1>
+        <h1 class="mt-5">Contrôle de service fait - {{ assessment.label_geiq_name }}</h1>
 
         <section class="mt-5">
             <h2>Structures concernées par la convention</h2>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -2706,7 +2706,7 @@
               </div>
           </div>
           <h1 class="mt-5">
-              Décision -
+              Contrôle de service fait -
           </h1>
           <section class="mt-5">
               <h2>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Boost https://app.notion.com/p/gip-inclusion/Modifier-le-titre-du-template-d-impression-de-la-page-de-d-cision-bilan-geiq-3965f321b604809b9878f9d89ffd8f8d
