### PR TITLE
Retirer livestorm des partenaires, CGU et consentement

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -729,7 +729,6 @@ SECURE_CSP = {
         "https://pilotage.inclusion.beta.gouv.fr",
     ],
     "frame-src": [
-        "https://app.livestorm.co",  # Upcoming events from the homepage
         # For stats/pilotage views
         "https://tally.so",
         "https://stats.inclusion.beta.gouv.fr",

--- a/itou/templates/includes/tarteaucitron_matomo.html
+++ b/itou/templates/includes/tarteaucitron_matomo.html
@@ -62,35 +62,6 @@
     {% endif %}
     /* beautify ignore:end */
 
-    // livestorm
-    tarteaucitron.services.livestorm = {
-        "key": "livestorm",
-        "type": "video",
-        "name": "Livestorm",
-        "uri": "https://livestorm.co/fr/politique-confidentialite",
-        "needConsent": true,
-        "cookies": [],
-        "js": function() {
-            "use strict";
-            tarteaucitron.fallback(['js-tac-livestorm'], function(x) {
-                var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'livestorm iframe'),
-                    height = tarteaucitron.fixSelfXSS(x.getAttribute("height") || '365'),
-                    url = tarteaucitron.fixSelfXSS(x.getAttribute("data-url"));
-                return '<iframe title="' + frame_title + '" src="' + url + '" style="min-height:' + height + 'px;" allowtransparency allowfullscreen></iframe>';
-            });
-        },
-        "fallback": function() {
-            "use strict";
-            var id = 'livestorm';
-            tarteaucitron.fallback(['js-tac-livestorm'], function(elem) {
-                elem.style.width = elem.getAttribute('width');
-                elem.style.height = "265px";
-                return tarteaucitron.engage(id);
-            });
-        }
-    };
-    (tarteaucitron.job = tarteaucitron.job || []).push('livestorm');
-
     // tally
     tarteaucitron.services.tally = {
         "key": "tally",

--- a/itou/templates/static/legal/privacy.html
+++ b/itou/templates/static/legal/privacy.html
@@ -213,14 +213,6 @@
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td>Livestorm</td>
-                                    <td>Irlande</td>
-                                    <td>Service de partage de vidéo pour enrichir le site avec du contenu multimédia ce qui augmente sa visibilité</td>
-                                    <td>
-                                        <a herf="https://livestorm.imgix.net/1127/1675174056-privacy-policy-fr.pdf" target="_blank" class="has-external-link">https://livestorm.imgix.net/1127/1675174056-privacy-policy-fr.pdf</a>
-                                    </td>
-                                </tr>
-                                <tr>
                                     <td>Tally</td>
                                     <td>Belgique</td>
                                     <td>Outil de sondage</td>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le service n’est plus utilisé.
