### PR TITLE
Corriger le test baggotant TestAutocomplete::test_as_employer)

### DIFF
--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -2504,7 +2504,12 @@ class TestAutocomplete:
             job_seeker__last_name="Brown",
         )
         JobApplicationFactory(
-            sent_by_prescriber_alone=True, to_company=company, sender__first_name="John", sender__last_name="Smith"
+            sent_by_prescriber_alone=True,
+            to_company=company,
+            sender__first_name="John",
+            sender__last_name="Smith",
+            job_seeker__first_name="Manny",
+            job_seeker__last_name="Calavera",
         )
         client.force_login(employer)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

```
pytest --randomly-seed=3161761792 tests/www/apply/test_list_for_siae.py::TestAutocomplete::test_as_employer

FAILED tests/www/apply/test_list_for_siae.py::TestAutocomplete::test_as_employer - AssertionError: assert {'results': [..., 'id': 758}]} == {'results': [...DGE Calvin'}]}

  Differing items:
  {'results': [{'text': 'COOLIDGE Calvin', 'id': 750}, {'text': 'THOMPSON Calvin', 'id': 758}]} != {'results': [{'id': 750, 'text': 'COOLIDGE Calvin'}]}

  Full diff:
    {
        'results': [
            {
  +             'text': 'COOLIDGE Calvin',
                'id': 750,
  +         },
  +         {
  -             'text': 'COOLIDGE Calvin',
  ?                      ^  ^^^^^
  +             'text': 'THOMPSON Calvin',
  ?                      ^^ +++ ^
  +             'id': 758,
            },
        ],
    }
```
