### PR TITLE
Tech: augmentation de la fréquence de la commande `delete_unused_files` et limitation du nombre de fichiers maximum à supprimer

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -23,6 +23,7 @@
 
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "45 0 * * * $ROOT/clevercloud/run_management_command.sh populate_metabase_nexus",
+  "0 1 * * * $ROOT/clevercloud/run_management_command.sh delete_unused_files",
   "20 1 * * * CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh delete_old_emails --wet-run",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh retry_certify_criteria --wet-run",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh send_users_to_brevo --wet-run",
@@ -53,7 +54,6 @@
   "0 12 * * MON-FRI $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
 
   "0 0 * * MON CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
-  "0 1 * * MON $ROOT/clevercloud/run_management_command.sh delete_unused_files",
   "0 2 * * MON $ROOT/clevercloud/run_management_command.sh populate_metabase_matomo --wet-run",
   "10 5 * * MON $ROOT/clevercloud/run_management_command.sh purge_disabled_otp_devices --wet-run",
 

--- a/itou/files/management/commands/delete_unused_files.py
+++ b/itou/files/management/commands/delete_unused_files.py
@@ -16,6 +16,8 @@ from itou.utils.storage.s3 import TEMPORARY_STORAGE_PREFIX, s3_client
 # Also Wait a bit before deleting a orphan File since it might have ben created outside an atomic transation
 CLEANING_DELAY = datetime.timedelta(days=1)
 
+MAX_FILES_CLEANUP = 50_000
+
 
 class Command(BaseCommand):
     ATOMIC_HANDLE = False
@@ -71,6 +73,18 @@ class Command(BaseCommand):
                         known_keys.remove(key)
                 else:
                     temporary_files_nb += 1
+                if removed_files_nb >= MAX_FILES_CLEANUP:
+                    self.logger.warning(
+                        (
+                            "Stopped bucket cleaning after reaching MAX_FILES_CLEANUP: "
+                            "found unknown=%d and temporary=%d files in the bucket, removed=%d files"
+                        ),
+                        unknown_files_nb,
+                        temporary_files_nb,
+                        removed_files_nb,
+                    )
+                    return
+
         self.logger.info(
             "Completed bucket cleaning: found unknown=%d and temporary=%d files in the bucket, removed=%d files",
             unknown_files_nb,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec #7957 on se retrouve avec beaucoup de fichiers à supprimer. La commande ne tourne qu'une fois par semaine et souvent ne termine [jamais](https://app.datadoghq.eu/logs?query=service%3Aitou-prod%20itou.files.management.commands.delete_unused_files&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1782036008911&to_ts=1784628008911&live=true).

Et effectivement le dernier succès de cette commande a pris 42483.10 secondes, ce qui laisse amplement le temps d'être tuée par un redéploiement.

## :cake: Comment ? <!-- optionnel -->

On limite le nombre de fichiers à supprimer à 50 000 (ce qui devrait prendre ~2h) et on lance la commande tous les jours.
Cela devrait couvrir largement le nombre de fichiers déplacés chaque nuit.