### PR TITLE
Insertion : Gérer les UID de services avec le caractère `/`

### DIFF
--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -1,4 +1,4 @@
-from urllib.parse import SplitResult, urlsplit
+from urllib.parse import SplitResult, quote, unquote, urlsplit
 
 from django.conf import settings
 from django.http import QueryDict
@@ -88,6 +88,20 @@ class SiretConverter:
 
     def to_url(self, value):
         return f"{value}"
+
+
+class EncodedUidConverter:
+    """
+    URL-encoded UID (handles slashes and other reserved characters).
+    """
+
+    regex = r"[^/]+"
+
+    def to_python(self, value: str) -> str:
+        return unquote(value)
+
+    def to_url(self, value: str) -> str:
+        return quote(value, safe="")
 
 
 def get_tally_form_url(form_id, **kwargs):

--- a/itou/www/insertion_views/urls.py
+++ b/itou/www/insertion_views/urls.py
@@ -1,21 +1,24 @@
-from django.urls import path
+from django.urls import path, register_converter
 
+from itou.utils.urls import EncodedUidConverter
 from itou.www.insertion_views import views
 
 
 app_name = "insertion_views"
 
+register_converter(EncodedUidConverter, "encoded_uid")
+
 urlpatterns = [
     path("structures/<str:structure_uid>/", views.StructureCardView.as_view(), name="structure_card"),
-    path("services/<str:service_uid>/", views.ServiceDetailView.as_view(), name="service_detail"),
+    path("services/<encoded_uid:service_uid>/", views.ServiceDetailView.as_view(), name="service_detail"),
     path("register-mobilization-event/", views.register_mobilization_event, name="register_mobilization_event"),
     path(
-        "orientations/<str:service_uid>/start/",
+        "orientations/<encoded_uid:service_uid>/start/",
         views.start_orientation,
         name="start_orientation",
     ),
     path(
-        "orientations/<str:service_uid>/job-seeker/",
+        "orientations/<encoded_uid:service_uid>/job-seeker/",
         views.OrientationSelectJobSeekerView.as_view(),
         name="orientation_select_job_seeker",
     ),
@@ -30,7 +33,7 @@ urlpatterns = [
         name="orientation_dismiss_disclaimer",
     ),
     path(
-        "orientations/<str:service_uid>/confirmation/",
+        "orientations/<encoded_uid:service_uid>/confirmation/",
         views.OrientationConfirmationView.as_view(),
         name="orientation_confirmation",
     ),

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -207,6 +207,13 @@ class TestStructures:
         assertContains(response, "Lieu d'accueil : Loudun")
         assertContains(response, "Lieu d'accueil : à distance")
 
+    def test_no_error_when_special_chars_in_uid(self, client):
+        structure = StructureFactory()
+        service = ServiceFactory(structure=structure, uid="fredo--97416_13643-activités / ateliers")  # real case
+
+        response = client.get(self.get_structure_url(structure))
+        assertContains(response, reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid}))
+
 
 class TestServices:
     LOGIN_URL = reverse("login:existing_user")

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -616,3 +616,24 @@ def test_orientation_wizard_banner_quitter_goes_to_job_seekers_list(client):
     response = client.get(conformity_url)
     quit_link = parse_response_to_soup(response, 'a[aria-label="Quitter la procédure"]')
     assert quit_link["href"] == reverse("job_seekers_views:list")
+
+
+def test_no_error_when_special_chars_in_uid(client):
+    """Check that reset url and redirection to orientation_select_job_seeker have encoded uids"""
+    prescriber = PrescriberFactory(membership=True)
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        structure__name="Structure orientation wizard",
+        uid="fredo--97416_13643-activités / ateliers",  # real case
+    )
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+    select_job_seeker_url = reverse(
+        "insertion_views:orientation_select_job_seeker", kwargs={"service_uid": service.uid}
+    )
+    service_url = reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid})
+
+    client.force_login(prescriber)
+    response = client.get(start_url)
+    assertRedirects(response, select_job_seeker_url, fetch_redirect_response=False)
+    response = client.get(select_job_seeker_url)
+    assertContains(response, service_url)  # reset button

--- a/tests/www/search_views/test_services.py
+++ b/tests/www/search_views/test_services.py
@@ -149,3 +149,12 @@ class TestSearchServices:
             client.get(self.URL, {"city": vannes.slug, "category": CATEGORY, "reception": REMOTE_RECEPTION_VALUE})
         )
         assertSoupEqual(simulated_page, fresh_page)
+
+    def test_no_error_when_special_chars_in_uid(self, client):
+        vannes = create_city_vannes()
+        service = ServiceFactory(
+            coordinates=vannes.coords, city="Vannes", uid="fredo--97416_13643-activités / ateliers"
+        )  # real case
+
+        response = client.get(self.URL, {"city": vannes.slug, "category": CATEGORY})
+        assertContains(response, reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid}))


### PR DESCRIPTION
## :thinking: Pourquoi ?

La plupart des services qui viennent de la source `fredo` ont un `/` dans leur UID. Ça casse beaucoup de nos URLs.  

[Carte notion](https://app.notion.com/p/gip-inclusion/Bug-sur-les-services-ayant-un-UID-avec-un-3985f321b60480b9bc9ae8c4072736f5?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link)
[Erreurs Sentry](https://inclusion.sentry.io/issues/132548617?project=4508410589020240)

## :cake: Comment ? <!-- optionnel -->

Un convertisseur de chemin personnalisé !

