### PR TITLE
Connexion : Clarification du wording après usage du code de récupération

### DIFF
--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -12,29 +12,77 @@
 {% endblock %}
 
 {% block title_extra %}
-    {% component_alert title=title content=content variant="warning" %}
-        {% fragment as title %}
-            Pour continuer, la sécurisation de votre compte est nécéssaire.
-        {% endfragment %}
-        {% fragment as content %}
-            <p class="mb-0">
-                Pour garantir la sécurité des données des personnes
-                accompagnées, la double authentification est obligatoire sur la
-                plateforme Les emplois de l’inclusion.
-                <br>
-                Configurez-la pour accéder à votre espace.
-            </p>
-        {% endfragment %}
-    {% endcomponent_alert %}
+    {% if after_recovery %}
+        {% component_alert title=title content=content variant="warning" %}
+            {% fragment as title %}
+                Votre code de récupération n’est plus valable, supprimez-le.
+            {% endfragment %}
+            {% fragment as content %}
+                <p class="mb-0">
+                    Il a été utilisé et ne peut plus servir. Si vous l’avez noté quelque part (document, gestionnaire de mots de passe, papier…), supprimez-le dès maintenant pour éviter toute confusion future.
+                    <br>
+                    À l’issue de cette configuration, un nouveau code de récupération vous sera généré. Conservez-le soigneusement, il remplacera définitivement l’ancien.
+                </p>
+            {% endfragment %}
+        {% endcomponent_alert %}
+    {% else %}
+        {% component_alert title=title content=content variant="warning" %}
+            {% fragment as title %}
+                Pour continuer, la sécurisation de votre compte est nécéssaire.
+            {% endfragment %}
+            {% fragment as content %}
+                <p class="mb-0">
+                    Pour garantir la sécurité des données des personnes
+                    accompagnées, la double authentification est obligatoire sur la
+                    plateforme Les emplois de l’inclusion.
+                    <br>
+                    Configurez-la pour accéder à votre espace.
+                </p>
+            {% endfragment %}
+        {% endcomponent_alert %}
+    {% endif %}
 {% endblock %}
 
 
 {% block content %}
+    {% if after_recovery %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        {% component_alert title=title content=content variant="info" %}
+                            {% fragment as title %}
+                                Les appareils suivants ont été retirés de votre compte :
+                            {% endfragment %}
+                            {% fragment as content %}
+                                <ul class="list-unstyled mb-0">
+                                    {% for device in disabled_devices %}
+                                        <li>
+                                            <strike>{{ device.name }}</strike>
+                                            <span class="badge badge-sm bg-tertiary rounded-pill">retiré</span>
+                                            <br>
+                                            Dernière utilisation le {{ device.last_used_at|date:"d F Y à H\hi"|default:'<i class="text-disabled">jamais</i>' }}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endfragment %}
+                        {% endcomponent_alert %}
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
-                    <h2 class="h3">Comment configurer la double authentification ?</h2>
+                    <h2 class="h3">
+                        {% if after_recovery %}
+                            Reconfigurez votre double authentification
+                        {% else %}
+                            Comment configurer la double authentification ?
+                        {% endif %}
+                    </h2>
                     <p>Nous vous guidons étape par étape, comptez environ 5 minutes.</p>
                 </div>
             </div>

--- a/itou/www/otp_views/views.py
+++ b/itou/www/otp_views/views.py
@@ -46,7 +46,16 @@ def otp_devices(request, template_name="otp_views/otp_devices.html"):
 
 @check_user_for_otp
 def enrollment_step_0_intro(request, template_name="otp_views/enrollment_step_0_intro.html"):
-    context = {"next_step_url": reverse("otp_views:enrollment_step_1_choose_device_type")}
+    after_recovery = "after_recovery" in request.GET
+    if after_recovery:
+        disabled_devices = ItouTOTPDevice.objects.filter(user=request.user, disabled_at__isnull=False)
+    else:
+        disabled_devices = ()  # ignored by template
+    context = {
+        "after_recovery": after_recovery,
+        "disabled_devices": disabled_devices,
+        "next_step_url": reverse("otp_views:enrollment_step_1_choose_device_type"),
+    }
     return render(request, template_name, context)
 
 
@@ -163,9 +172,9 @@ def login_with_backup_code(request, template_name="otp_views/login_with_backup_c
         logger.info("User %s authenticated with 2FA backup code", request.user.id)
         messages.success(
             request,
-            "Vous avez été identifié grâce à votre code de récupération. "
-            "Vos appareils précedemment enregistrés ont été supprimés. "
-            "Vous devez à nouveau enregistrer un appareil.",
+            "Code de récupération validé. Votre identité a été vérifiée. "
+            "Vous pouvez maintenant reconfigurer votre double authentification",
+            extra_tags=["toast"],
         )
 
         # No need to delete the ItouStaticToken, it's already been
@@ -182,7 +191,14 @@ def login_with_backup_code(request, template_name="otp_views/login_with_backup_c
 
         # Now that the user does not have any usable device anymore,
         # they must enroll again.
-        return HttpResponseRedirect(reverse("otp_views:enrollment_step_0_intro"))
+        return HttpResponseRedirect(
+            reverse(
+                "otp_views:enrollment_step_0_intro",
+                query={
+                    "after_recovery": "1",
+                },
+            )
+        )
 
     context = {"form": form}
     return render(request, template_name, context)

--- a/tests/www/otp_views/tests.py
+++ b/tests/www/otp_views/tests.py
@@ -396,15 +396,15 @@ class TestItouStaffLogin:
         static_device.save()
         correct_code_data = {"code": backup_code}
         response = client.post(login_with_backup_code_url, data=correct_code_data)
-        assertRedirects(response, reverse("otp_views:enrollment_step_0_intro"))
+        assertRedirects(response, reverse("otp_views:enrollment_step_0_intro") + "?after_recovery=1")
         assertMessages(
             response,
             [
                 messages.Message(
                     messages.SUCCESS,
-                    "Vous avez été identifié grâce à votre code de récupération. "
-                    "Vos appareils précedemment enregistrés ont été supprimés. "
-                    "Vous devez à nouveau enregistrer un appareil.",
+                    "Code de récupération validé. Votre identité a été vérifiée. "
+                    "Vous pouvez maintenant reconfigurer votre double authentification",
+                    extra_tags=["toast"],
                 )
             ],
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Carte Notion : https://app.notion.com/p/gip-inclusion/Modifier-les-alertes-avant-la-reconfig-38f5f321b60480b7a14ad93b5c80f790

Y a un petit delta par rapport au design Figma, au niveau de l'alignement de l'étiquette "retiré", mais je pense qu'on y survivra :

Figma : 

<img width="1192" height="308" alt="image" src="https://github.com/user-attachments/assets/eee7317e-ba5b-47f0-8f17-48694c1632f0" />

Dans cette PR : 

<img width="783" height="208" alt="Capture d’écran du 2026-07-21 16-13-43" src="https://github.com/user-attachments/assets/9f85eac4-5f7b-4a73-92aa-fc409ab4194d" />