### PR TITLE
Candidature: Désactivation des candidatures spontanées pour les employeurs n'ayant pas actualisé depuis > 90 jours

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -34,6 +34,7 @@
   "45 3 * * * $ROOT/clevercloud/run_management_command.sh migrate_resume_to_private --wet-run",
   "0 4 * * * $ROOT/clevercloud/run_management_command.sh metabase_data stalled-job-seekers --wet-run",
   "30 4 * * * $ROOT/clevercloud/run_management_command.sh redact_zendesk_attachments",
+  "45 4 * * * $ROOT/clevercloud/run_management_command.sh deactivate_spontaneous_jobapps",
   "0 5 * * * $ROOT/clevercloud/run_management_command.sh deactivate_old_job_descriptions",
   "15 5 * * * $ROOT/clevercloud/run_management_command.sh prolongation_requests_chores email_reminder --wet-run",
   "45 5 * * * $ROOT/clevercloud/run_management_command.sh migrate_resume_to_private --wet-run",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -913,5 +913,5 @@ def _read_id_list(relative_path: str) -> set:
 REQUIRE_MFA_ON_COMPANY_IDS = _read_id_list("otp/data/mfa_required_companies.csv")
 REQUIRE_MFA_ON_ORGANIZATION_IDS = _read_id_list("otp/data/mfa_required_organizations.csv")
 
-# Delay until job descriptions are deactivated
+# Delay until job descriptions or spontaneous job applications are deactivated
 DEACTIVATION_DELAY = datetime.timedelta(days=90)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -912,3 +912,6 @@ def _read_id_list(relative_path: str) -> set:
 
 REQUIRE_MFA_ON_COMPANY_IDS = _read_id_list("otp/data/mfa_required_companies.csv")
 REQUIRE_MFA_ON_ORGANIZATION_IDS = _read_id_list("otp/data/mfa_required_organizations.csv")
+
+# Delay until job descriptions are deactivated
+DEACTIVATION_DELAY = datetime.timedelta(days=90)

--- a/itou/companies/management/commands/deactivate_old_job_descriptions.py
+++ b/itou/companies/management/commands/deactivate_old_job_descriptions.py
@@ -1,5 +1,4 @@
-import datetime
-
+from django.conf import settings
 from django.db.models import Prefetch
 from django.utils import timezone
 
@@ -8,7 +7,6 @@ from itou.companies.notifications import OldJobDescriptionDeactivationNotificati
 from itou.utils.command import BaseCommand
 
 
-DEACTIVATION_DELAY = datetime.timedelta(days=90)
 BATCH_SIZE = 200  # Limit the number of sent notifications by limiting the number of deactivated job descriptions
 
 
@@ -19,7 +17,7 @@ class Command(BaseCommand):
         old_job_descriptions_qs = (
             JobDescription.objects.active()
             .is_internal()  # Exclude external sources such as FT API
-            .exclude(last_employer_update_at__gte=timezone.now() - DEACTIVATION_DELAY)
+            .exclude(last_employer_update_at__gte=timezone.now() - settings.DEACTIVATION_DELAY)
         )
         old_job_descriptions = list(
             old_job_descriptions_qs.select_related("company", "appellation", "location")

--- a/itou/companies/management/commands/deactivate_old_job_descriptions.py
+++ b/itou/companies/management/commands/deactivate_old_job_descriptions.py
@@ -39,5 +39,5 @@ class Command(BaseCommand):
                 ).send()
         self.logger.info(f"Deactivated {deactivated_nb} JobDescriptions")
         # More than one day delay
-        if old_job_descriptions_qs.count() > BATCH_SIZE:
-            self.logger.error("Too many old JobDescriptions to deactivate")
+        if (count := old_job_descriptions_qs.count()) > BATCH_SIZE:
+            self.logger.error(f"Too many old JobDescriptions to deactivate: {count}")

--- a/itou/companies/management/commands/deactivate_spontaneous_jobapps.py
+++ b/itou/companies/management/commands/deactivate_spontaneous_jobapps.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.db.models import Prefetch, Q
+from django.utils import timezone
+
+from itou.companies.models import Company, CompanyMembership
+from itou.companies.notifications import SpontaneousJobApplicationsDeactivationNotification
+from itou.utils.command import BaseCommand
+
+
+BATCH_SIZE = 200
+
+
+class Command(BaseCommand):
+    """
+    Deactivates spontaneous job applications for companies that haven't updated this method of recruitment in 90 days.
+    """
+
+    ATOMIC_HANDLE = True
+
+    def handle(self, verbosity, **options):
+        companies_without_update_qs = Company.objects.exclude(
+            Q(spontaneous_applications_open_since__gte=timezone.now() - settings.DEACTIVATION_DELAY)
+            | Q(spontaneous_applications_open_since__isnull=True)
+        ).order_by("spontaneous_applications_open_since")
+        companies_without_update = list(
+            companies_without_update_qs.prefetch_related(
+                Prefetch("memberships", queryset=CompanyMembership.objects.select_related("user"))
+            )[:BATCH_SIZE]
+        )
+        deactivated_companies_nb = Company.objects.filter(
+            pk__in=[company.pk for company in companies_without_update]
+        ).update(spontaneous_applications_open_since=None)
+        for company in companies_without_update:
+            # Only send to active members (the default manager checks both the user and membership is_active statuses)
+            for membership in company.memberships.all():
+                SpontaneousJobApplicationsDeactivationNotification(membership.user, company).send()
+        self.logger.info(f"Deactivated spontaneous job applications for {deactivated_companies_nb} Companies")
+        if (count := companies_without_update_qs.count()) > BATCH_SIZE:
+            self.logger.error(f"Too many Companies to deactivate spontaneous job applications for: {count}")

--- a/itou/companies/notifications.py
+++ b/itou/companies/notifications.py
@@ -11,3 +11,13 @@ class OldJobDescriptionDeactivationNotification(EmailNotification, ProfessionalN
     category = NotificationCategory.JOB_DESCRIPTION
     subject_template = "companies/email/old_job_description_deactivated_subject.txt"
     body_template = "companies/email/old_job_description_deactivated_body.txt"
+
+
+@notifications_registry.register
+class SpontaneousJobApplicationsDeactivationNotification(EmailNotification, ProfessionalNotification):
+    """Notification sent to the members of a company when spontaneous applications are deactivated"""
+
+    name = "Désactivation des candidatures spontanées"
+    category = NotificationCategory.JOB_APPLICATION
+    subject_template = "companies/email/spontaneous_jobapps_deactivated_subject.txt"
+    body_template = "companies/email/spontaneous_jobapps_deactivated_body.txt"

--- a/itou/templates/companies/email/spontaneous_jobapps_deactivated_body.txt
+++ b/itou/templates/companies/email/spontaneous_jobapps_deactivated_body.txt
@@ -1,0 +1,16 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Nous vous informons que la réception des candidatures spontanées pour la structure {{ structure.kind }} {{ structure.display_name }} a été suspendue automatiquement, car ce mode de recrutement n’a pas été actualisé depuis plus de 3 mois.
+
+Si vous souhaitez continuer à recevoir des candidatures spontanées, vous pouvez réactiver cette fonctionnalité depuis votre espace :
+
+Structure > Métiers et recrutements sur les Emplois de l’inclusion
+
+Si vous ne recrutez plus actuellement, aucune action de votre part n’est nécessaire.
+
+Cette mesure vise à garantir que les candidats adressent leurs candidatures spontanées à des structures dont les recrutements sont toujours d’actualité et à maintenir des opportunités de recrutement à jour.
+
+Cordialement,
+{% endblock body%}

--- a/itou/templates/companies/email/spontaneous_jobapps_deactivated_subject.txt
+++ b/itou/templates/companies/email/spontaneous_jobapps_deactivated_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+La réception des candidatures spontanées pour votre structure a été suspendue
+{% endblock %}

--- a/tests/companies/__snapshots__/test_management_commands.ambr
+++ b/tests/companies/__snapshots__/test_management_commands.ambr
@@ -611,3 +611,520 @@
 # name: test_deactivate_old_job_description[email subject]
   '[TEST] Votre fiche de poste Agent / Agente cariste de livraison ferroviaire à Vannes - 56 a été dépubliée'
 # ---
+# name: test_deactivate_spontaneous_jobapps[SQL]
+  dict({
+    'num_queries': 21,
+    'queries': list([
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "companies_company"
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND NOT ("companies_company"."kind" IN (%s,
+                                                         %s))
+                 AND NOT ((("companies_company"."spontaneous_applications_open_since" >= %s
+                            AND "companies_company"."spontaneous_applications_open_since" IS NOT NULL)
+                           OR "companies_company"."spontaneous_applications_open_since" IS NULL)))
+          ORDER BY "companies_company"."spontaneous_applications_open_since" ASC
+          LIMIT 200
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" IN (%s))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          UPDATE "companies_company"
+          SET "spontaneous_applications_open_since" = NULL
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND NOT ("companies_company"."kind" IN (%s,
+                                                         %s))
+                 AND "companies_company"."id" IN (%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'SpontaneousJobApplicationsDeactivationNotification.should_send[communications/dispatch/base.py]',
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "communications_notificationsettings"
+          INNER JOIN "communications_disablednotification" ON ("communications_notificationsettings"."id" = "communications_disablednotification"."settings_id")
+          INNER JOIN "communications_notificationrecord" ON ("communications_disablednotification"."notification_record_id" = "communications_notificationrecord"."id")
+          WHERE ("communications_notificationsettings"."user_id" = %s
+                 AND "communications_notificationsettings"."structure_pk" = %s
+                 AND "communications_notificationsettings"."structure_type_id" = %s
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'SpontaneousJobApplicationsDeactivationNotification.should_send[communications/dispatch/base.py]',
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "communications_notificationsettings"
+          INNER JOIN "communications_disablednotification" ON ("communications_notificationsettings"."id" = "communications_disablednotification"."settings_id")
+          INNER JOIN "communications_notificationrecord" ON ("communications_disablednotification"."notification_record_id" = "communications_notificationrecord"."id")
+          WHERE ("communications_notificationsettings"."user_id" = %s
+                 AND "communications_notificationsettings"."structure_pk" = %s
+                 AND "communications_notificationsettings"."structure_type_id" = %s
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'SpontaneousJobApplicationsDeactivationNotification.send[communications/dispatch/email.py]',
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.handle[companies/management/commands/deactivate_spontaneous_jobapps.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "companies_company"
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND NOT ("companies_company"."kind" IN (%s,
+                                                         %s))
+                 AND NOT ((("companies_company"."spontaneous_applications_open_since" >= %s
+                            AND "companies_company"."spontaneous_applications_open_since" IS NOT NULL)
+                           OR "companies_company"."spontaneous_applications_open_since" IS NULL)))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': '''
+          SELECT "emails_email"."id",
+                 "emails_email"."to",
+                 "emails_email"."cc",
+                 "emails_email"."bcc",
+                 "emails_email"."subject",
+                 "emails_email"."body_text",
+                 "emails_email"."from_email",
+                 "emails_email"."reply_to",
+                 "emails_email"."created_at",
+                 "emails_email"."esp_response"
+          FROM "emails_email"
+          WHERE "emails_email"."id" = %s
+          LIMIT 21
+          FOR NO KEY
+          UPDATE OF "emails_email"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': '''
+          UPDATE "emails_email"
+          SET "esp_response" = NULL
+          WHERE "emails_email"."id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': '''
+          SELECT "emails_email"."id",
+                 "emails_email"."to",
+                 "emails_email"."cc",
+                 "emails_email"."bcc",
+                 "emails_email"."subject",
+                 "emails_email"."body_text",
+                 "emails_email"."from_email",
+                 "emails_email"."reply_to",
+                 "emails_email"."created_at",
+                 "emails_email"."esp_response"
+          FROM "emails_email"
+          WHERE "emails_email"."id" = %s
+          LIMIT 21
+          FOR NO KEY
+          UPDATE OF "emails_email"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': '''
+          UPDATE "emails_email"
+          SET "esp_response" = NULL
+          WHERE "emails_email"."id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          '_async_send_message[emails/tasks.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: test_deactivate_spontaneous_jobapps[email body]
+  '''
+  Bonjour,
+  
+  Nous vous informons que la réception des candidatures spontanées pour la structure EI Black Mesa a été suspendue automatiquement, car ce mode de recrutement n’a pas été actualisé depuis plus de 3 mois.
+  
+  Si vous souhaitez continuer à recevoir des candidatures spontanées, vous pouvez réactiver cette fonctionnalité depuis votre espace :
+  
+  Structure > Métiers et recrutements sur les Emplois de l’inclusion
+  
+  Si vous ne recrutez plus actuellement, aucune action de votre part n’est nécessaire.
+  
+  Cette mesure vise à garantir que les candidats adressent leurs candidatures spontanées à des structures dont les recrutements sont toujours d’actualité et à maintenir des opportunités de recrutement à jour.
+  
+  Cordialement,
+  
+  ---
+  [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
+  Les emplois de l'inclusion
+  http://localhost:8000/
+  '''
+# ---
+# name: test_deactivate_spontaneous_jobapps[email subject]
+  '[TEST] La réception des candidatures spontanées pour votre structure a été suspendue'
+# ---

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -334,10 +334,10 @@ def test_update_companies_coords(settings, capsys, respx_mock):
     assert company_3.coords.y == 42.42
 
 
-def test_deactivate_old_job_description(snapshot, mailoutbox, django_capture_on_commit_callbacks, caplog):
+def test_deactivate_old_job_description(snapshot, mailoutbox, django_capture_on_commit_callbacks, caplog, settings):
     create_test_romes_and_appellations(("N1101",))
     old_job_description_1 = companies_factories.JobDescriptionFactory(
-        last_employer_update_at=timezone.now() - datetime.timedelta(days=90),
+        last_employer_update_at=timezone.now() - settings.DEACTIVATION_DELAY,
         company__with_membership=True,
         company__for_snapshot=True,
         for_snapshot=True,
@@ -360,7 +360,7 @@ def test_deactivate_old_job_description(snapshot, mailoutbox, django_capture_on_
         source_kind=JobSource.PE_API,
     )
     recently_updated_job_description = companies_factories.JobDescriptionFactory(
-        last_employer_update_at=timezone.now() - datetime.timedelta(days=89),
+        last_employer_update_at=timezone.now() - settings.DEACTIVATION_DELAY + datetime.timedelta(days=1),
         location=None,
     )
     assert JobDescription.objects.active().count() == 4
@@ -385,10 +385,10 @@ def test_deactivate_old_job_description(snapshot, mailoutbox, django_capture_on_
     assert mail.body == snapshot(name="email body")
 
 
-def test_deactivate_old_job_description_batch_size(mocker, caplog):
+def test_deactivate_old_job_description_batch_size(mocker, caplog, settings):
     create_test_romes_and_appellations(("N1101",))
     companies_factories.JobDescriptionFactory.create_batch(
-        3, last_employer_update_at=timezone.now() - datetime.timedelta(days=90)
+        3, last_employer_update_at=timezone.now() - settings.DEACTIVATION_DELAY
     )
     assert JobDescription.objects.active().count() == 3
     mocker.patch("itou.companies.management.commands.deactivate_old_job_descriptions.BATCH_SIZE", 1)

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -396,7 +396,7 @@ def test_deactivate_old_job_description_batch_size(mocker, caplog, settings):
     management.call_command("deactivate_old_job_descriptions")
     assert JobDescription.objects.active().count() == 2
     assert [record.message for record in caplog.records if record.levelname == "ERROR"] == [
-        "Too many old JobDescriptions to deactivate"
+        "Too many old JobDescriptions to deactivate: 2"
     ]
 
     caplog.clear()

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -403,3 +403,52 @@ def test_deactivate_old_job_description_batch_size(mocker, caplog, settings):
     management.call_command("deactivate_old_job_descriptions")
     assert JobDescription.objects.active().count() == 1
     assert [record.message for record in caplog.records if record.levelname == "ERROR"] == []
+
+
+def test_deactivate_spontaneous_jobapps(snapshot, mailoutbox, django_capture_on_commit_callbacks, caplog, settings):
+    company = companies_factories.CompanyWith2MembershipsFactory(
+        name="Black Mesa",
+        kind=CompanyKind.EI,
+        spontaneous_applications_open_since=timezone.now() - settings.DEACTIVATION_DELAY,
+    )
+    # Inactive memberships or users should not receive the mail
+    companies_factories.CompanyMembershipFactory(company=company, is_admin=False, is_active=False)
+    companies_factories.CompanyMembershipFactory(company=company, is_admin=False, user__is_active=False)
+
+    with assertSnapshotQueries(snapshot(name="SQL")):
+        with django_capture_on_commit_callbacks(execute=True):
+            management.call_command("deactivate_spontaneous_jobapps")
+
+    company.refresh_from_db()
+    assert company.spontaneous_applications_open_since is None
+    assert not company.is_open_to_spontaneous_applications
+
+    assert caplog.messages[:-1] == ["Deactivated spontaneous job applications for 1 Companies"]
+    assert len(mailoutbox) == 2
+
+    assert set(sum((mail.to for mail in mailoutbox), [])) == set(
+        company.memberships.values_list("user__email", flat=True)
+    )
+    mail = next(mail for mail in mailoutbox if mail.to == [company.members.first().email])
+    assert mail.subject == snapshot(name="email subject")
+    assert mail.body == snapshot(name="email body")
+
+
+def test_deactivate_spontaneous_jobapps_batch_size(mocker, caplog, settings):
+    companies_factories.CompanyMembershipFactory.create_batch(
+        3,
+        company__spontaneous_applications_open_since=timezone.now() - settings.DEACTIVATION_DELAY,
+    )
+    assert Company.objects.filter(spontaneous_applications_open_since__isnull=False).count() == 3
+    mocker.patch("itou.companies.management.commands.deactivate_spontaneous_jobapps.BATCH_SIZE", 1)
+
+    management.call_command("deactivate_spontaneous_jobapps")
+    assert Company.objects.filter(spontaneous_applications_open_since__isnull=False).count() == 2
+    assert [record.message for record in caplog.records if record.levelname == "ERROR"] == [
+        "Too many Companies to deactivate spontaneous job applications for: 2",
+    ]
+
+    caplog.clear()
+    management.call_command("deactivate_spontaneous_jobapps")
+    assert Company.objects.filter(spontaneous_applications_open_since__isnull=False).count() == 1
+    assert [record.message for record in caplog.records if record.levelname == "ERROR"] == []

--- a/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
@@ -831,6 +831,7 @@
                                                                                   %s,
                                                                                   %s,
                                                                                   %s,
+                                                                                  %s,
                                                                                   %s))
           ORDER BY "communications_notificationrecord"."category" ASC,
                    "communications_notificationrecord"."name" ASC
@@ -860,6 +861,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,
@@ -1617,6 +1619,7 @@
                                                                                   %s,
                                                                                   %s,
                                                                                   %s,
+                                                                                  %s,
                                                                                   %s))
           ORDER BY "communications_notificationrecord"."category" ASC,
                    "communications_notificationrecord"."name" ASC
@@ -1646,6 +1649,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,
@@ -2453,6 +2457,7 @@
                                                                                   %s,
                                                                                   %s,
                                                                                   %s,
+                                                                                  %s,
                                                                                   %s))
           ORDER BY "communications_notificationrecord"."category" ASC,
                    "communications_notificationrecord"."name" ASC
@@ -2482,6 +2487,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Des règles de gestion ont été mises en place pour dépublier les fiches de postes non-actualisées depuis 90 jours. Les candidatures spontanées sont également concernées par ces règles et doivent être désactivées pour les entreprises qui n'ont pas mis à jour ce moyen de recrutement depuis 90 jours.
[Carte Notion](https://app.notion.com/p/gip-inclusion/Int-grer-les-candidatures-spontan-es-aux-r-gles-de-gestion-de-d-publication-des-fiches-de-poste-3965f321b6048026b2ffdba4bf7522ad)

## :cake: Comment ? <!-- optionnel -->

Ajout d'une nouvelle commande séparée pour désactiver les candidatures spontanées chez les entreprises concernées.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
