### PR TITLE
Statistiques: Réduction de la consommation de RAM de l'export vers Metabase

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -557,7 +557,7 @@ class Command(BaseCommand):
                 "origin",
             )
         )
-        metabase_db.populate_table(approvals.TABLE, batch_size=50_000, querysets=[queryset])
+        metabase_db.populate_table(approvals.TABLE, batch_size=30_000, querysets=[queryset])
 
     def populate_prolongations(self):
         queryset = Prolongation.objects.all()
@@ -598,7 +598,7 @@ class Command(BaseCommand):
 
     def populate_users(self):
         queryset = User.objects.filter(kind=UserKind.PROFESSIONAL, is_active=True)
-        metabase_db.populate_table(users.TABLE, batch_size=50_000, querysets=[queryset])
+        metabase_db.populate_table(users.TABLE, batch_size=30_000, querysets=[queryset])
 
     def populate_memberships(self):
         siae_queryset = CompanyMembership.objects.all()


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'instance worker n'a suffisamment de RAM pour faire tourner des gros export, la tache de scan antivirus, clamd, la tache huey et les workers uwsgi.
Si tout se retrouve à tourner en même temps, la commande populate_metabase_emploi se fait parfois tuer
 
## :cake: Comment ? <!-- optionnel -->

En faisant des batchs plus petits.
Je n'ai pas vu de perte de performance en local (gros batchs 3587s, petits batchs 3240s)
Sur un seul essais de chaque ça montre au moins qu'on n'a pas de dégradation forte de la performance.

À voir comment ça va impacter la prod où l'appel à la base de donnée est un appel réseau un peu plus long que sur on setup de dev.


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
