### PR TITLE
Insertion : Ne plus tenter de poster des iMERs pour certains utilisateurs

### DIFF
--- a/itou/templates/insertion/includes/structure_card_tabs.html
+++ b/itou/templates/insertion/includes/structure_card_tabs.html
@@ -1,10 +1,10 @@
 <div id="structure-tabs">
     <div class="tab-content">
         <div id="structure-description" class="tab-pane active show" aria-labelledby="structure-description-tab" role="tabpanel">
-            {% include "insertion/includes/structure_card_tab_description.html" %}
+            {% include "insertion/includes/structure_card_tab_description.html" with structure=structure only %}
         </div>
         <div id="structure-services" class="tab-pane" aria-labelledby="structure-services-tab" role="tabpanel">
-            {% include "insertion/includes/structure_card_tab_services.html" %}
+            {% include "insertion/includes/structure_card_tab_services.html" with services=services request=request only %}
         </div>
     </div>
 </div>

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -421,5 +421,7 @@
 
 {% block script %}
     {{ block.super }}
-    {% include "insertion/includes/register_mobilization_event.html" with service_uid=service.uid csp_nonce=csp_nonce csrf_token=csrf_token only %}
+    {% if can_register_mobilization_event %}
+        {% include "insertion/includes/register_mobilization_event.html" with service_uid=service.uid csp_nonce=csp_nonce csrf_token=csrf_token only %}
+    {% endif %}
 {% endblock %}

--- a/itou/templates/insertion/structure_card.html
+++ b/itou/templates/insertion/structure_card.html
@@ -141,5 +141,7 @@
             }
         }
     </script>
-    {% include "insertion/includes/register_mobilization_event.html" with structure_uid=structure.uid csp_nonce=csp_nonce csrf_token=csrf_token only %}
+    {% if can_register_mobilization_event %}
+        {% include "insertion/includes/register_mobilization_event.html" with structure_uid=structure.uid csp_nonce=csp_nonce csrf_token=csrf_token only %}
+    {% endif %}
 {% endblock %}

--- a/itou/templates/insertion/structure_card.html
+++ b/itou/templates/insertion/structure_card.html
@@ -59,7 +59,9 @@
     <section id="structure-content-tabs" class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
-                <div class="s-section__col col-12">{% include "insertion/includes/structure_card_tabs.html" %}</div>
+                <div class="s-section__col col-12">
+                    {% include "insertion/includes/structure_card_tabs.html" with structure=structure services=services request=request only %}
+                </div>
             </div>
         </div>
     </section>

--- a/itou/users/perms.py
+++ b/itou/users/perms.py
@@ -1,2 +1,6 @@
 def can_orient_towards_insertion_service(request):
     return bool(request.user.is_authenticated and (request.from_employer or request.from_prescriber))
+
+
+def can_register_mobilization_event(request):
+    return bool(not request.user.is_authenticated or request.from_employer or request.from_prescriber)

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -27,6 +27,7 @@ from itou.insertion.utils import (
 )
 from itou.users.enums import UserKind
 from itou.users.models import User
+from itou.users.perms import can_register_mobilization_event
 from itou.utils.apis.dora import DoraAPIClient, DoraAPIException
 from itou.utils.auth import LoginNotRequiredMixin
 from itou.utils.perms.utils import can_edit_personal_information, can_view_personal_information
@@ -169,7 +170,7 @@ class ServiceDetailView(LoginNotRequiredMixin, DetailView):
 @login_not_required
 @require_POST
 def register_mobilization_event(request):
-    if request.user.is_authenticated and not (request.from_employer or request.from_prescriber):
+    if not can_register_mobilization_event(request):
         raise PermissionDenied()
 
     if not (kind := request.POST.get("kind")) or kind not in MobilizationEventKind.values:

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -102,6 +102,7 @@ class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
             ),
             "services": services,
             "formatted_opening_hours": self.format_opening_hours(),
+            "can_register_mobilization_event": can_register_mobilization_event(self.request),
         }
 
 
@@ -163,6 +164,7 @@ class ServiceDetailView(LoginNotRequiredMixin, DetailView):
                 ),
                 "formatted_categories": self.format_categories(),
                 "can_view_modal": can_view_modal,
+                "can_register_mobilization_event": can_register_mobilization_event(self.request),
             }
         )
 

--- a/tests/users/test_perms.py
+++ b/tests/users/test_perms.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
 from itou.companies.enums import CompanyKind
@@ -6,11 +7,11 @@ from itou.companies.models import Company
 from itou.companies.perms import can_create_antenna
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import IdentityProvider
-from itou.users.perms import can_orient_towards_insertion_service
+from itou.users.perms import can_orient_towards_insertion_service, can_register_mobilization_event
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
 from tests.institutions.factories import InstitutionMembershipFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
-from tests.users.factories import JobSeekerFactory
+from tests.users.factories import ItouStaffFactory, JobSeekerFactory
 from tests.utils.testing import get_request
 
 
@@ -39,6 +40,10 @@ class TestCanCreateSiaeAntenna:
         assert can_create_antenna(request) is expected
 
 
+def make_anonymous():
+    return AnonymousUser(), None
+
+
 def make_jobseeker():
     return JobSeekerFactory(), None
 
@@ -56,6 +61,10 @@ def make_prescriber(**kwargs):
 def make_labor_inspector():
     membership = InstitutionMembershipFactory()
     return membership.user, membership.institution
+
+
+def make_itou_staff():
+    return ItouStaffFactory(), None
 
 
 @pytest.mark.parametrize(
@@ -105,3 +114,54 @@ def test_can_orient_towards_insertion_service(user_factory, expected):
         elif isinstance(structure, Company):
             request.from_employer = True
     assert can_orient_towards_insertion_service(request) is expected
+
+
+@pytest.mark.parametrize(
+    "user_factory,expected",
+    (
+        pytest.param(make_anonymous, True, id="anonymous"),
+        pytest.param(make_jobseeker, False, id="job_seeker"),
+        pytest.param(make_employer, True, id="employer"),
+        pytest.param(
+            lambda: make_prescriber(organization__authorized=False),
+            True,
+            id="orienteur",
+        ),
+        pytest.param(
+            lambda: make_prescriber(organization__authorized=True),
+            True,
+            id="prescriber_authorized",
+        ),
+        pytest.param(
+            lambda: make_prescriber(
+                user__identity_provider=IdentityProvider.DJANGO,
+                organization__authorized=True,
+            ),
+            True,
+            id="prescriber_authorized_identity_provider_django",
+        ),
+        pytest.param(
+            lambda: make_prescriber(
+                organization__authorized=True,
+                organization__siret=None,
+            ),
+            True,
+            id="prescriber_authorized_no_siret",
+        ),
+        pytest.param(make_labor_inspector, False, id="labor_inspector"),
+        pytest.param(make_itou_staff, False, id="itou_staff"),
+    ),
+)
+def test_can_register_mobilization_event(user_factory, expected):
+    request_factory = RequestFactory()
+    request = request_factory.get("/")
+    request.user, structure = user_factory()
+    request.from_prescriber = False
+    request.from_employer = False
+    if structure:
+        request.current_organization = structure
+        if isinstance(structure, PrescriberOrganization):
+            request.from_prescriber = True
+        elif isinstance(structure, Company):
+            request.from_employer = True
+    assert can_register_mobilization_event(request) is expected

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -24,7 +24,13 @@ from tests.insertion.factories import (
     ServiceFactory,
     StructureFactory,
 )
-from tests.users.factories import ItouStaffFactory, JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.users.factories import (
+    EmployerFactory,
+    ItouStaffFactory,
+    JobSeekerFactory,
+    LaborInspectorFactory,
+    PrescriberFactory,
+)
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
@@ -213,6 +219,34 @@ class TestStructures:
 
         response = client.get(self.get_structure_url(structure))
         assertContains(response, reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid}))
+
+    @pytest.mark.parametrize(
+        "user_factory,assertion",
+        [
+            (None, assertContains),
+            (JobSeekerFactory, assertNotContains),
+            (partial(PrescriberFactory, membership=True), assertContains),
+            (partial(EmployerFactory, membership=True), assertContains),
+            (partial(LaborInspectorFactory, membership=True), assertNotContains),
+            (ItouStaffFactory, assertNotContains),
+        ],
+    )
+    def test_card_view_register_mobilization_event_per_user_kind(self, client, user_factory, assertion):
+        structure = StructureFactory(
+            name="Structure test",
+            description="Description de test",
+            source=GenericReferenceItemFactory(
+                source=GenericReferenceItemSource.DATA_INCLUSION,
+                kind=GenericReferenceItemKind.SOURCE,
+                value=SOURCE_DORA_VALUE,
+            ),
+            source_link=f"{settings.DORA_WWW_BASE_URL}/structures/structure-test",
+        )
+        if user_factory:
+            client.force_login(user_factory())
+        response = client.get(self.get_structure_url(structure))
+
+        assertion(response, f'body.set("structure_uid", "{structure.uid}");')
 
 
 class TestServices:
@@ -889,6 +923,28 @@ class TestServices:
         response = client.get(self.get_service_url(service))
         assertNotContains(response, "Via le formulaire DORA")
         assertContains(response, "Via le formulaire (bouton “Orienter votre bénéficiaire”)")
+
+    @pytest.mark.parametrize(
+        "user_factory,assertion",
+        [
+            (None, assertContains),
+            (JobSeekerFactory, assertNotContains),
+            (partial(PrescriberFactory, membership=True), assertContains),
+            (partial(EmployerFactory, membership=True), assertContains),
+            (partial(LaborInspectorFactory, membership=True), assertNotContains),
+            (ItouStaffFactory, assertNotContains),
+        ],
+    )
+    def test_card_view_register_mobilization_event_per_user_kind(self, client, user_factory, assertion):
+        service = ServiceFactory(
+            contact_email="contact@example.com",
+            contact_is_public=True,
+        )
+        if user_factory:
+            client.force_login(user_factory())
+        response = client.get(self.get_service_url(service))
+
+        assertion(response, f'body.set("service_uid", "{service.uid}");')
 
 
 @pytest.mark.parametrize("user_factory", [None, partial(PrescriberFactory, membership=True)])


### PR DESCRIPTION
## :thinking: Pourquoi ?

On enregistre les intentions de mise en relation (iMER) uniquement pour les utilisateurs non connectés et les prescripteurs/employeurs.
Ce n’est donc pas la peine d’envoyer de requête POST pour les autres types d’utilisateurs.
Cela évite des requêtes inutiles qui se terminent en 403.

