### PR TITLE
Stabilité : correction d'un test bagottant lié à `ServiceFactory`

### DIFF
--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -176,7 +176,7 @@ class TestStructures:
 
         assert response.status_code == 200
         perimeters = [service.perimeter for service in response.context["services"]]
-        assert sorted(perimeters) == ["Finistère", "Ille-et-Vilaine", "Morbihan"]
+        assert perimeters == ["Finistère", "Morbihan", "Ille-et-Vilaine"]
         assertContains(response, "Périmètre : Finistère")
         assertContains(response, "Périmètre : Morbihan")
         assertContains(response, "Périmètre : Ille-et-Vilaine")

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -159,8 +159,8 @@ class TestStructures:
             Department.objects.create(code=code, name=name, region="53")
 
         structure = StructureFactory()
-        for code in ("29", "56", "35"):
-            ServiceFactory(structure=structure, eligibility_zones=[code])
+        for name, code in [("Service A", "29"), ("Service B", "56"), ("Service C", "35")]:
+            ServiceFactory(structure=structure, name=name, eligibility_zones=[code])
 
         with assertNumQueries(
             1  # structure + source


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un test était _flaky_ : une vue liste les services par `name`, mais `ServiceFactory` génère des noms via une séquence ("Service 0", "Service 1", ...) qui trie lexicographiquement et non numériquement. Une fois le compteur global passant un seuil de chiffre (ex. "Service 9" > "Service 10"), l'ordre obtenu divergeait de l'ordre de création, faisant échouer le test de façon aléatoire.

## :cake: Comment ?

Noms explicites fixés ("Service A/B/C") dans le test pour que `order_by("name")` soit déterministe.