### PR TITLE
Tech: Ajout des contrôles a posteriori et des bilans d'exécution à la commande `move_company_data`

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -16,7 +16,6 @@ from itou.common_apps.organizations.admin import HasMembersFilter, MembersInline
 from itou.companies import enums, models, transfer
 from itou.companies.admin_forms import CompanyChooseFieldsToTransfer, SelectTargetCompanyForm
 from itou.companies.enums import POLE_EMPLOI_SIRET, CompanySource
-from itou.siae_evaluations.models import EvaluatedSiae
 from itou.utils.admin import (
     CreatedOrUpdatedByMixin,
     ItouGISMixin,
@@ -355,70 +354,56 @@ class CompanyAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
                         )
                     )
 
-            siae_evaluations = EvaluatedSiae.objects.filter(siae=from_company).exists()
             form = CompanyChooseFieldsToTransfer(
                 fields_choices=sorted(fields_choices, key=lambda field: field[1]),
-                siae_evaluations=siae_evaluations,
                 data=request.POST or None,
             )
             if request.POST and form.is_valid():
-                if siae_evaluations and not form.cleaned_data["ignore_siae_evaluations"]:
-                    messages.error(
-                        request,
-                        (
-                            f"Impossible de transférer les objets de l'entreprise ID={from_company.pk}: "
-                            "il y a un contrôle a posteriori lié. Vérifiez avec l'équipe support."
-                        ),
+                fields_to_transfer = form.cleaned_data["fields_to_transfer"]
+                disable_from_company = form.cleaned_data["disable_from_company"]
+                try:
+                    reporter = transfer.transfer_company_data(
+                        from_company,
+                        to_company,
+                        fields_to_transfer=fields_to_transfer,
+                        disable_from_company=disable_from_company,
                     )
+                except transfer.TransferError as e:
+                    messages.error(request, e.args[0])
                 else:
-                    fields_to_transfer = form.cleaned_data["fields_to_transfer"]
-                    disable_from_company = form.cleaned_data["disable_from_company"]
-                    ignore_siae_evaluations = form.cleaned_data.get("ignore_siae_evaluations", False)
-                    try:
-                        reporter = transfer.transfer_company_data(
-                            from_company,
-                            to_company,
-                            fields_to_transfer=fields_to_transfer,
-                            disable_from_company=disable_from_company,
-                            ignore_siae_evaluations=ignore_siae_evaluations,
-                        )
-                    except transfer.TransferError as e:
-                        messages.error(request, e.args[0])
-                    else:
-                        summary_lines = [
-                            "-" * 20,
-                            f"Transfert du {timezone.now():%Y-%m-%d %H:%M:%S} effectué par {request.user} ",
-                            f"de l'entreprise {from_company.pk} vers {to_company.pk}:",
-                        ]
-                        for report_field, items in reporter.changes.items():
-                            if items:
-                                summary_lines.extend([f"- {report_field.label}:"] + [f"  * {item}" for item in items])
-                        summary_lines += ["-" * 20]
-                        summary_text = "\n".join(summary_lines)
-                        bulk_add_support_remark_to_objs([from_company, to_company], summary_text)
-                        message = format_html(
-                            "Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}.",
-                            from_company=from_company,
-                            to_company=to_company,
-                        )
-                        messages.info(request, message)
-                        logger.info(
-                            "staff user=%d transferred company=%d to company=%d with fields_to_transfer=%s, "
-                            "disable_from_company=%s, ignore_siae_evaluations=%s",
-                            request.user.pk,
-                            from_company.pk,
-                            to_company.pk,
-                            fields_to_transfer,
-                            disable_from_company,
-                            ignore_siae_evaluations,
-                        )
+                    summary_lines = [
+                        "-" * 20,
+                        f"Transfert du {timezone.now():%Y-%m-%d %H:%M:%S} effectué par {request.user} ",
+                        f"de l'entreprise {from_company.pk} vers {to_company.pk}:",
+                    ]
+                    for report_field, items in reporter.changes.items():
+                        if items:
+                            summary_lines.extend([f"- {report_field.label}:"] + [f"  * {item}" for item in items])
+                    summary_lines += ["-" * 20]
+                    summary_text = "\n".join(summary_lines)
+                    bulk_add_support_remark_to_objs([from_company, to_company], summary_text)
+                    message = format_html(
+                        "Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}.",
+                        from_company=from_company,
+                        to_company=to_company,
+                    )
+                    messages.info(request, message)
+                    logger.info(
+                        "staff user=%d transferred company=%d to company=%d with fields_to_transfer=%s, "
+                        "disable_from_company=%s",
+                        request.user.pk,
+                        from_company.pk,
+                        to_company.pk,
+                        fields_to_transfer,
+                        disable_from_company,
+                    )
 
-                        return redirect(
-                            reverse(
-                                "admin:companies_company_change",
-                                kwargs={"object_id": from_company.pk},
-                            )
+                    return redirect(
+                        reverse(
+                            "admin:companies_company_change",
+                            kwargs={"object_id": from_company.pk},
                         )
+                    )
         title = f"Transfert des données de '{from_company}' [{from_company.kind}]"
         if to_company:
             title += f" vers '{to_company}' [{to_company.kind}]"

--- a/itou/companies/admin_forms.py
+++ b/itou/companies/admin_forms.py
@@ -37,11 +37,3 @@ class SelectTargetCompanyForm(forms.Form):
 
 class CompanyChooseFieldsToTransfer(ChooseFieldsToTransfer):
     disable_from_company = forms.BooleanField(label="Désactiver l’entreprise source", required=False, initial=True)
-
-    def __init__(self, *args, fields_choices, siae_evaluations, **kwargs):
-        super().__init__(*args, fields_choices=fields_choices, **kwargs)
-        if siae_evaluations:
-            self.fields["ignore_siae_evaluations"] = forms.BooleanField(
-                label="Ignorer la présence d'un contrôle a posteriori.",
-                required=True,
-            )

--- a/itou/companies/management/commands/move_company_data.py
+++ b/itou/companies/management/commands/move_company_data.py
@@ -54,12 +54,6 @@ class Command(BaseCommand):
             required=True,
         )
         parser.add_argument(
-            "--ignore-siae-evaluations",
-            action=argparse.BooleanOptionalAction,
-            default=False,
-            help="Set to True to move company data despite the <FROM> company having an SIAE evaluation.",
-        )
-        parser.add_argument(
             "--preserve-to-company-data",
             action=argparse.BooleanOptionalAction,
             default=False,
@@ -85,7 +79,6 @@ class Command(BaseCommand):
         from_id,
         to_id,
         *,
-        ignore_siae_evaluations,
         only_job_applications,
         preserve_to_company_data,
         allow_asp_to_user_created_transfer,
@@ -165,7 +158,6 @@ class Command(BaseCommand):
                     to_company,
                     fields_to_transfer,
                     disable_from_company=disable_from_company,
-                    ignore_siae_evaluations=ignore_siae_evaluations,
                     allow_asp_to_user_created_transfer=allow_asp_to_user_created_transfer,
                 )
                 for section, section_changes in reporter.changes.items():

--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -11,7 +11,7 @@ from itou.eligibility import models as eligibility_models
 from itou.employee_record.models import EmployeeRecord
 from itou.invitations import models as invitations_models
 from itou.job_applications import models as job_applications_models
-from itou.siae_evaluations.models import EvaluatedSiae
+from itou.siae_evaluations import models as siae_evaluations_models
 from itou.users import models as users_models
 from itou.users.utils import merge_job_seeker_assignments
 
@@ -19,6 +19,7 @@ from itou.users.utils import merge_job_seeker_assignments
 class TransferField(TextChoices):
     IAE_DIAG_CREATED = "iae_diag_created", "Diagnostics IAE créés"
     GEIQ_DIAG_CREATED = "geiq_diag_created", "Diagnostics GEIQ créés"
+    EVALUATED_SIAES = "evaluated_siaes", "Contrôles a posteriori IAE"
     JOB_APPLICATIONS_SENT = "job_applications_sent", "Candidatures envoyées"
     JOB_APPLICATIONS_RECEIVED = "job_applications_received", "Candidatures reçues"
     JOB_APPLICATIONS_TRANSFERRED = "job_applications_transferred", "Candidatures transférées"
@@ -51,6 +52,11 @@ TRANSFER_SPECS = {
         "related_model": eligibility_models.GEIQEligibilityDiagnosis,
         "related_model_field": "author_geiq",
         "geiq_only": True,
+    },
+    TransferField.EVALUATED_SIAES: {
+        "related_model": siae_evaluations_models.EvaluatedSiae,
+        "related_model_field": "siae",
+        "iae_only": True,
     },
     TransferField.JOB_APPLICATIONS_SENT: {
         "related_model": job_applications_models.JobApplication,
@@ -169,15 +175,9 @@ def transfer_company_data(
     to_company,
     fields_to_transfer,
     disable_from_company=False,
-    ignore_siae_evaluations=False,
     allow_asp_to_user_created_transfer=False,
 ):
     assert from_company.pk != to_company.pk, "Cannot transfer from one company to itself"
-    if not ignore_siae_evaluations and EvaluatedSiae.objects.filter(siae=from_company).exists():
-        raise TransferError(
-            f"Impossible de transférer les objets de l'entreprise ID={from_company.pk}: il y a un contrôle "
-            "a posteriori lié. Vérifiez avec l'équipe support."
-        )
     if (
         not allow_asp_to_user_created_transfer
         and from_company.source == CompanySource.ASP

--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -9,6 +9,7 @@ from itou.companies import enums, models
 from itou.companies.enums import CompanySource
 from itou.eligibility import models as eligibility_models
 from itou.employee_record.models import EmployeeRecord
+from itou.geiq_assessments import models as geiq_assessments_models
 from itou.invitations import models as invitations_models
 from itou.job_applications import models as job_applications_models
 from itou.siae_evaluations import models as siae_evaluations_models
@@ -20,6 +21,7 @@ class TransferField(TextChoices):
     IAE_DIAG_CREATED = "iae_diag_created", "Diagnostics IAE créés"
     GEIQ_DIAG_CREATED = "geiq_diag_created", "Diagnostics GEIQ créés"
     EVALUATED_SIAES = "evaluated_siaes", "Contrôles a posteriori IAE"
+    GEIQ_ASSESSMENTS = "geiq_assessments", "Bilans d'exécution GEIQ"
     JOB_APPLICATIONS_SENT = "job_applications_sent", "Candidatures envoyées"
     JOB_APPLICATIONS_RECEIVED = "job_applications_received", "Candidatures reçues"
     JOB_APPLICATIONS_TRANSFERRED = "job_applications_transferred", "Candidatures transférées"
@@ -57,6 +59,11 @@ TRANSFER_SPECS = {
         "related_model": siae_evaluations_models.EvaluatedSiae,
         "related_model_field": "siae",
         "iae_only": True,
+    },
+    TransferField.GEIQ_ASSESSMENTS: {
+        "related_model": geiq_assessments_models.Assessment.companies.through,
+        "related_model_field": "company",
+        "geiq_only": True,
     },
     TransferField.JOB_APPLICATIONS_SENT: {
         "related_model": job_applications_models.JobApplication,

--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -9,6 +9,7 @@ from itou.companies import enums, models
 from itou.companies.enums import CompanySource
 from itou.eligibility import models as eligibility_models
 from itou.employee_record.models import EmployeeRecord
+from itou.geiq_assessments import models as geiq_assessments_models
 from itou.invitations import models as invitations_models
 from itou.job_applications import models as job_applications_models
 from itou.siae_evaluations import models as siae_evaluations_models
@@ -20,6 +21,7 @@ class TransferField(TextChoices):
     IAE_DIAG_CREATED = "iae_diag_created", "Diagnostics IAE créés"
     GEIQ_DIAG_CREATED = "geiq_diag_created", "Diagnostics GEIQ créés"
     EVALUATED_SIAES = "evaluated_siaes", "Contrôles a posteriori IAE"
+    GEIQ_ASSESSMENTS = "geiq_assessments", "Bilans d'exécution GEIQ"
     JOB_APPLICATIONS_SENT = "job_applications_sent", "Candidatures envoyées"
     JOB_APPLICATIONS_RECEIVED = "job_applications_received", "Candidatures reçues"
     JOB_APPLICATIONS_TRANSFERRED = "job_applications_transferred", "Candidatures transférées"
@@ -57,6 +59,16 @@ TRANSFER_SPECS = {
         "related_model": siae_evaluations_models.EvaluatedSiae,
         "related_model_field": "siae",
         "iae_only": True,
+    },
+    TransferField.GEIQ_ASSESSMENTS: {
+        "related_model": geiq_assessments_models.Assessment.companies.through,
+        "related_model_field": "company",
+        "geiq_only": True,
+        "upsert": {
+            "key": {"assessment", "company"},
+            "fields": {},  # We're not upserting any field: we just need to delete `from_item`
+            "merge_function": lambda from_item, _: from_item.delete(),
+        },
     },
     TransferField.JOB_APPLICATIONS_SENT: {
         "related_model": job_applications_models.JobApplication,

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -391,8 +391,7 @@ class TestTransferCompanyData:
         assert "Candidatures reçues" in remark
         assert (
             f"staff user={get_user(admin_client).pk} transferred company={from_company.pk} to company={to_company.pk}"
-            " with fields_to_transfer=['job_applications_received'], disable_from_company=False,"
-            " ignore_siae_evaluations=False" in caplog.messages
+            " with fields_to_transfer=['job_applications_received'], disable_from_company=False" in caplog.messages
         )
 
     @freeze_time("2023-08-31 12:34:56")

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -106,25 +106,6 @@ class TestMoveCompanyData:
         company_1.refresh_from_db()
         assert company_1.is_searchable is False
 
-    def test_prevent_move_with_siae_evaluations(self, capsys):
-        company1 = EvaluatedSiaeFactory().siae
-        company2 = companies_factories.CompanyFactory()
-
-        management.call_command("move_company_data", from_id=company1.pk, to_id=company2.pk, wet_run=True)
-        _stdout, stderr = capsys.readouterr()
-        assert stderr == (
-            f"Impossible de transférer les objets de l'entreprise ID={company1.pk}: "
-            "il y a un contrôle a posteriori lié. Vérifiez avec l'équipe support.\n"
-        )
-
-        management.call_command(
-            "move_company_data", from_id=company1.pk, to_id=company2.pk, wet_run=True, ignore_siae_evaluations=True
-        )
-        stdout, stderr = capsys.readouterr()
-        assert stderr == ""
-        assert f"MOVE DATA OF company.id={company1.pk}" in stdout
-        assert f"INTO company.id={company2.pk}" in stdout
-
     def test_prevent_move_for_asp_to_user_created_companies(self, capsys):
         company1 = companies_factories.CompanyFactory(source=CompanySource.ASP)
         company2 = companies_factories.CompanyFactory(source=CompanySource.USER_CREATED)
@@ -235,6 +216,21 @@ class TestMoveCompanyData:
 
         job_application.refresh_from_db()
         assert job_application.transferred_from == company_to
+
+    def test_move_siae_evaluations(self):
+        evaluated_siae = EvaluatedSiaeFactory()
+        company_from = evaluated_siae.siae
+        company_to = companies_factories.CompanyFactory(subject_to_iae_rules=True)
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        evaluated_siae.refresh_from_db()
+        assert evaluated_siae.siae == company_to
 
 
 def test_update_companies_job_app_score(caplog):

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -17,6 +17,7 @@ from tests.approvals.factories import ProlongationRequestFactory
 from tests.cities.factories import create_city_guerande
 from tests.companies import factories as companies_factories
 from tests.eligibility import factories as eligibility_factories
+from tests.geiq_assessments.factories import AssessmentFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.siae_evaluations.factories import EvaluatedSiaeFactory
@@ -231,6 +232,21 @@ class TestMoveCompanyData:
 
         evaluated_siae.refresh_from_db()
         assert evaluated_siae.siae == company_to
+
+    def test_move_geiq_assessments(self):
+        company_from = companies_factories.CompanyFactory(kind=CompanyKind.GEIQ)
+        company_to = companies_factories.CompanyFactory(kind=CompanyKind.GEIQ)
+        assessment = AssessmentFactory(companies=[company_from])
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        assessment.refresh_from_db()
+        assertQuerySetEqual(assessment.companies.all(), [company_to])
 
 
 def test_update_companies_job_app_score(caplog):

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -17,6 +17,7 @@ from tests.approvals.factories import ProlongationRequestFactory
 from tests.cities.factories import create_city_guerande
 from tests.companies import factories as companies_factories
 from tests.eligibility import factories as eligibility_factories
+from tests.geiq_assessments.factories import AssessmentFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.siae_evaluations.factories import EvaluatedSiaeFactory
@@ -231,6 +232,35 @@ class TestMoveCompanyData:
 
         evaluated_siae.refresh_from_db()
         assert evaluated_siae.siae == company_to
+
+    def test_move_geiq_assessments(self):
+        company_from = companies_factories.CompanyFactory(kind=CompanyKind.GEIQ)
+        company_to = companies_factories.CompanyFactory(kind=CompanyKind.GEIQ)
+        assessment = AssessmentFactory(companies=[company_from])
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        assessment.refresh_from_db()
+        assertQuerySetEqual(assessment.companies.all(), [company_to])
+
+        # Check case where two GEIQ companies are part of the same assessment
+        assessment2 = AssessmentFactory(companies=[company_from, company_to])
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        assessment2.refresh_from_db()
+        assertQuerySetEqual(assessment2.companies.all(), [company_to])
+        assertQuerySetEqual(company_to.assessments.all(), [assessment, assessment2], ordered=False)
 
 
 def test_update_companies_job_app_score(caplog):


### PR DESCRIPTION
## :thinking: Pourquoi ?
Les bilans d'exécution pour les GEIQ ne sont pas transférés à l'entreprise cible lors de l'exécution de la commande. Pour les contrôles a posteriori, le transfert des données d'une entreprise à une autre est bloqué s'il existe des contrôles a posteriori.
[Carte Notion](https://app.notion.com/p/gip-inclusion/Ajouter-les-objets-bilans-d-ex-cution-et-contr-le-a-posteriori-la-commande-MOVE-SIAE-DATA-3755f321b60480b38351f1bb78bb49f2)

## :cake: Comment ? <!-- optionnel -->

On ajoute `EvaluatedSiae` à la liste des données transférées par la commande.
Idem pour les bilans  d'exécution ?

## :rotating_light: À vérifier

J'ai des doutes sur la simplicité de la manœuvre. Je ne connais pas suffisamment le fonctionnement des bilans d'exécution, mais est-ce que ça ne poserait pas problème si on transférait les données de A vers B et que chacun a un bilan d'exécution sur la même campagne ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
