### PR TITLE
Performances : Réduction du nombre de lignes de candidats traitées par batch lors de l'envoi à Metabase

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -455,7 +455,7 @@ class Command(BaseCommand):
         )
         job_seekers_table = job_seekers.get_table()
 
-        metabase_db.populate_table(job_seekers_table, batch_size=20_000, querysets=[queryset])
+        metabase_db.populate_table(job_seekers_table, batch_size=10_000, querysets=[queryset])
 
     def populate_criteria(self):
         queryset = AdministrativeCriteria.objects.all()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Probable OOM.

Refs: https://gip-inclusion.slack.com/archives/C0412CTV63D/p1783951460954159

## :cake: Comment ? <!-- optionnel -->

Passage d'un batch de 20000 à un batch de 10000 pour cette table.
