### PR TITLE
Inscription : Corriger le lien vers la base SIRENE dans l’aide du champ siret

### DIFF
--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -49,7 +49,7 @@ def get_access_token():
 def etablissement_get_or_error(siret):
     """
     Return a tuple (etablissement, error) where error is None on success.
-    https://www.sirene.fr/static-resources/htm/siret_unitaire_variables_reponse.html
+    https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f/doc
     """
 
     access_token = get_access_token()

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -241,7 +241,8 @@ class CheckAlreadyExistsForm(forms.Form):
         help_text=mark_safe(
             "Le numéro SIRET contient <b>14 chiffres</b>. "
             "Retrouvez facilement votre numéro SIRET à partir du nom de votre organisation sur le site "
-            '<a href="https://sirene.fr/" rel="noopener" target="_blank" class="has-external-link">sirene.fr</a>'
+            '<a href="https://annuaire-entreprises.data.gouv.fr/" rel="noopener" '
+            'target="_blank" class="has-external-link">annuaire-entreprises.data.gouv.fr</a>'
         ),
     )
     department = forms.ChoiceField(


### PR DESCRIPTION


## :thinking: Pourquoi ?
Reprise de https://github.com/gip-inclusion/les-emplois/pull/8374 d'Arnaud (qui a pas les droits sur le repo, et dont la CI ne peux s'exécuter correctement sur son fork).

> Correction du lien URL vers la base SIREN (le lien actuel ne marche pas, et utilise un site privé plutôt que celui de l'État).
