### PR TITLE
Tech: Surveiller l'age de notre mot de passe pour le portail INSEE

### DIFF
--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -1,14 +1,40 @@
+import datetime
 import json
 import logging
 from dataclasses import dataclass
 
 import httpx
+import jwt
 from django.conf import settings
+from django.core.cache import caches
+from django.utils import timezone
 
 from itou.common_apps.address.departments import department_from_postcode
+from itou.utils.slack import send_slack_message
 
 
 logger = logging.getLogger(__name__)
+
+INSEE_EXPIRY_ALREADY_NOTIFIED_CACHE_KEY = "INSEE_EXPIRY_ALREADY_NOTIFIED"
+
+
+def check_and_warn_password_renewal(access_token):
+    cache = caches["failsafe"]
+    if cache.get(INSEE_EXPIRY_ALREADY_NOTIFIED_CACHE_KEY):
+        return
+    # The documentation does not explain where to retrieve the public key required to check the jwt signature
+    token_content = jwt.decode(access_token, options={"verify_signature": False})
+    password_changed_date = timezone.localdate(
+        datetime.datetime.strptime(token_content["pwdChangedTime"], "%Y%m%d%H%M%S%z")
+    )
+    expiry_date = password_changed_date + datetime.timedelta(days=90)
+    if timezone.localdate() >= expiry_date - datetime.timedelta(days=15):
+        send_slack_message(
+            f"Le mot de passe INSEE va expirer le {expiry_date}, "
+            "merci de le modifier sur https://portail-api.insee.fr et "
+            "de le changer dans les settings (API_INSEE_PASSWORD)",
+        )
+    cache.set(INSEE_EXPIRY_ALREADY_NOTIFIED_CACHE_KEY, True, timeout=60 * 60 * 24)  # Skip for one day
 
 
 @dataclass
@@ -43,6 +69,7 @@ def get_access_token():
         logger.exception("Failed to retrieve an access token")
         return None
     else:
+        check_and_warn_password_renewal(access_token)
         return access_token
 
 

--- a/itou/utils/mocks/api_entreprise.py
+++ b/itou/utils/mocks/api_entreprise.py
@@ -1,9 +1,16 @@
-import uuid
+import jwt
+
+
+def generate_insee_access_token(payload=None):
+    payload = payload or {
+        "pwdChangedTime": "20500101000000Z",  # There are other fields, but it's the only one we use
+    }
+    return jwt.encode(payload, key="x" * 64, algorithm="HS256")
 
 
 # Result for a call to: https://api.insee.fr/token
 INSEE_API_RESULT_MOCK = {
-    "access_token": str(uuid.uuid4()),
+    "access_token": generate_insee_access_token(),
 }
 
 # Result for a call to: https://api.insee.fr/entreprises/sirene/V3/siret/26570134200148?masquerValeursNulles=true

--- a/tests/utils/apis/test_entreprise_api.py
+++ b/tests/utils/apis/test_entreprise_api.py
@@ -6,9 +6,15 @@ import httpx
 import pytest
 import respx
 from django.conf import settings
+from django.core.cache import caches
+from freezegun import freeze_time
 
 from itou.utils.apis import api_entreprise
-from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
+from itou.utils.mocks.api_entreprise import (
+    ETABLISSEMENT_API_RESULT_MOCK,
+    INSEE_API_RESULT_MOCK,
+    generate_insee_access_token,
+)
 
 
 class TestINSEEApi:
@@ -52,6 +58,42 @@ class TestINSEEApi:
         assert access_token is None
         assert "Failed to retrieve an access token" in caplog.records[0].message
         assert caplog.records[0].exc_info[0] is json.JSONDecodeError
+
+    def test_password_expiry(self, mocker, respx_mock):
+        access_token = generate_insee_access_token({"pwdChangedTime": "20260901102354Z"})
+        respx_mock.post(f"{settings.API_INSEE_AUTH_URL}/token").respond(200, json={"access_token": access_token})
+        slack_mock = mocker.patch("itou.utils.apis.api_entreprise.send_slack_message")
+        cache = caches["failsafe"]
+
+        with freeze_time() as frozen_time:
+            frozen_time.move_to("2026-09-11")
+            api_entreprise.get_access_token()
+            assert slack_mock.mock_calls == []
+            cache.delete(api_entreprise.INSEE_EXPIRY_ALREADY_NOTIFIED_CACHE_KEY)
+
+            # 16 days before the expiry date
+            frozen_time.move_to("2026-11-14")
+            api_entreprise.get_access_token()
+            assert slack_mock.mock_calls == []
+            cache.delete(api_entreprise.INSEE_EXPIRY_ALREADY_NOTIFIED_CACHE_KEY)
+
+            # 15 days before the expiry date
+            frozen_time.move_to("2026-11-15")
+            api_entreprise.get_access_token()
+            assert slack_mock.mock_calls == [
+                mocker.call(
+                    "Le mot de passe INSEE va expirer le 2026-11-30, merci de le modifier sur "
+                    "https://portail-api.insee.fr et de le changer dans les settings (API_INSEE_PASSWORD)"
+                )
+            ]
+            slack_mock.reset_mock()
+
+            # call again in the next following 24h
+            frozen_time.move_to("2026-11-15 01:00:00")
+            api_entreprise.get_access_token()
+            assert slack_mock.mock_calls == []
+
+            # We cannot check the cache duration since it's handled in redis
 
 
 class TestApiEntreprise:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce mot de passe a une durée de vie de 3 mois et est utilisé à la fois pour accéder au portail web et pour accéder à l'API SIRENE privée.

On le stock dans notre gestionnaire de mots de passe et dans nos settings de production ce qui empêche de le faire automatiquement via API depuis les emplois.

On va juste loguer dans sentry quand il faut l changer.


Il faudrait limiter à un log par jour, ou alors trouver une solution alternative (mail envoyé à tech@ par exemple également une fois par jours)
 
## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
