### PR TITLE
Fiches salarié : Correction de l'envoi à l'ASP pour les salarié.es né.es dans certaines communes de Polynésie

### DIFF
--- a/itou/asp/constants.py
+++ b/itou/asp/constants.py
@@ -10,6 +10,14 @@
 #       .order_by("name")
 #       .values_list("name", "code")
 #   )
+#
+# ... with the following adaptations:
+# [1] Some countries have a dash in their name (e.g. "FATU-HIVA")
+#     while the corresponding communes do not ("FATU HIVA").
+#
+# WARNING: if you update `ASP_COMMUNES_AS_COUNTRIES`, you must run
+# `pytest tests/asp/test_utils.py --runslow` to check consistency.
+#
 ASP_COMMUNES_AS_COUNTRIES = {
     "ALO": "611",
     "ANAA": "711",
@@ -18,7 +26,7 @@ ASP_COMMUNES_AS_COUNTRIES = {
     "ARUE": "712",
     "ARUTUA": "713",
     "BELEP": "801",
-    "BORA-BORA": "714",
+    "BORA BORA": "714",  # [1]
     "BOULOUPARI": "802",
     "BOURAIL": "803",
     "CANALA": "804",
@@ -27,20 +35,20 @@ ASP_COMMUNES_AS_COUNTRIES = {
     "FAKARAVA": "716",
     "FANGATAU": "717",
     "FARINO": "806",
-    "FATU-HIVA": "718",
+    "FATU HIVA": "718",  # [1]
     "GAMBIER": "719",
     "HAO": "720",
     "HIENGHENE": "807",
     "HIKUERU": "721",
     "HITIAA O TE RA": "722",
-    "HIVA-OA": "723",
+    "HIVA OA": "723",  # [1]
     "HOUAILOU": "808",
     "HUAHINE": "724",
     "ILE DE CLIPPERTON": "901",
     "ILE-DES-PINS (L')": "809",
     "ILES EPARSES DE L'OCEAN INDIEN": "415",
     "ILES SAINT-PAUL ET NOUVELLE-AMSTERDAM": "411",
-    "KAALA-GOMEN": "810",
+    "KAALA GOMEN": "810",  # [1]
     "KONE": "811",
     "KOUAOUA": "833",
     "KOUMAC": "812",
@@ -53,11 +61,11 @@ ASP_COMMUNES_AS_COUNTRIES = {
     "MARE": "815",
     "MAUPITI": "728",
     "MOINDOU": "816",
-    "MONT-DORE (LE)": "817",
-    "MOOREA-MAIAO": "729",
+    "MONT DORE": "817",  # [1]
+    "MOOREA MAIAO": "729",  # [1]
     "NAPUKA": "730",
     "NOUMEA": "818",
-    "NUKU-HIVA": "731",
+    "NUKU HIVA": "731",  # [1]
     "NUKUTAVAKE": "732",
     "OUEGOA": "819",
     "OUVEA": "820",
@@ -84,8 +92,8 @@ ASP_COMMUNES_AS_COUNTRIES = {
     "SIGAVE": "612",
     "TAHAA": "745",
     "TAHUATA": "746",
-    "TAIARAPU-EST": "747",
-    "TAIARAPU-OUEST": "748",
+    "TAIARAPU EST": "747",  # [1]
+    "TAIARAPU OUEST": "748",  # [1]
     "TAKAROA": "749",
     "TAPUTAPUATEA": "750",
     "TATAKOTO": "751",
@@ -95,8 +103,8 @@ ASP_COMMUNES_AS_COUNTRIES = {
     "TUBUAI": "753",
     "TUMARAA": "754",
     "TUREIA": "755",
-    "UA-HUKA": "756",
-    "UA-POU": "757",
+    "UA HUKA": "756",  # [1]
+    "UA POU": "757",  # [1]
     "UTUROA": "758",
     "UVEA": "613",
     "VOH": "831",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,6 @@ addopts = [
 ]
 markers = [
     "no_django_db: mark tests that should not be marked with django_db.",
+    "slow: slow tests that are skipped unless pytest is run with `--runslow`",
     "snapshot: automic mark added to tests using snapshots",
 ]

--- a/tests/asp/test_utils.py
+++ b/tests/asp/test_utils.py
@@ -1,5 +1,8 @@
 import pytest
+from django.test import TestCase
 
+from itou.asp.constants import ASP_COMMUNES_AS_COUNTRIES
+from itou.asp.models import Commune
 from itou.asp.utils import guess_birth_place_from_nir
 
 
@@ -33,3 +36,25 @@ def test_guess_birth_place_from_nir(nir, expected_city, expected_country):
         assert country is None
     else:
         assert country.name == expected_country
+
+
+@pytest.mark.slow  # loading fixtures takes ~30 seconds
+class TestAspCommunesAsCountries(TestCase):
+    fixtures = ["itou/asp/fixtures/asp_INSEE_communes.json"]
+
+    def test_consistency(self):
+        from_communes = set(Commune.objects.values_list("name", flat=True))
+        from_constant = set(ASP_COMMUNES_AS_COUNTRIES)
+        diff = from_constant - from_communes
+        # The following diff is inevitable: these "countries" do not
+        # have a corresponding commune. Hopefully, nobody was born
+        # there.
+        assert diff == {
+            "ARCHIPEL DES CROZET",
+            "ARCHIPEL DES KERGUELEN",
+            "ILE DE CLIPPERTON",
+            "ILE-DES-PINS (L')",
+            "ILES EPARSES DE L'OCEAN INDIEN",
+            "ILES SAINT-PAUL ET NOUVELLE-AMSTERDAM",
+            "LA TERRE-ADELIE",
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,15 +48,28 @@ from tests.utils.htmx.testing import HtmxClient  # noqa: E402
 from tests.utils.testing import ItouClient  # noqa: E402
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="run slow tests",
+    )
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """Automatically add pytest db marker if needed."""
+    run_slow = config.getoption("--runslow")
+    skip_slow_marker = pytest.mark.skip(reason="Use --runslow to execute this test")
     for item in items:
         markers = {marker.name for marker in item.iter_markers()}
         if "no_django_db" not in markers and "django_db" not in markers:
             item.add_marker(pytest.mark.django_db)
         if "snapshot" in item.fixturenames:
             item.add_marker(pytest.mark.snapshot)
+        if "slow" in markers and not run_slow:
+            item.add_marker(skip_slow_marker)
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certaines fiches salarié sont rejetées par l'ASP quand le salarié est né dans certaines communes de Polynésie pour lesquelles l'objet `asp.Commune` ne contient pas de tiret alors que l'objet `asp.Country` en contient un. Par exemple : "BORA BORA" vs. "BORA-BORA".