### PR TITLE
Connexion : Masquer la bannière "anciennes fiches de poste" dans le parcours d'enrôlement 2FA

### DIFF
--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -1,6 +1,8 @@
 {% extends "layout/base.html" %}
 {% load components %}
 
+{% block global_messages %}{% endblock %}
+
 {% block title %}Configuration 2FA {{ block.super }}{% endblock %}
 
 {% block title_content %}

--- a/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
+++ b/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
@@ -1,6 +1,8 @@
 {% extends "layout/base.html" %}
 {% load components %}
 
+{% block global_messages %}{% endblock %}
+
 {% block title %}Configuration 2FA {{ block.super }}{% endblock %}
 
 {% block title_content %}

--- a/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
+++ b/itou/templates/otp_views/enrollment_step_2_and_3_confirm_device.html
@@ -3,6 +3,8 @@
 {% load components %}
 {% load django_bootstrap5 %}
 
+{% block global_messages %}{% endblock %}
+
 {% block title %}Sécurisez votre accès {{ block.super }}{% endblock %}
 
 {% block title_content %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

La [carte Notion](https://app.notion.com/p/gip-inclusion/ne-pas-afficher-le-bandeau-bleu-qui-alerte-sur-la-mise-jour-des-fiches-de-poste-38f5f321b60480cba8dde45dfb7c1e21) dit que la bannière "capte toute l'attention".