### PR TITLE
Insertion: corrections à l'affichage des horaires et pré-requis des services

### DIFF
--- a/itou/insertion/opening_hours.py
+++ b/itou/insertion/opening_hours.py
@@ -6,10 +6,26 @@ DAYS = {"Mo": 0, "Tu": 1, "We": 2, "Th": 3, "Fr": 4, "Sa": 5, "Su": 6}
 
 DAY_NAMES_LONG = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"]
 
+MONTHS_FR = {
+    "Jan": "janvier",
+    "Feb": "février",
+    "Mar": "mars",
+    "Apr": "avril",
+    "May": "mai",
+    "Jun": "juin",
+    "Jul": "juillet",
+    "Aug": "août",
+    "Sep": "septembre",
+    "Oct": "octobre",
+    "Nov": "novembre",
+    "Dec": "décembre",
+}
+
 
 class DaySchedule(TypedDict):
     times: list[str]
     comment: str | None
+    open_all_day: bool
 
 
 class OpeningHoursEntry(TypedDict):
@@ -21,6 +37,42 @@ class OpeningHoursEntry(TypedDict):
 class FormattedOpeningHours(TypedDict):
     entries: list[OpeningHoursEntry]
     has_ph_off: bool
+    comments: list[str]
+
+
+def _format_day(day: str) -> str:
+    return "1er" if day == "1" else day
+
+
+def _translate_month_off(selector: str) -> str | None:
+    try:
+        # Cross-month date range: "Dec 25-Jan 1"
+        m = re.match(r"^([A-Z][a-z]{2}) (\d{1,2})-([A-Z][a-z]{2}) (\d{1,2})$", selector)
+        if m:
+            m1, d1, m2, d2 = m.groups()
+            return f"Fermé du {_format_day(d1)} {MONTHS_FR[m1]} au {_format_day(d2)} {MONTHS_FR[m2]}"
+
+        # Same-month date range: "Dec 20-31"
+        m = re.match(r"^([A-Z][a-z]{2}) (\d{1,2})-(\d{1,2})$", selector)
+        if m:
+            month, d1, d2 = m.groups()
+            return f"Fermé du {_format_day(d1)} au {_format_day(d2)} {MONTHS_FR[month]}"
+
+        # Single day: "Dec 25"
+        m = re.match(r"^([A-Z][a-z]{2}) (\d{1,2})$", selector)
+        if m:
+            month, day = m.groups()
+            return f"Fermé le {_format_day(day)} {MONTHS_FR[month]}"
+
+        if "-" in selector:
+            start, end = selector.split("-")
+            return f"Fermé de {MONTHS_FR[start]} à {MONTHS_FR[end]}"
+        if "," in selector:
+            names = [MONTHS_FR[m] for m in selector.split(",")]
+            return "Fermé en " + ", ".join(names)
+        return f"Fermé en {MONTHS_FR[selector]}"
+    except KeyError:
+        return None
 
 
 def _expand_day_selector(selector: str) -> list[int]:
@@ -44,9 +96,13 @@ def _format_time_range(time_range: str) -> str:
     return f"{_format_time(start)} à {_format_time(end)}"
 
 
-def parse_osm_hours(value: str) -> tuple[dict[int, DaySchedule], bool]:
+def parse_osm_hours(value: str) -> tuple[dict[int, DaySchedule], bool, list[str]]:
     schedule: dict[int, DaySchedule] = {}
     has_ph_off = False
+    comments: list[str] = []
+
+    value = re.sub(r"\bclosed\b", "off", value)
+    value = re.sub(r"(open|off)\s*,", r"\1;", value)
 
     for rule in value.split(";"):
         rule = rule.strip()
@@ -64,6 +120,11 @@ def parse_osm_hours(value: str) -> tuple[dict[int, DaySchedule], bool]:
         parts = rule.split()
 
         if not parts or parts[0].split(",")[0].split("-")[0] not in DAYS:
+            if parts and parts[-1] == "off":
+                selector = " ".join(parts[:-1])
+                translated = _translate_month_off(selector)
+                if translated:
+                    comments.append(translated)
             continue
 
         if "off" in parts:
@@ -75,32 +136,39 @@ def parse_osm_hours(value: str) -> tuple[dict[int, DaySchedule], bool]:
                 if re.match(r"\d{2}:\d{2}-\d{2}:\d{2}$", tr):
                     time_ranges.append(tr)
 
-        if not time_ranges:
+        open_all_day = not time_ranges and "open" in parts
+        if not time_ranges and not open_all_day:
             continue
 
         for day in _expand_day_selector(parts[0]):
             if day not in schedule:
-                schedule[day] = {"times": [], "comment": comment}
+                schedule[day] = {"times": [], "comment": comment, "open_all_day": False}
             schedule[day]["times"].extend(time_ranges)
+            if open_all_day:
+                schedule[day]["open_all_day"] = True
 
-    return schedule, has_ph_off
+    return schedule, has_ph_off, comments
 
 
 def format_osm_hours(value: str) -> FormattedOpeningHours | None:
     if not value:
         return None
     try:
-        schedule, has_ph_off = parse_osm_hours(value)
+        schedule, has_ph_off, comments = parse_osm_hours(value)
         if not schedule:
             return None
         entries: list[OpeningHoursEntry] = [
             {
                 "label": DAY_NAMES_LONG[day_idx],
-                "hours": " - ".join(_format_time_range(tr) for tr in sorted(schedule[day_idx]["times"])),
+                "hours": (
+                    "ouvert"
+                    if schedule[day_idx]["open_all_day"] and not schedule[day_idx]["times"]
+                    else " - ".join(_format_time_range(tr) for tr in sorted(schedule[day_idx]["times"]))
+                ),
                 "comment": schedule[day_idx]["comment"],
             }
             for day_idx in sorted(schedule.keys())
         ]
-        return {"entries": entries, "has_ph_off": has_ph_off}
+        return {"entries": entries, "has_ph_off": has_ph_off, "comments": comments}
     except (KeyError, ValueError):
         return None

--- a/itou/templates/insertion/includes/orientation_credentials_list.html
+++ b/itou/templates/insertion/includes/orientation_credentials_list.html
@@ -1,3 +1,5 @@
+{% load markdownify %}
+
 {% if service.has_prerequisites %}
     {% if show_section_heading|default:False %}
         {% if show_heading == False %}
@@ -10,6 +12,6 @@
         <p>(A récupérer auprès de l'usager)</p>
     {% endif %}
     <ul class="{% if show_section_heading|default:False or show_recovery_note|default:False %}mb-3 mb-md-4{% endif %}">
-        {% for prerequisite in service.prerequisites %}<li>{{ prerequisite }}</li>{% endfor %}
+        {% for prerequisite in service.prerequisites %}<li>{{ prerequisite|markdownify }}</li>{% endfor %}
     </ul>
 {% endif %}

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -210,6 +210,13 @@
                                                     </strong>
                                                 </div>
                                             {% endfor %}
+                                            {% if formatted_opening_hours.comments %}
+                                                <div class="mt-2">
+                                                    {% for comment in formatted_opening_hours.comments %}
+                                                        <div class="d-flex"><span class="fst-italic">{{ comment }}.</span></div>
+                                                    {% endfor %}
+                                                </div>
+                                            {% endif %}
                                         </div>
                                     {% else %}
                                         {{ service.opening_hours }}
@@ -324,11 +331,11 @@
                                 {% endif %}
                             {% else %}
                                 <ul class="mb-0">
-                                    {% for mobilization in service.mobilizations.all %}<li>{{ mobilization.label }}</li>{% endfor %}
+                                    {% for mobilization in service.mobilizations.all %}
+                                        <li>{{ mobilization.label }}</li>
+                                    {% endfor %}
                                 </ul>
-                                {% if service.mobilizations_details %}
-                                    <p class="mt-3 mb-0">{{ service.mobilizations_details }}</p>
-                                {% endif %}
+                                {% if service.mobilizations_details %}<p class="mt-3 mb-0">{{ service.mobilizations_details }}</p>{% endif %}
                             {% endif %}
                         </div>
                     {% endif %}

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load enums %}
 {% load format_filters %}
+{% load markdownify %}
 {% load matomo %}
 {% load str_filters %}
 {% load url_add_query %}
@@ -245,7 +246,6 @@
                     {% if service.description %}
                         <div class="c-box mb-3 mb-md-4">
                             <h2 class="h3">Description du service</h2>
-                            {% load markdownify %}
                             {% if service.description|wordcount > 30 %}
                                 <div class="collapse show has-no-transition" id="collapse-description">
                                     <div class="mb-0">{{ service.description|markdownify|truncatewords_html:30 }}</div>
@@ -324,9 +324,7 @@
                                 {% endif %}
                             {% else %}
                                 <ul class="mb-0">
-                                    {% for mobilization in service.mobilizations.all %}
-                                        <li>{{ mobilization.label }}</li>
-                                    {% endfor %}
+                                    {% for mobilization in service.mobilizations.all %}<li>{{ mobilization.label }}</li>{% endfor %}
                                 </ul>
                                 {% if service.mobilizations_details %}
                                     <p class="mt-3 mb-0">{{ service.mobilizations_details }}</p>
@@ -339,7 +337,9 @@
                         <div class="c-box mb-3 mb-md-4">
                             <h2 class="h3">Pré-requis et justificatifs</h2>
                             <ul class="mb-0">
-                                {% for prerequisite in service.prerequisites %}<li>{{ prerequisite }}</li>{% endfor %}
+                                {% for prerequisite in service.prerequisites %}
+                                    <li>{{ prerequisite|markdownify }}</li>
+                                {% endfor %}
                             </ul>
                         </div>
                     {% endif %}

--- a/tests/insertion/test_opening_hours.py
+++ b/tests/insertion/test_opening_hours.py
@@ -87,3 +87,58 @@ def test_complex_case():
     assert result["entries"][3] == {"comment": None, "hours": "8h30 à 12h00", "label": "Jeudi"}
     assert result["entries"][4] == {"comment": "Sans rendez-vous", "hours": "10h00 à 11h00", "label": "Vendredi"}
     assert result["has_ph_off"] is True
+
+
+def test_comma_separated_rules_with_closed():
+    result = format_osm_hours(
+        "Mo 09:00-21:00 open, Tu 09:00-21:00 open, We 09:00-21:00 open, "
+        "Th 09:00-21:00 open, Fr 09:00-21:00 open, Sa 09:00-21:00 open, "
+        "Su closed; PH closed"
+    )
+    assert result is not None
+    assert result["has_ph_off"] is True
+    labels = [e["label"] for e in result["entries"]]
+    assert labels == ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"]
+    for entry in result["entries"]:
+        assert entry["hours"] == "9h00 à 21h00"
+
+
+def test_open_without_times():
+    result = format_osm_hours(
+        "Mo 08:30-12:00,13:30-18:00 open, Tu 08:30-12:00,13:30-18:00 open, "
+        "We 08:30-12:00,13:30-18:00 open, Th 13:30-18:00 open, Fr 13:30-18:00 open, "
+        "Sa open, Su open; Aug closed"
+    )
+    assert result is not None
+    labels = [e["label"] for e in result["entries"]]
+    assert labels == ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"]
+    hours = {e["label"]: e["hours"] for e in result["entries"]}
+    assert hours["Lundi"] == "8h30 à 12h00 - 13h30 à 18h00"
+    assert hours["Jeudi"] == "13h30 à 18h00"
+    assert hours["Samedi"] == "ouvert"
+    assert hours["Dimanche"] == "ouvert"
+    assert result["comments"] == ["Fermé en août"]
+
+
+def test_month_off_comments():
+    result = format_osm_hours("Mo-Fr 09:00-17:00; Jul-Aug off")
+    assert result is not None
+    assert result["comments"] == ["Fermé de juillet à août"]
+
+    result = format_osm_hours("Mo-Fr 09:00-17:00; Jan,Feb off")
+    assert result is not None
+    assert result["comments"] == ["Fermé en janvier, février"]
+
+
+def test_date_range_off_comments():
+    result = format_osm_hours("Mo-Fr 07:30-18:30 open; Aug closed; Dec 25-Jan 1 closed")
+    assert result is not None
+    assert result["comments"] == ["Fermé en août", "Fermé du 25 décembre au 1er janvier"]
+
+    result = format_osm_hours("Mo-Fr 09:00-17:00; Dec 20-31 off")
+    assert result is not None
+    assert result["comments"] == ["Fermé du 20 au 31 décembre"]
+
+    result = format_osm_hours("Mo-Fr 09:00-17:00; Dec 25 off")
+    assert result is not None
+    assert result["comments"] == ["Fermé le 25 décembre"]

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -126,13 +126,19 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  Avoir plus de 18 ans
+                                  <p>
+                                      Avoir plus de 18 ans
+                                  </p>
                               </li>
                               <li>
-                                  Résider en France
+                                  <p>
+                                      Résider en France
+                                  </p>
                               </li>
                               <li>
-                                  Pièce d'identité en cours de validité
+                                  <p>
+                                      Pièce d'identité en cours de validité
+                                  </p>
                               </li>
                           </ul>
                       </div>
@@ -271,10 +277,14 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  Être orienté par un prescripteur
+                                  <p>
+                                      Être orienté par un prescripteur
+                                  </p>
                               </li>
                               <li>
-                                  Avoir 18 ans
+                                  <p>
+                                      Avoir 18 ans
+                                  </p>
                               </li>
                           </ul>
                       </div>
@@ -596,7 +606,9 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  Être orienté par un prescripteur.
+                                  <p>
+                                      Être orienté par un prescripteur.
+                                  </p>
                               </li>
                           </ul>
                       </div>

--- a/tests/www/insertion_views/__snapshots__/test_wizard.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_wizard.ambr
@@ -329,13 +329,19 @@
                           </p>
                           <ul class="mb-3 mb-md-4">
                               <li>
-                                  Résident QPV / ZFRR
+                                  <p>
+                                      Résident QPV / ZFRR
+                                  </p>
                               </li>
                               <li>
-                                  Pièce d'identité
+                                  <p>
+                                      Pièce d'identité
+                                  </p>
                               </li>
                               <li>
-                                  Justificatif de domicile
+                                  <p>
+                                      Justificatif de domicile
+                                  </p>
                               </li>
                           </ul>
                           <div class="form-group form-group-required-check form-group-required">
@@ -453,13 +459,19 @@
                           </p>
                           <ul class="mb-3 mb-md-4">
                               <li>
-                                  Résident QPV / ZFRR
+                                  <p>
+                                      Résident QPV / ZFRR
+                                  </p>
                               </li>
                               <li>
-                                  Pièce d'identité
+                                  <p>
+                                      Pièce d'identité
+                                  </p>
                               </li>
                               <li>
-                                  Justificatif de domicile
+                                  <p>
+                                      Justificatif de domicile
+                                  </p>
                               </li>
                           </ul>
                           <div class="form-group">

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -241,6 +241,28 @@ class TestServices:
         response = client.get(self.get_service_url(service))
         assert response.status_code == 200
 
+    def test_detail_opening_hours_with_comments(self, client):
+        service = ServiceFactory(
+            uid="test-service-uid",
+            name="Mon service de test",
+            updated_on="2025-01-15",
+            source__value="other",
+            source__label="Other",
+            opening_hours="Mo-Fr 07:45-18:30 open; Sa open; Aug closed; Dec 25-Jan 1 closed",
+            structure__uid="test-structure-uid",
+            structure__name="Ma structure de test",
+            structure__updated_on="2025-01-15",
+        )
+        response = client.get(self.get_service_url(service))
+        assert response.status_code == 200
+        formatted_opening_hours = response.context["formatted_opening_hours"]
+        hours = {e["label"]: e["hours"] for e in formatted_opening_hours["entries"]}
+        assert hours["Lundi"] == "7h45 à 18h30"
+        assert hours["Samedi"] == "ouvert"
+        assert formatted_opening_hours["comments"] == ["Fermé en août", "Fermé du 25 décembre au 1er janvier"]
+        assertContains(response, "Fermé en août.")
+        assertContains(response, "Fermé du 25 décembre au 1er janvier.")
+
     def test_detail_basic_dora(self, client, snapshot):
         user = PrescriberFactory(membership=True)
         service = ServiceFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

Certains services contiennent des pré-requis dans le format markdown. Cette PR affiche correctement ces cas pour la fiche service et le formulaire d'orientation

Il y a aussi des problèmes d'affichage des horaires d'accueil quand les éléments sont séparés par des virgules. Je vois aussi qu'il y a des services qui ont des jours ouverts sans des horaires précises et des commentaires qui indiquent les mois des vacances. 

Cette PR affiche les jours ouverts sans horaires avec <Day>: ouvert et dans le tooltip qui montre "Hors jours fériés` si applicable, on affiche aussi des mois ou jours particuliers quand le service est fermé
## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
Markdown:
Avant:
<img width="1038" height="349" alt="Capture d’écran, le 2026-07-07 à 18 18 25" src="https://github.com/user-attachments/assets/4e2f7f4b-f178-4754-a8ed-015de89f4cee" />
Aprés:
<img width="839" height="217" alt="Screenshot 2026-07-08 at 13 49 30" src="https://github.com/user-attachments/assets/d28aa92b-08f1-4b48-8e10-9d38a8ca3220" />

Horaires:

Avant :
<img width="754" height="382" alt="Screenshot 2026-07-08 at 11 50 58" src="https://github.com/user-attachments/assets/c1017976-5b76-4b6f-a7bc-1a2cc945cd8c" />

Après :
<img width="1001" height="526" alt="Screenshot 2026-07-08 at 17 43 04" src="https://github.com/user-attachments/assets/1af028d3-aad0-4e97-9190-a3ba81afd50f" />



<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
