### PR TITLE
Interface : ajout du lien "Configuration 2FA" dans "Mon espace" pour les professionnels concernés

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -87,6 +87,9 @@ if os.getenv("DEBUG_SQL_SNAPSHOT"):
 FORCE_PROCONNECT_LOGIN = True  # default behaviour in tests
 
 REQUIRE_OTP_FOR_STAFF = False
+REQUIRE_MFA_FOR_PROS = False
+REQUIRE_MFA_ON_COMPANY_IDS = set()
+REQUIRE_MFA_ON_ORGANIZATION_IDS = set()
 
 BREVO_API_URL = "https://mailer.test.com"
 

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -36,13 +36,10 @@ def notify_backup_code_has_been_used(user):
     email.send()
 
 
-def require_otp(user):
-    if not user.is_authenticated:
-        return False
-
-    if user.is_verified():  # user has already authenticated with MFA
-        return False
-
+def user_is_concerned_by_otp(user):
+    """Whether 2FA applies to this user, regardless of whether they have already
+    verified in the current session (unlike `require_otp`, which short-circuits on
+    `is_verified()`). Assumes an authenticated itou user."""
     if settings.REQUIRE_OTP_FOR_STAFF and user.is_itou_staff:
         return True
 
@@ -50,6 +47,16 @@ def require_otp(user):
         return True
 
     return False
+
+
+def require_otp(user):
+    if not user.is_authenticated:
+        return False
+
+    if user.is_verified():  # user has already authenticated with MFA
+        return False
+
+    return user_is_concerned_by_otp(user)
 
 
 def _require_otp_for_pro(user):

--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -49,6 +49,26 @@ def user_is_concerned_by_otp(user):
     return False
 
 
+def user_uses_external_mfa(user):
+    """Whether the current session was verified by the identity provider's own MFA.
+
+    See `create_placeholder_for_external_totp_device()`.
+    Only meaningful for the request user after OTPMiddleware.
+    """
+    return isinstance(getattr(user, "otp_device", None), ExternalTOTPDevice)
+
+
+def user_can_enroll_otp_device(user):
+    """Whether our own 2FA applies to this user and the identity provider does not already
+    handle it: enrolling a device is useful."""
+    return user_is_concerned_by_otp(user) and not user_uses_external_mfa(user)
+
+
+def user_can_manage_otp_devices(user):
+    """Same as `user_can_enroll_otp_device`, plus at least one device to see, use or delete."""
+    return user_can_enroll_otp_device(user) and ItouTOTPDevice.objects.filter(user=user, disabled_at=None).exists()
+
+
 def require_otp(user):
     if not user.is_authenticated:
         return False
@@ -63,6 +83,11 @@ def _require_otp_for_pro(user):
     assert user.is_professional
     if not settings.REQUIRE_MFA_FOR_PROS:
         return False
+    # We tested the enrollment flow on some users who were not yet in
+    # the targeted batches that we check below. If they have enrolled
+    # a device, we should require them to use it.
+    if ItouTOTPDevice.objects.filter(user=user, disabled_at=None).exists():
+        return True
     org_ids = set(
         PrescriberMembership.objects.active().filter(user_id=user.id).values_list("organization_id", flat=True)
     )

--- a/itou/templates/layout/_header_user_dropdown_menu.html
+++ b/itou/templates/layout/_header_user_dropdown_menu.html
@@ -1,3 +1,4 @@
+{% load otp %}
 <ul class="list-unstyled">
     <li class="dropdown-item">
         <div class="d-flex align-items-center">
@@ -31,9 +32,10 @@
             <a class="dropdown-item" href="{% url 'dashboard:edit_user_email' %}">Modifier mon adresse e-mail</a>
         </li>
     {% endif %}
-    {% if user.is_staff %}
+    {% show_otp_configuration user as show_otp_config %}
+    {% if show_otp_config %}
         <li>
-            <a class="dropdown-item text-primary" href="{% url 'otp_views:otp_devices' %}">Configuration OTP</a>
+            <a class="dropdown-item text-primary" href="{% url 'otp_views:otp_devices' %}">Configuration 2FA</a>
         </li>
     {% endif %}
     <li class="dropdown-divider"></li>

--- a/itou/utils/auth.py
+++ b/itou/utils/auth.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import PermissionDenied
+from django.http import Http404
 
 
 def check_user(test_func, err_msg=""):
@@ -12,6 +13,22 @@ def check_user(test_func, err_msg=""):
             if test_pass:
                 return view_func(request, *args, **kwargs)
             raise PermissionDenied(err_msg)
+
+        return wraps(view_func)(_check_user_view_wrapper)
+
+    return decorator
+
+
+def check_user_or_404(test_func, err_msg=""):
+    """Same as `check_user`, but hides the existence of the view instead of denying access."""
+
+    def decorator(view_func):
+        def _check_user_view_wrapper(request, *args, **kwargs):
+            test_pass = test_func(request.user)
+
+            if test_pass:
+                return view_func(request, *args, **kwargs)
+            raise Http404(err_msg)
 
         return wraps(view_func)(_check_user_view_wrapper)
 

--- a/itou/utils/templatetags/otp.py
+++ b/itou/utils/templatetags/otp.py
@@ -1,0 +1,11 @@
+from django import template
+
+from itou.otp.utils import user_is_concerned_by_otp
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def show_otp_configuration(user):
+    return user.is_authenticated and user_is_concerned_by_otp(user)

--- a/itou/utils/templatetags/otp.py
+++ b/itou/utils/templatetags/otp.py
@@ -1,6 +1,6 @@
 from django import template
 
-from itou.otp.utils import user_is_concerned_by_otp
+from itou.otp.utils import user_can_manage_otp_devices
 
 
 register = template.Library()
@@ -8,4 +8,5 @@ register = template.Library()
 
 @register.simple_tag
 def show_otp_configuration(user):
-    return user.is_authenticated and user_is_concerned_by_otp(user)
+    # Same predicate as the OTP views, so that the menu only shows what is reachable
+    return user.is_authenticated and user_can_manage_otp_devices(user)

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -9,13 +9,20 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.views.generic.edit import FormView
 from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import default_key as generate_otp_key
 
 from itou.otp.models import ItouStaticDevice, ItouTOTPDevice
-from itou.otp.utils import create_otp_backup_code, get_user_devices, notify_backup_code_has_been_used
-from itou.utils.auth import check_user
+from itou.otp.utils import (
+    create_otp_backup_code,
+    get_user_devices,
+    notify_backup_code_has_been_used,
+    user_can_enroll_otp_device,
+    user_can_manage_otp_devices,
+)
+from itou.utils.auth import check_user_or_404
 from itou.utils.readonly import http_methods
 from itou.utils.urls import get_safe_url
 from itou.www.otp_views.enums import DeviceType
@@ -23,11 +30,13 @@ from itou.www.otp_views.forms import ConfirmTOTPDeviceForm, LoginWithBackupCodeF
 
 
 logger = logging.getLogger(__name__)
-check_user_for_otp = check_user(lambda user: user.is_staff or user.is_professional)
+
+check_user_can_enroll = check_user_or_404(user_can_enroll_otp_device)
+check_user_can_manage_devices = check_user_or_404(user_can_manage_otp_devices)
 
 
 @http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
-@check_user_for_otp
+@check_user_can_manage_devices
 def otp_devices(request, template_name="otp_views/otp_devices.html"):
     devices = get_user_devices(request.user)
     if request.method == "POST":
@@ -44,7 +53,7 @@ def otp_devices(request, template_name="otp_views/otp_devices.html"):
     return render(request, template_name, context)
 
 
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_0_intro(request, template_name="otp_views/enrollment_step_0_intro.html"):
     after_recovery = "after_recovery" in request.GET
     if after_recovery:
@@ -59,14 +68,14 @@ def enrollment_step_0_intro(request, template_name="otp_views/enrollment_step_0_
     return render(request, template_name, context)
 
 
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_1_choose_device_type(request, template_name="otp_views/enrollment_step_1_choose_device_type.html"):
     context = {"next_step_url": reverse("otp_views:enrollment_step_2_and_3_confirm_device")}
     return render(request, template_name, context)
 
 
 @http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
-@check_user_for_otp
+@check_user_can_enroll
 def enrollment_step_2_and_3_confirm_device(
     request, template_name="otp_views/enrollment_step_2_and_3_confirm_device.html"
 ):
@@ -122,6 +131,7 @@ def enrollment_step_2_and_3_confirm_device(
     return render(request, template_name, context)
 
 
+@method_decorator(check_user_can_manage_devices, name="dispatch")
 class VerifyOTPView(FormView):
     template_name = "otp_views/verify_otp.html"
     form_class = VerifyOTPForm
@@ -142,15 +152,10 @@ class VerifyOTPView(FormView):
         return get_safe_url(self.request, REDIRECT_FIELD_NAME, reverse("dashboard:index"))
 
 
-@check_user_for_otp
+@check_user_can_manage_devices
 def login_with_backup_code(request, template_name="otp_views/login_with_backup_code.html"):
     static_device = ItouStaticDevice.objects.filter(user=request.user).first()
     if not static_device:
-        if not get_user_devices(request.user):
-            # Direct access to this route without any enrolled device.
-            # Reject by redirecting to dashboard, user will be
-            # redirected if an OTP is required.
-            return HttpResponseRedirect(reverse("dashboard:index"))
         # If user enrolled a device after June 2026, they must have a
         # static device (backup code). If they enrolled before (which
         # is the case for most staff users), they don't have a static

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -1,10 +1,10 @@
 from django.utils import timezone
 
-from itou.otp.utils import _require_otp_for_pro, get_user_devices
+from itou.otp.utils import _require_otp_for_pro, get_user_devices, user_is_concerned_by_otp
 from tests.companies.factories import CompanyMembershipFactory
 from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
-from tests.users.factories import EmployerFactory, ItouStaffFactory, PrescriberFactory
+from tests.users.factories import EmployerFactory, ItouStaffFactory, JobSeekerFactory, PrescriberFactory
 
 
 def test_get_user_devices():
@@ -42,3 +42,39 @@ class TestRequireOtpForPro:
 
         settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
         assert _require_otp_for_pro(user)
+
+
+class TestUserIsConcernedByOtp:
+    def test_staff_depends_on_setting(self, settings):
+        user = ItouStaffFactory()
+
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        assert user_is_concerned_by_otp(user)
+
+    def test_professional_in_allowlisted_organization(self, settings):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = PrescriberFactory(membership=True)
+        org = user.prescriberorganization_set.get()
+
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_MFA_ON_ORGANIZATION_IDS = {org.id}
+        assert user_is_concerned_by_otp(user)
+
+    def test_professional_in_allowlisted_company(self, settings):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        company = user.company_set.get()
+
+        assert not user_is_concerned_by_otp(user)
+
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {company.id}
+        assert user_is_concerned_by_otp(user)
+
+    def test_job_seeker_is_never_concerned(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        settings.REQUIRE_MFA_FOR_PROS = True
+        assert not user_is_concerned_by_otp(JobSeekerFactory())

--- a/tests/otp/test_utils.py
+++ b/tests/otp/test_utils.py
@@ -1,6 +1,15 @@
+import pytest
 from django.utils import timezone
 
-from itou.otp.utils import _require_otp_for_pro, get_user_devices, user_is_concerned_by_otp
+from itou.otp.utils import (
+    _require_otp_for_pro,
+    create_placeholder_for_external_totp_device,
+    get_user_devices,
+    user_can_enroll_otp_device,
+    user_can_manage_otp_devices,
+    user_is_concerned_by_otp,
+    user_uses_external_mfa,
+)
 from tests.companies.factories import CompanyMembershipFactory
 from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
@@ -78,3 +87,48 @@ class TestUserIsConcernedByOtp:
         settings.REQUIRE_OTP_FOR_STAFF = True
         settings.REQUIRE_MFA_FOR_PROS = True
         assert not user_is_concerned_by_otp(JobSeekerFactory())
+
+
+class TestUserCanUseOtp:
+    """`user_can_enroll_otp_device` and `user_can_manage_otp_devices` gate both the OTP
+    section and its menu link."""
+
+    def test_not_concerned_by_otp(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        user = ItouStaffFactory()
+        ItouTOTPDeviceFactory(user=user)
+
+        assert not user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)
+
+    def test_concerned_by_otp(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+
+        # Without a device, there is nothing to manage yet
+        assert user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)
+
+        ItouTOTPDeviceFactory(user=user)
+        assert user_can_manage_otp_devices(user)
+
+    def test_disabled_device_is_ignored(self, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        ItouTOTPDeviceFactory(user=user, disabled_at=timezone.now())
+
+        assert not user_can_manage_otp_devices(user)
+
+    @pytest.mark.parametrize("with_device", [True, False])
+    def test_mfa_handled_by_identity_provider(self, settings, with_device):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        if with_device:
+            ItouTOTPDeviceFactory(user=user)
+        # Mimic `OtpMiddleware` for a session verified through ProConnect
+        user.otp_device = create_placeholder_for_external_totp_device(user)
+
+        assert user_uses_external_mfa(user)
+        # It would only confuse the user and our support team
+        assert not user_can_enroll_otp_device(user)
+        assert not user_can_manage_otp_devices(user)

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -82,6 +82,7 @@ from tests.institutions.factories import (
     InstitutionMembershipFactory,
 )
 from tests.job_applications.factories import JobApplicationFactory
+from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationFactory
 from tests.users.factories import (
     EmployerFactory,
@@ -1631,7 +1632,7 @@ def test_geiq_eligibility_badge(snapshot, is_eligible, for_job_seeker):
     assert badges.geiq_eligibility_badge(is_eligible=is_eligible, for_job_seeker=for_job_seeker) == snapshot
 
 
-def test_active_announcement_campaign_context_processor(client, empty_active_announcements_cache):
+def test_active_announcement_campaign_context_processor(client, settings, empty_active_announcements_cache):
     AnnouncementCampaignFactory(with_item=True, start_date=date.today().replace(day=1), live=True)
 
     response = client.get(reverse("search:employers_results"))
@@ -1643,7 +1644,12 @@ def test_active_announcement_campaign_context_processor(client, empty_active_ann
     assert response.status_code == 200
     assert response.context["display_campaign_announce"] is True
 
-    client.force_login(ItouStaffFactory())
+    # The OTP verification page is only reachable by a user who must use our own 2FA
+    settings.REQUIRE_OTP_FOR_STAFF = True
+    staff_user = ItouStaffFactory()
+    ItouTOTPDeviceFactory(user=staff_user)
+    client.force_login(staff_user)
+
     response = client.get(reverse("otp_views:verify_otp") + "?next=%2Fadmin%2F")
     assert response.status_code == 200
     assert response.context["display_campaign_announce"] is False

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -62,6 +62,42 @@ def test_permissions(client, factory, expected_status):
     assert response.status_code == expected_status
 
 
+class TestConfigurationOtpMenuLink:
+    """The "Configuration OTP" item in the "Mon espace" dropdown is shown to every user
+    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff."""
+
+    OTP_CONFIG_MARKUP = ">Configuration OTP</a>"
+
+    def _get_dashboard(self, client, user, verified=False):
+        client.force_login(user)
+        if verified:
+            # Mark the session verified so the OTP middleware does not redirect a concerned
+            # user to enrollment: the menu link must still show for a verified concerned user.
+            attach_device_to_user_session(client, ItouTOTPDeviceFactory(user=user))
+        return client.get(reverse("dashboard:index"), follow=True)
+
+    def test_hidden_for_job_seeker(self, client):
+        response = self._get_dashboard(client, JobSeekerFactory(with_address=True))
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    @pytest.mark.parametrize("is_concerned", [True, False])
+    def test_professional_depends_on_allowlist(self, client, settings, is_concerned):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        if is_concerned:
+            settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        response = self._get_dashboard(client, user, verified=is_concerned)
+        if is_concerned:
+            assertContains(response, self.OTP_CONFIG_MARKUP)
+        else:
+            assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    def test_visible_for_staff(self, client, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        response = self._get_dashboard(client, ItouStaffFactory(), verified=True)
+        assertContains(response, self.OTP_CONFIG_MARKUP)
+
+
 @freeze_time("2025-03-11 05:18:56")
 def test_device_list(client, snapshot):
     user = ItouStaffFactory()

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -360,6 +360,30 @@ class TestEnrollmentSteps2And3ConfirmDevice:
         backup_token = ItouStaticToken.objects.get()
         assert backup_token.check_token("secret-backup-code")
 
+    def test_unverified_user_with_device_cannot_enroll_another(self, client):
+        # Security regression (2FA bypass): a user who knows the password (first factor) but has
+        # NOT passed 2FA must not be able to enroll a brand-new device and be silently verified by
+        # `otp_login()`. The OTP middleware redirects them to `verify_otp` before the view runs.
+        user = ItouStaffFactory()
+        existing_device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)  # authenticated but NOT OTP-verified: no device attached to session
+
+        url = reverse("otp_views:enrollment_step_2_and_3_confirm_device")
+        fake_device = ItouTOTPDevice(key="8fe0a9983c7dddb4acb0146c5507553371e9f211")
+        data = {
+            "name": "attacker device",
+            "device_type": "smartphone",
+            "key": "R7QKTGB4PXO3JLFQCRWFKB2VGNY6T4QR",
+            "otp_token": TOTP(fake_device.bin_key).token(),
+        }
+        response = client.post(url, data)
+
+        # Redirected to verification instead of enrolling the new device...
+        assertRedirects(response, add_url_params(reverse("otp_views:verify_otp"), {"next": url}))
+        # ...no new device was created and the session is still unverified.
+        assert user.itou_totp_devices.exclude(pk=existing_device.pk).count() == 0
+        assert DEVICE_ID_SESSION_KEY not in client.session
+
     def test_post_invalid_totp(self, client):
         user = ItouStaffFactory()
         client.force_login(user)

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -19,7 +19,7 @@ from pytest_django.asserts import (
 )
 
 from itou.otp.models import ItouStaticDevice, ItouStaticToken, ItouTOTPDevice
-from itou.otp.utils import create_otp_backup_code
+from itou.otp.utils import create_otp_backup_code, create_placeholder_for_external_totp_device
 from itou.www.login.constants import ITOU_SESSION_LOGIN_EMAIL_KEY
 from itou.www.otp_views.forms import ConfirmTOTPDeviceForm
 from tests.otp.factories import ItouTOTPDeviceFactory
@@ -42,31 +42,106 @@ def attach_device_to_user_session(client, device):
     session.save()
 
 
-@pytest.mark.parametrize(
-    "factory,expected_status",
-    [
-        (JobSeekerFactory, 403),
-        (partial(EmployerFactory, membership=True), 200),
-        (partial(PrescriberFactory, membership=True), 200),
-        (partial(LaborInspectorFactory, membership=True), 200),
-        (ItouStaffFactory, 200),
-    ],
-)
-def test_permissions(client, factory, expected_status):
-    user = factory()
-    client.force_login(user)
-    response = client.get(reverse("otp_views:otp_devices"))
-    assert response.status_code == expected_status
+def attach_external_device_to_user_session(client, user):
+    # Mimic a ProConnect login through an identity provider that already implements MFA.
+    session = client.session
+    session[DEVICE_ID_SESSION_KEY] = create_placeholder_for_external_totp_device(user).persistent_id
+    session.save()
 
-    response = client.get(reverse("otp_views:enrollment_step_1_choose_device_type"))
-    assert response.status_code == expected_status
+
+OTP_URL_NAMES = [
+    "otp_devices",
+    "enrollment_step_0_intro",
+    "enrollment_step_1_choose_device_type",
+    "enrollment_step_2_and_3_confirm_device",
+    "verify_otp",
+    "login_with_backup_code",
+]
+ENROLLMENT_URL_NAMES = [
+    "enrollment_step_0_intro",
+    "enrollment_step_1_choose_device_type",
+]
+
+
+class TestPermissions:
+    """Pages of the OTP section are hidden (404) from users for whom our own 2FA is not
+    required: job seekers, users of an organization that is not in the allowlist, and users
+    whose identity provider already handled MFA for this session."""
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            JobSeekerFactory,
+            partial(EmployerFactory, membership=True),
+            partial(PrescriberFactory, membership=True),
+            partial(LaborInspectorFactory, membership=True),
+            ItouStaffFactory,
+        ],
+    )
+    def test_hidden_when_otp_is_not_required(self, client, factory, url_name, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = False
+        settings.REQUIRE_MFA_FOR_PROS = False
+        client.force_login(factory())
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_visible_for_a_concerned_user_with_a_device(self, client, settings, url_name):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        client.force_login(user)
+        attach_device_to_user_session(client, ItouTOTPDeviceFactory(user=user))
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        if url_name == "enrollment_step_2_and_3_confirm_device":
+            # without a `device_type` query param it redirects to step-1
+            assert response.status_code == 302
+        else:
+            assert response.status_code == 200
+
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_hidden_without_a_device_but_for_enrollment(self, client, settings, url_name):
+        # A concerned user without any enabled device is sent to enrollment by the middleware:
+        # the other pages have nothing to show
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)
+        attach_device_to_user_session(client, device)  # avoid the middleware redirection
+        device.disabled_at = timezone.now()
+        device.save(update_fields=["disabled_at"])
+
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        if url_name == "enrollment_step_2_and_3_confirm_device":
+            # without a `device_type` query param it redirects to step-1
+            assert response.status_code == 302
+        elif url_name in ENROLLMENT_URL_NAMES:
+            assert response.status_code == 200
+        else:
+            assert response.status_code == 404
+
+    @pytest.mark.parametrize("with_device", [True, False])
+    @pytest.mark.parametrize("url_name", OTP_URL_NAMES)
+    def test_hidden_when_mfa_comes_from_identity_provider(self, client, settings, url_name, with_device):
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        if with_device:
+            ItouTOTPDeviceFactory(user=user)  # shouldn't happen anyway
+        client.force_login(user)
+        attach_external_device_to_user_session(client, user)
+
+        response = client.get(reverse(f"otp_views:{url_name}"))
+        assert response.status_code == 404
 
 
 class TestConfigurationOtpMenuLink:
-    """The "Configuration OTP" item in the "Mon espace" dropdown is shown to every user
-    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff."""
+    """The "Configuration 2FA" item in the "Mon espace" dropdown is shown to every user
+    concerned by 2FA (`user_is_concerned_by_otp`), not only to staff, provided they enrolled
+    at least one device of ours (users whose identity provider handles MFA have nothing to
+    configure here)."""
 
-    OTP_CONFIG_MARKUP = ">Configuration OTP</a>"
+    OTP_CONFIG_MARKUP = ">Configuration 2FA</a>"
 
     def _get_dashboard(self, client, user, verified=False):
         client.force_login(user)
@@ -97,9 +172,34 @@ class TestConfigurationOtpMenuLink:
         response = self._get_dashboard(client, ItouStaffFactory(), verified=True)
         assertContains(response, self.OTP_CONFIG_MARKUP)
 
+    def test_hidden_when_mfa_comes_from_identity_provider(self, client, settings):
+        # The user is concerned by 2FA but was verified by ProConnect: they never enroll
+        # a TOTP device on our side, so there is nothing to configure
+        settings.REQUIRE_MFA_FOR_PROS = True
+        user = EmployerFactory(membership=True)
+        settings.REQUIRE_MFA_ON_COMPANY_IDS = {user.company_set.get().id}
+        client.force_login(user)
+        attach_external_device_to_user_session(client, user)
+        response = client.get(reverse("dashboard:index"), follow=True)
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+
+    def test_hidden_when_only_device_is_disabled(self, client, settings):
+        settings.REQUIRE_OTP_FOR_STAFF = True
+        user = ItouStaffFactory()
+        device = ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)
+        attach_device_to_user_session(client, device)
+        device.disabled_at = timezone.now()
+        device.save(update_fields=["disabled_at"])
+        response = client.get(reverse("dashboard:index"), follow=True)
+        assertNotContains(response, self.OTP_CONFIG_MARKUP)
+        # anyway, the user is redirected to enrollment by the middleware,
+        # they cannot reach the dashboard with a disabled device
+
 
 @freeze_time("2025-03-11 05:18:56")
-def test_device_list(client, snapshot):
+def test_device_list(client, snapshot, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
     device = ItouTOTPDeviceFactory(user=user, name="Mon appareil")
 
@@ -176,7 +276,8 @@ def test_delete_devices(client, snapshot, settings):
         assertMessages(response, [messages.Message(messages.SUCCESS, "L’appareil a été supprimé.")])
 
 
-def test_enrollment_step_0_intro(client):
+def test_enrollment_step_0_intro(client, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
 
     client.force_login(user)
@@ -185,7 +286,8 @@ def test_enrollment_step_0_intro(client):
     assertContains(response, "Nous vous guidons étape par étape")
 
 
-def test_enrollment_step_1_choose_device_type(client):
+def test_enrollment_step_1_choose_device_type(client, settings):
+    settings.REQUIRE_OTP_FOR_STAFF = True
     user = ItouStaffFactory()
 
     client.force_login(user)
@@ -195,6 +297,11 @@ def test_enrollment_step_1_choose_device_type(client):
 
 
 class TestEnrollmentSteps2And3ConfirmDevice:
+    @pytest.fixture(autouse=True)
+    def require_otp_for_staff(self, settings):
+        # Enrollment pages are only reachable when our own 2FA applies to the user
+        settings.REQUIRE_OTP_FOR_STAFF = True
+
     @pytest.mark.parametrize(
         "device_type,should_show_qr_code",
         (
@@ -280,6 +387,8 @@ class TestEnrollmentSteps2And3ConfirmDevice:
             name="existing",
             user=user,
         )
+        # The user already enrolled a device: they must be verified to add another one.
+        attach_device_to_user_session(client, existing_user_device)
         new_devices = user.itou_totp_devices.exclude(pk=existing_user_device.pk)
         fake_device = ItouTOTPDevice(key="8fe0a9983c7dddb4acb0146c5507553371e9f211")
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'entrée "Configuration OTP" du menu "Mon espace" (en bas à gauche) n'était visible que pour les membres du staff (`user.is_staff`), alors que la page `/otp/devices` sera bientôt aussi accessible par certains professionnels. Résultat : les professionnels concernés par la 2FA ne pouvaient pas accéder à la gestion de leurs appareils depuis le menu.

## :cake: Comment ?

- Extraction de la logique d'éligibilité `user_is_concerned_by_otp` de `require_otp` (on veut que le lien reste visible même après vérification en session).
- Nouveau tag de template `show_otp_configuration` pour exposer ce test au partial du menu (inclus avec `only`).
- Le lien est désormais affiché à tous les utilisateurs concernés par la 2FA : staff (selon `REQUIRE_OTP_FOR_STAFF`) et professionnels d'une organisation / entreprise de la liste MFA.
- Ajout de tests sur l'éligibilité et sur l'affichage du lien selon le type d'utilisateur.

## :computer: Captures d'écran

<img width="2876" height="1799" alt="image" src="https://github.com/user-attachments/assets/baa77700-229a-4d35-93a3-735537531e4a" />

