### PR TITLE
Sécurité : Vérification du paramètre nonce dans les connexions OIDC ProConnect

### DIFF
--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -86,7 +86,7 @@ class OIDConnectState(models.Model):
     used_at = models.DateTimeField(verbose_name="date d'utilisation", null=True)
     # Length used in call to get_random_string()
     state = models.CharField(max_length=12, unique=True)
-    nonce = models.CharField(unique=True, null=True)  # TODO(xfernandez): remove null=True in a few weeks
+    nonce = models.CharField(unique=True, null=True)
 
     objects = OIDConnectQuerySet.as_manager()
 

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -243,6 +243,15 @@ def pro_connect_callback(request):
     pro_connect_state = ProConnectState.get_from_state(state)
     if pro_connect_state is None or not pro_connect_state.is_valid():
         return _redirect_to_login_page_on_error(request=request)
+
+    # Decode id_token and check nonce
+    try:
+        id_token_data = _decode_token(token_data["id_token"])
+    except jwt.InvalidTokenError:
+        return _redirect_to_login_page_on_error(error_msg="ProConnect unable to decode id_token ", request=request)
+    if id_token_data.get("nonce") != pro_connect_state.nonce:
+        return _redirect_to_login_page_on_error(error_msg="ProConnect id_token nonce mismatch", request=request)
+
     pc_session = ProConnectSession(state=state, token=token_data["id_token"])
     pc_session.bind_to_request(request)
 
@@ -353,7 +362,6 @@ def pro_connect_callback(request):
     amr = ()
     idp_id = None
     try:
-        id_token_data = _decode_token(token_data["id_token"])
         amr = id_token_data.get("amr", ())
         idp_id = user_data.get("idp_id", "")
         ProConnectAuthentication.objects.create(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -778,8 +778,8 @@ def setup_pro_connect(respx_mock):
     # this import requirest the settings to be loaded so we con't put it with the others
     from tests.openid_connect.pro_connect.testing import pro_connect_setup
 
-    with pro_connect_setup():
-        yield pro_connect_setup
+    with pro_connect_setup() as setup:
+        yield setup
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/openid_connect/pro_connect/testing.py
+++ b/tests/openid_connect/pro_connect/testing.py
@@ -69,9 +69,9 @@ def mock_oauth_dance(
     channel=None,
     oidc_userinfo=None,
     id_token_data=None,
+    expected_failure=False,  # login flow failed, redirect to logout
 ):
     user_info = oidc_userinfo or OIDC_USERINFO.copy()
-    id_token_data = id_token_data or deepcopy(ID_TOKEN_DATA)
 
     # Authorize params depend on user kind.
     authorize_params = {
@@ -87,11 +87,13 @@ def mock_oauth_dance(
     response = client.get(authorize_url)
     assert response.url.startswith(constants.PRO_CONNECT_ENDPOINT_AUTHORIZE)
 
+    id_token_data = id_token_data or deepcopy(ID_TOKEN_DATA)
+    id_token = _encode_id_token(id_token_data)
     token_json = {
         "access_token": "access_token",
         "token_type": "Bearer",
         "expires_in": 60,
-        "id_token": _encode_id_token(id_token_data),
+        "id_token": id_token,
     }
     respx.post(constants.PRO_CONNECT_ENDPOINT_TOKEN).mock(return_value=httpx.Response(200, json=token_json))
 
@@ -108,6 +110,15 @@ def mock_oauth_dance(
     # If a expected_redirect_url was provided, check it redirects there
     # If not, the default redirection is next_url if provided, or welcoming_tour for new users
     expected = expected_redirect_url or next_url or reverse("welcoming_tour:index")
+    if expected_failure:
+        assert expected_redirect_url is None, "No expected_redirect_url when expecting a failure"
+        expected = reverse(
+            "pro_connect:logout",
+            query={
+                "redirect_url": previous_url or reverse("search:employers_home"),
+                "token": id_token,
+            },
+        )
     assertRedirects(response, expected, fetch_redirect_response=False)
     return response
 

--- a/tests/openid_connect/pro_connect/testing.py
+++ b/tests/openid_connect/pro_connect/testing.py
@@ -8,12 +8,13 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import crypto, timezone
 from itoutils.urls import add_url_params
 from pytest_django.asserts import assertContains, assertRedirects
 
 from itou.openid_connect.pro_connect import constants
 from itou.users.enums import IdentityProvider
+from itou.utils.urls import get_url_param_value
 from tests.utils.testing import reload_module
 
 
@@ -70,6 +71,7 @@ def mock_oauth_dance(
     oidc_userinfo=None,
     id_token_data=None,
     expected_failure=False,  # login flow failed, redirect to logout
+    matching_nonces=True,
 ):
     user_info = oidc_userinfo or OIDC_USERINFO.copy()
 
@@ -87,7 +89,11 @@ def mock_oauth_dance(
     response = client.get(authorize_url)
     assert response.url.startswith(constants.PRO_CONNECT_ENDPOINT_AUTHORIZE)
 
+    state = get_url_param_value(response.url, "state")
+    nonce = get_url_param_value(response.url, "nonce") if matching_nonces else crypto.get_random_string(length=12)
+
     id_token_data = id_token_data or deepcopy(ID_TOKEN_DATA)
+    id_token_data["nonce"] = nonce
     id_token = _encode_id_token(id_token_data)
     token_json = {
         "access_token": "access_token",
@@ -104,7 +110,6 @@ def mock_oauth_dance(
     user_info_jwt = jwt.encode(payload=user_info, key=constants.PRO_CONNECT_CLIENT_SECRET, algorithm="HS256")
     respx.get(constants.PRO_CONNECT_ENDPOINT_USERINFO).mock(return_value=httpx.Response(200, content=user_info_jwt))
 
-    state = client.session[constants.PRO_CONNECT_SESSION_KEY]["state"]
     url = reverse("pro_connect:callback")
     response = client.get(url, data={"code": "123", "state": state})
     # If a expected_redirect_url was provided, check it redirects there

--- a/tests/openid_connect/pro_connect/testing.py
+++ b/tests/openid_connect/pro_connect/testing.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import classproperty
 from itoutils.urls import add_url_params
 from pytest_django.asserts import assertContains, assertRedirects
 
@@ -134,8 +133,6 @@ def assert_and_mock_forced_logout(client, response, expected_redirect_url=revers
 class pro_connect_setup:
     oidc_userinfo = OIDC_USERINFO
     oidc_userinfo_with_safir = OIDC_USERINFO_FT_WITH_SAFIR
-    mock_oauth_dance = mock_oauth_dance
-    assert_and_mock_forced_logout = assert_and_mock_forced_logout
     identity_provider = IdentityProvider.PRO_CONNECT
     session_key = constants.PRO_CONNECT_SESSION_KEY
 
@@ -145,19 +142,25 @@ class pro_connect_setup:
     def __enter__(self):
         for context_manager in self.context_managers:
             context_manager.__enter__()
+        return self
 
     def __exit__(self, *args, **kwargs):
         for context_manager in self.context_managers:
             context_manager.__exit__(*args, **kwargs)
 
-    @classmethod
-    def assertContainsButton(cls, response):
+    def assertContainsButton(self, response):
         assertContains(response, 'class="proconnect-button"')
 
-    @classproperty
-    def authorize_url(cls):
+    @property
+    def authorize_url(self):
         return reverse("pro_connect:authorize")
 
-    @classproperty
-    def logout_url(cls):
+    @property
+    def logout_url(self):
         return reverse("pro_connect:logout")
+
+    def mock_oauth_dance(self, *args, **kwargs):
+        return mock_oauth_dance(*args, **kwargs)
+
+    def assert_and_mock_forced_logout(sefl, *args, **kwargs):
+        return assert_and_mock_forced_logout(*args, **kwargs)

--- a/tests/openid_connect/pro_connect/testing.py
+++ b/tests/openid_connect/pro_connect/testing.py
@@ -120,13 +120,13 @@ def mock_oauth_dance(
             },
         )
     assertRedirects(response, expected, fetch_redirect_response=False)
-    return response
+    return response, id_token
 
 
-def assert_and_mock_forced_logout(client, response, expected_redirect_url=reverse("search:employers_home")):
+def assert_and_mock_forced_logout(client, response, id_token, expected_redirect_url=reverse("search:employers_home")):
     expected_logout_url = add_url_params(
         reverse("pro_connect:logout"),
-        {"redirect_url": expected_redirect_url, "token": ID_TOKEN_ENCODED},
+        {"redirect_url": expected_redirect_url, "token": id_token},
     )
     assertRedirects(response, expected_logout_url, fetch_redirect_response=False)
     response = client.get(response.url)
@@ -146,6 +146,7 @@ class pro_connect_setup:
     oidc_userinfo_with_safir = OIDC_USERINFO_FT_WITH_SAFIR
     identity_provider = IdentityProvider.PRO_CONNECT
     session_key = constants.PRO_CONNECT_SESSION_KEY
+    id_token = None  # Set when calling mock_oauth_dance and used in assert_and_mock_forced_logout
 
     def __init__(self):
         self.context_managers = [override_settings(**TEST_SETTINGS), reload_module(constants)]
@@ -171,7 +172,10 @@ class pro_connect_setup:
         return reverse("pro_connect:logout")
 
     def mock_oauth_dance(self, *args, **kwargs):
-        return mock_oauth_dance(*args, **kwargs)
+        response, id_token = mock_oauth_dance(*args, **kwargs)
+        self.id_token = id_token
+        return response
 
-    def assert_and_mock_forced_logout(sefl, *args, **kwargs):
-        return assert_and_mock_forced_logout(*args, **kwargs)
+    def assert_and_mock_forced_logout(self, *args, **kwargs):
+        assert self.id_token
+        return assert_and_mock_forced_logout(*args, id_token=self.id_token, **kwargs)

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -566,6 +566,16 @@ class TestProConnectCallbackView:
             ],
         )
 
+    def test_callback_mismatched_nonce(self, client, pro_connect, caplog):
+        pro_connect.mock_oauth_dance(
+            client,
+            expected_redirect_url=reverse("search:employers_home"),
+            matching_nonces=False,
+        )
+        assert User.objects.count() == 0
+        assert get_user(client).is_authenticated is False
+        assert "ProConnect id_token nonce mismatch" in caplog.messages
+
 
 class TestProConnectSession:
     def test_start_session(self, subtests):
@@ -716,7 +726,7 @@ class TestProConnectLogout:
             add_url_params(
                 constants.PRO_CONNECT_ENDPOINT_LOGOUT,
                 {
-                    "id_token_hint": ID_TOKEN_ENCODED,
+                    "id_token_hint": pro_connect.id_token,
                     "state": signed_state,
                     "post_logout_redirect_uri": post_logout_redirect_uri,
                 },
@@ -741,7 +751,7 @@ class TestProConnectLogout:
             add_url_params(
                 constants.PRO_CONNECT_ENDPOINT_LOGOUT,
                 {
-                    "id_token_hint": ID_TOKEN_ENCODED,
+                    "id_token_hint": pro_connect.id_token,
                     "state": signed_state,
                     "post_logout_redirect_uri": post_logout_redirect_uri,
                 },

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -374,30 +374,22 @@ class TestProConnectCallbackView:
         pc_user_data = ProConnectUserData.from_user_info(pro_connect.oidc_userinfo)
         user = UserFactory(username=pc_user_data.username, email=pc_user_data.email, kind=UserKind.JOB_SEEKER)
 
-        expected_redirect_url = reverse(
-            "pro_connect:logout",
-            query={
-                "redirect_url": reverse("search:employers_home"),
-                "token": ID_TOKEN_ENCODED,
-            },
-        )
-
-        pro_connect.mock_oauth_dance(client, expected_redirect_url=expected_redirect_url)
+        pro_connect.mock_oauth_dance(client, expected_failure=True)
         user.refresh_from_db()
         assert user.kind == UserKind.JOB_SEEKER
         assert get_user(client).is_authenticated is False
 
-        pro_connect.mock_oauth_dance(client, expected_redirect_url=expected_redirect_url)
+        pro_connect.mock_oauth_dance(client, expected_failure=True)
         user.refresh_from_db()
         assert user.kind == UserKind.JOB_SEEKER
         assert get_user(client).is_authenticated is False
 
-        pro_connect.mock_oauth_dance(client, expected_redirect_url=expected_redirect_url)
+        pro_connect.mock_oauth_dance(client, expected_failure=True)
         user.refresh_from_db()
         assert user.kind == UserKind.JOB_SEEKER
         assert get_user(client).is_authenticated is False
 
-        pro_connect.mock_oauth_dance(client, expected_redirect_url=expected_redirect_url)
+        pro_connect.mock_oauth_dance(client, expected_failure=True)
         user.refresh_from_db()
         assert user.kind == UserKind.JOB_SEEKER
         assert get_user(client).is_authenticated is False
@@ -406,16 +398,7 @@ class TestProConnectCallbackView:
         pc_user_data = ProConnectUserData.from_user_info(pro_connect.oidc_userinfo)
 
         user = JobSeekerFactory(username=pc_user_data.username, email=pc_user_data.email)
-        response = pro_connect.mock_oauth_dance(
-            client,
-            expected_redirect_url=reverse(
-                "pro_connect:logout",
-                query={
-                    "redirect_url": reverse("search:employers_home"),
-                    "token": ID_TOKEN_ENCODED,
-                },
-            ),
-        )
+        response = pro_connect.mock_oauth_dance(client, expected_failure=True)
         response = client.get(reverse("search:employers_home"))
         assertContains(response, "existe déjà avec cette adresse e-mail")
         assertContains(response, "pour devenir professionnel sur la plateforme")
@@ -430,16 +413,7 @@ class TestProConnectCallbackView:
             kind=UserKind.PROFESSIONAL,
             is_active=False,
         )
-        response = pro_connect.mock_oauth_dance(
-            client,
-            expected_redirect_url=reverse(
-                "pro_connect:logout",
-                query={
-                    "redirect_url": reverse("search:employers_home"),
-                    "token": ID_TOKEN_ENCODED,
-                },
-            ),
-        )
+        response = pro_connect.mock_oauth_dance(client, expected_failure=True)
         assertMessages(
             response,
             [

--- a/tests/www/invitations_views/test_generic.py
+++ b/tests/www/invitations_views/test_generic.py
@@ -8,7 +8,6 @@ from django.shortcuts import reverse
 from django.urls import reverse_lazy
 from django.utils.html import escape
 from freezegun import freeze_time
-from itoutils.urls import add_url_params
 from pytest_django.asserts import (
     assertContains,
     assertMessages,
@@ -26,7 +25,6 @@ from tests.invitations.factories import (
     LaborInspectorInvitationFactory,
     PrescriberWithOrgInvitationFactory,
 )
-from tests.openid_connect.pro_connect.testing import ID_TOKEN_ENCODED
 from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationFactory
 from tests.users.factories import (
     DEFAULT_PASSWORD,
@@ -595,13 +593,7 @@ class ProConnectSignupTestAcceptInvitation:
             channel="invitation",
             previous_url=previous_url,
             next_url=next_url,
-            expected_redirect_url=add_url_params(
-                pro_connect.logout_url,
-                {
-                    "redirect_url": previous_url,
-                    "token": ID_TOKEN_ENCODED,
-                },
-            ),
+            expected_failure=True,
         )
         # After logout, the SSO redirects to previous_url (see redirect_url param in expected_redirect_url)
         response = client.get(previous_url, follow=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://auth0.com/blog/demystifying-oauth-security-state-vs-nonce-vs-pkce/#The-Nonce-Parameter--Preventing-ID-Token-Replay

Bon, j'ai pas du tout récupéré le nonce au bon endroit, il faut que je corrige ma PR
TODO: tests à ajouter

## :cake: Comment ? <!-- optionnel -->

Reprise de https://github.com/gip-inclusion/les-emplois/commit/69544954cab724bd8c5467f9d6205b5e94138050 mis en place il y a quelques temps