### PR TITLE
Tech : Suppression du lien symbolique `configure_bucket.py`

### DIFF
--- a/itou/files/management/commands/configure_bucket.py
+++ b/itou/files/management/commands/configure_bucket.py
@@ -1,1 +1,0 @@
-configure_buckets.py


### PR DESCRIPTION
## :thinking: Pourquoi ?

⚠️ À fusionner seulement après avoir mis à jour sur Clever `CC_PYTHON_MANAGE_TASKS` avec `configure_buckets` (au pluriel) sur les différents environnements.




