### PR TITLE
Marque : préparer le changement de nom de l'application

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 import itou
 import itou.api.changelog
 from config.sentry import sentry_init
+from itou.utils.brand import product_name
 from itou.utils.enums import ItouEnvironment
 from itou.utils.urls import markdown_url_set_protocol, markdown_url_set_target_blank
 
@@ -196,7 +197,10 @@ TEMPLATES = [
                 "itou.utils.context_processors.matomo",
                 "itou.utils.context_processors.active_announcement_campaign",
             ],
-            "builtins": ["slippers.templatetags.slippers"],
+            "builtins": [
+                "itou.utils.templatetags.branding",
+                "slippers.templatetags.slippers",
+            ],
         },
     }
 ]
@@ -604,7 +608,7 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "API - Les emplois de l'inclusion",
+    "TITLE": f"API - {product_name()}",
     "DESCRIPTION": "Documentation de l'API **emplois.inclusion.beta.gouv.fr**\n\n" + itou.api.changelog.CHANGELOG,
     "VERSION": "1.0.0",
     "ENUM_NAME_OVERRIDES": {
@@ -861,7 +865,7 @@ SERIALIZATION_MODULES = {
 
 # OTP
 # ------------------------------------------------------------------------------
-OTP_TOTP_ISSUER = f"Les Emplois de l'inclusion ({ITOU_ENVIRONMENT})"
+OTP_TOTP_ISSUER = f"{product_name()} ({ITOU_ENVIRONMENT})"
 REQUIRE_OTP_FOR_STAFF = os.getenv("REQUIRE_OTP_FOR_STAFF", "True") == "True"
 REQUIRE_MFA_FOR_PROS = os.getenv("REQUIRE_MFA_FOR_PROS", "False") == "True"
 OTP_DEVICES_GRACE_PERIOD_BEFORE_DELETION = datetime.timedelta(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 import itou
 import itou.api.changelog
 from config.sentry import sentry_init
+from itou.utils.brand import product_name
 from itou.utils.enums import ItouEnvironment
 from itou.utils.urls import markdown_url_set_protocol, markdown_url_set_target_blank
 
@@ -197,7 +198,10 @@ TEMPLATES = [
                 "itou.utils.context_processors.matomo",
                 "itou.utils.context_processors.active_announcement_campaign",
             ],
-            "builtins": ["slippers.templatetags.slippers"],
+            "builtins": [
+                "itou.utils.templatetags.branding",
+                "slippers.templatetags.slippers",
+            ],
         },
     }
 ]
@@ -640,7 +644,7 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    "TITLE": "API - Les emplois de l'inclusion",
+    "TITLE": f"API - {product_name()}",
     "DESCRIPTION": "Documentation de l'API **emplois.inclusion.beta.gouv.fr**\n\n" + itou.api.changelog.CHANGELOG,
     "VERSION": "1.0.0",
     "ENUM_NAME_OVERRIDES": {
@@ -878,7 +882,7 @@ SERIALIZATION_MODULES = {
 
 # OTP
 # ------------------------------------------------------------------------------
-OTP_TOTP_ISSUER = f"Les Emplois de l'inclusion ({ITOU_ENVIRONMENT})"
+OTP_TOTP_ISSUER = f"{product_name()} ({ITOU_ENVIRONMENT})"
 REQUIRE_OTP_FOR_STAFF = os.getenv("REQUIRE_OTP_FOR_STAFF", "True") == "True"
 REQUIRE_MFA_FOR_PROS = os.getenv("REQUIRE_MFA_FOR_PROS", "False") == "True"
 SHOW_UPCOMING_MFA_FOR_PROS_BANNER = os.getenv("SHOW_UPCOMING_MFA_FOR_PROS_BANNER", "False") == "True"

--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -11,6 +11,7 @@ from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.auth import LoginNotRequiredMixin
+from itou.utils.brand import product_name
 from itou.utils.readonly import ReadonlyViewMixin
 
 
@@ -77,7 +78,7 @@ ApplicantsView.__doc__ = f"""\
 Cette API retourne la liste de tous les demandeurs d'emploi liés aux candidatures reçues par
 la ou les structure(s) sélectionnée(s).
 
-Les candidats sont triés par date de création dans la base des emplois de l'inclusion,
+Les candidats sont triés par date de création dans la base {product_name("de")},
 du plus récent au plus ancien.
 
 **Note** : la clé `lien_cv` est dépréciée et associée à une valeur vide. Elle est conservée pour

--- a/itou/api/geiq/views.py
+++ b/itou/api/geiq/views.py
@@ -104,6 +104,7 @@ class GeiqJobApplicationListView(LoginNotRequiredMixin, ReadonlyViewMixin, gener
 
     @extend_schema(operation_id="list")
     def get(self, request, *args, **kwargs):
+        # TODO(branding): nom en dur dans la description OpenAPI — à basculer manuellement au flip du nom
         """
         # Liste des embauches réalisées en GEIQ
 

--- a/itou/nexus/enums.py
+++ b/itou/nexus/enums.py
@@ -8,6 +8,7 @@ from itou.users.enums import UserKind
 class Service(models.TextChoices):
     DATA_INCLUSION = "data-inclusion", "Data inclusion"
     DORA = "dora", "Dora"
+    # Label left untokenized: it is part of ServiceToken.service choices, so changing it needs a migration.
     EMPLOIS = "les-emplois", "les emplois de l’inclusion"
     MARCHE = "le-marche", "Le marché de l’inclusion"
     MON_RECAP = "mon-recap", "Mon Récap"

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -15,6 +15,7 @@ from itou.users.enums import (
     UserKind,
 )
 from itou.users.models import User
+from itou.utils.brand import product_name
 from itou.utils.constants import ITOU_HELP_CENTER_URL
 
 
@@ -50,10 +51,11 @@ class InactiveUserException(Exception):
 
     def format_message_html(self, identity_provider):
         return format_html(
-            "La connexion via {} a fonctionné mais le compte lié sur les Emplois de l’inclusion est désactivé. "
+            "La connexion via {} a fonctionné mais le compte lié sur {} est désactivé. "
             "Veuillez vous rapprocher du support pour débloquer la situation en suivant "
             '<a href="{}">ce lien</a> et en leur fournissant l’identifiant public de ce compte : {}.',
             identity_provider.label,
+            product_name(),
             ITOU_HELP_CENTER_URL,
             self.user.public_id,
         )

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -37,6 +37,7 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import IdentityProvider
 from itou.users.models import User
 from itou.utils import constants as global_constants
+from itou.utils.brand import product_name
 from itou.utils.readonly import http_methods
 from itou.utils.urls import get_absolute_url, get_safe_url, get_zendesk_form_url
 from itou.utils.views import with_triggers_context
@@ -312,8 +313,9 @@ def pro_connect_callback(request):
             format_html(
                 "Vous n'avez pas encore de compte avec cette adresse e-mail. "
                 "Pour utiliser ce service, merci de vous créer un compte sur "
-                "<a href='{}'>les emplois de l’inclusion</a>",
+                "<a href='{}'>{}</a>",
                 reverse("signup:choose_user_kind"),
+                product_name(),
             ),
         )
         return HttpResponseRedirect(pro_connect_state.data["previous_url"])

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -38,6 +38,7 @@ from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import IdentityProvider
 from itou.users.models import User
 from itou.utils import constants as global_constants
+from itou.utils.brand import product_name
 from itou.utils.readonly import http_methods
 from itou.utils.urls import get_absolute_url, get_safe_url, get_zendesk_form_url
 from itou.utils.views import with_triggers_context
@@ -313,8 +314,9 @@ def pro_connect_callback(request):
             format_html(
                 "Vous n'avez pas encore de compte avec cette adresse e-mail. "
                 "Pour utiliser ce service, merci de vous créer un compte sur "
-                "<a href='{}'>les emplois de l’inclusion</a>",
+                "<a href='{}'>{}</a>",
                 reverse("signup:choose_user_kind"),
+                product_name(),
             ),
         )
         return HttpResponseRedirect(pro_connect_state.data["previous_url"])

--- a/itou/templates/account/activate_pro_connect_account.html
+++ b/itou/templates/account/activate_pro_connect_account.html
@@ -11,7 +11,7 @@
                 <div class="s-section__col col-12 col-lg-6 bg-lg-white">
                     <div class="bg-white p-3 py-lg-7 px-lg-8">
                         <h1 class="h2 mb-lg-4">ProConnect, un accès unique à tous vos services !</h1>
-                        <p>Le service ProConnect est obligatoire pour se connecter au service les emplois de l'inclusion.</p>
+                        <p>Le service ProConnect est obligatoire pour se connecter au service {% brand %}.</p>
                         <p>
                             Pour conserver l'accès à votre compte existant vous devez vous connecter ou créer un compte avec ProConnect à l'aide du bouton ci-dessous.
                         </p>

--- a/itou/templates/account/email/email_archive_user_body.txt
+++ b/itou/templates/account/email/email_archive_user_body.txt
@@ -7,7 +7,7 @@
 
 {% block body %}
 Bonjour {{ user.get_full_name }},
-Le {{ user.upcoming_deletion_notified_at|date:"d/m/Y" }}, nous vous avons informé que votre compte sur les Emplois de l’inclusion associé à l’email {{ user.email }} serait supprimé.
+Le {{ user.upcoming_deletion_notified_at|date:"d/m/Y" }}, nous vous avons informé que votre compte sur {% brand %} associé à l’email {{ user.email }} serait supprimé.
 A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
 En cas de besoin, vous pouvez toujours vous réinscrire sur {{ base_url }}
 {% endblock body %}

--- a/itou/templates/account/email/email_archive_user_subject.txt
+++ b/itou/templates/account/email/email_archive_user_subject.txt
@@ -1,3 +1,3 @@
 {% extends "layout/base_email_text_subject.txt" %}
 
-{% block subject %}Suppression de votre compte sur les Emplois de l’inclusion{% endblock subject %}
+{% block subject %}Suppression de votre compte sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/email_disable_password_auth_body.txt
+++ b/itou/templates/account/email/email_disable_password_auth_body.txt
@@ -3,7 +3,7 @@
 {% block body %}
 Bonjour {{ user.get_full_name }},
 
-En raison d'une alerte de sécurité sur votre compte les Emplois de l'inclusion, nous avons procédé à la réinitialisation du mot de passe associé à l'adresse {{ user.email }}.
+En raison d'une alerte de sécurité sur votre compte {% brand %}, nous avons procédé à la réinitialisation du mot de passe associé à l'adresse {{ user.email }}.
 
 Pour accéder de nouveau à votre compte, veuillez définir un nouveau mot de passe en suivant ce lien : {{ password_reset_url }}
 {% endblock body %}

--- a/itou/templates/account/email/email_disable_password_auth_subject.txt
+++ b/itou/templates/account/email/email_disable_password_auth_subject.txt
@@ -1,3 +1,3 @@
 {% extends "layout/base_email_text_subject.txt" %}
 
-{% block subject %}Désactivation de votre mot de passe sur les emplois de l'inclusion{% endblock subject %}
+{% block subject %}Désactivation de votre mot de passe sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/email_inactive_user_body.txt
+++ b/itou/templates/account/email/email_inactive_user_body.txt
@@ -8,7 +8,7 @@
 
 {% block body %}
 Bonjour {{ user.get_full_name }},
-Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse {{ user.email }} depuis le {{ inactivity_since|date:"d/m/Y" }}.
+Nous n’avons détecté aucune activité sur votre compte sur {% brand %} associé à l’adresse {{ user.email }} depuis le {{ inactivity_since|date:"d/m/Y" }}.
 Sans connexion de votre part avant le {{ end_of_grace_period|date:"d/m/Y" }}, votre compte sera supprimé ainsi que toutes les données associées.
 Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur {{ base_url }}
 {% endblock body %}

--- a/itou/templates/account/email/email_inactive_user_subject.txt
+++ b/itou/templates/account/email/email_inactive_user_subject.txt
@@ -1,3 +1,3 @@
 {% extends "layout/base_email_text_subject.txt" %}
 
-{% block subject %}Information avant suppression de votre compte sur les Emplois de l’inclusion{% endblock subject %}
+{% block subject %}Information avant suppression de votre compte sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
+++ b/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
@@ -13,10 +13,10 @@
 
 Bonjour {% if job_seeker.title %}{{ job_seeker.get_title_display }} {% endif %}{{ job_seeker.get_full_name }},
 
-Votre compte candidat vient d’être créé sur les Emplois de l’inclusion par {{ creator.get_full_name }}{% if creator_org %} de {{ creator_org.display_name }}{% endif %}.
+Votre compte candidat vient d’être créé sur {% brand %} par {{ creator.get_full_name }}{% if creator_org %} de {{ creator_org.display_name }}{% endif %}.
 
 Pour finaliser votre inscription, merci de cliquer sur le lien suivant : {{ account_activation_link }}. Ce lien expirera dans 14 jours.
-Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité à définir un mot de passe pour votre compte candidat.
+Dès votre arrivée sur le site {% brand "de" %}, vous serez invité à définir un mot de passe pour votre compte candidat.
 
 Cet e-mail a été généré et envoyé automatiquement, merci de ne pas y répondre.
 

--- a/itou/templates/account/email/email_jobseeker_email_edited_body.txt
+++ b/itou/templates/account/email/email_jobseeker_email_edited_body.txt
@@ -10,7 +10,7 @@
 {% block body %}
 Bonjour {{ user.get_full_name }},
 
-Votre adresse e-mail a été mise à jour sur les Emplois de l’inclusion par la structure {{ organization }}.
+Votre adresse e-mail a été mise à jour sur {% brand %} par la structure {{ organization }}.
 - Ancienne adresse e-mail: {{ old_email_address|default_if_none:"Non renseignée" }}
 - Nouvelle adresse e-mail: {{ user.email }}
 

--- a/itou/templates/account/email/email_jobseeker_email_edited_subject.txt
+++ b/itou/templates/account/email/email_jobseeker_email_edited_subject.txt
@@ -1,3 +1,3 @@
 {% extends "layout/base_email_text_subject.txt" %}
 
-{% block subject %}Votre adresse e-mail a été mise à jour sur les Emplois de l'inclusion{% endblock subject %}
+{% block subject %}Votre adresse e-mail a été mise à jour sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/email_jobseeker_personal_info_edited_body.txt
+++ b/itou/templates/account/email/email_jobseeker_personal_info_edited_body.txt
@@ -10,7 +10,7 @@
 {% block body %}
 Bonjour {{ user.get_full_name }},
 
-Vos informations personnelles ont été mises à jour sur les Emplois de l’inclusion par la structure {{ organization }}.
+Vos informations personnelles ont été mises à jour sur {% brand %} par la structure {{ organization }}.
 
 Si vous n'êtes pas à l'origine de cette demande ou si vous souhaitez consulter, modifier ou supprimer vos données, vous pouvez vous connecter à votre espace candidat ici : {{ edit_user_info_url }}.
 

--- a/itou/templates/account/email/email_jobseeker_personal_info_edited_subject.txt
+++ b/itou/templates/account/email/email_jobseeker_personal_info_edited_subject.txt
@@ -1,3 +1,3 @@
 {% extends "layout/base_email_text_subject.txt" %}
 
-{% block subject %}Vos données personnelles ont été mises à jour sur les Emplois de l'inclusion{% endblock subject %}
+{% block subject %}Vos données personnelles ont été mises à jour sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/email_new_API_token_body.txt
+++ b/itou/templates/account/email/email_new_API_token_body.txt
@@ -4,7 +4,7 @@
 
 Bonjour {{ user.get_full_name }},
 
-Nous vous informons qu'un nouveau token API vient d'être généré sur votre compte des Emplois de l’inclusion.
+Nous vous informons qu'un nouveau token API vient d'être généré sur votre compte {% brand "de" %}.
 
 Détails de l’opération :
 • Date et heure : {{ token_created_at }}

--- a/itou/templates/account/email/email_new_API_token_subject.txt
+++ b/itou/templates/account/email/email_new_API_token_subject.txt
@@ -1,2 +1,2 @@
 {% extends "layout/base_email_text_subject.txt" %}
-{% block subject %}Génération d’un nouveau token d’API sur les Emplois de l'inclusion{% endblock subject %}
+{% block subject %}Génération d’un nouveau token d’API sur {% brand %}{% endblock subject %}

--- a/itou/templates/account/email/unknown_account_message.txt
+++ b/itou/templates/account/email/unknown_account_message.txt
@@ -1,6 +1,6 @@
 Bonjour,
 
-Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion ({{ base_url }}).
+Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur {% brand %} ({{ base_url }}).
 
 Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
 
@@ -8,11 +8,11 @@ Si vous n’avez fait aucune demande de nouveau mot de passe, vous pouvez ignore
 
 Si vous avez fait cette demande de nouveau mot de passe :
 
-- Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
+- Assurez-vous que vous n’aviez pas créé votre compte sur {% brand %} depuis une autre adresse e-mail.
 - Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
 
 {{ signup_url }}
 
 Cordialement,
 
-L’équipe des emplois de l’inclusion
+L’équipe {% brand "de" %}

--- a/itou/templates/admin/base_site.html
+++ b/itou/templates/admin/base_site.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load theme_inclusion %}
 
-{% block title %}{{ title }} | Les emplois de l'inclusion{% endblock %}
+{% block title %}{{ title }} | {% brand %}{% endblock %}
 
 {% block branding %}
     <h1 id="site-name">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -1,15 +1,15 @@
 {% extends "layout/base.html" %}
 
-{% block title %}API Les emplois de l’inclusion{% endblock %}
+{% block title %}API {% brand %}{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 p-3">
-                    <h1 class="h1-hero-c1">API Les emplois de l’inclusion</h1>
+                    <h1 class="h1-hero-c1">API {% brand %}</h1>
                     <p class="lead">
-                        L'API des <a href="{% url 'home:hp' %}" aria-label="Vers les emplois de l'inclusion">emplois de l'inclusion</a> met à disposition des données de la plateforme.
+                        L'API de <a href="{% url 'home:hp' %}" aria-label="Vers {% brand %}">{% brand %}</a> met à disposition des données de la plateforme.
                     </p>
                     <p>Cette API est encore en construction et est appelée à évoluer.</p>
                     <p class="text-muted">Version: 1</p>

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -1,15 +1,15 @@
 {% extends "layout/base.html" %}
 
-{% block title %}API {% brand %}{% endblock %}
+{% block title %}API {% brand "de" %}{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 p-3">
-                    <h1 class="h1-hero-c1">API {% brand %}</h1>
+                    <h1 class="h1-hero-c1">API {% brand "de" %}</h1>
                     <p class="lead">
-                        L'API de <a href="{% url 'home:hp' %}" aria-label="Vers {% brand %}">{% brand %}</a> met à disposition des données de la plateforme.
+                        <a href="{% url 'v1:redoc' %}">L'API {% brand "de" %}</a> met à disposition des données de la plateforme.
                     </p>
                     <p>Cette API est encore en construction et est appelée à évoluer.</p>
                     <p class="text-muted">Version: 1</p>

--- a/itou/templates/apply/email/accept_for_proxy_body.txt
+++ b/itou/templates/apply/email/accept_for_proxy_body.txt
@@ -30,7 +30,7 @@ Afin de nous aider à évaluer la performance de notre service, accepteriez-vous
 
 Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ prescriber_survey_link }}
 
-Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
+Merci de votre participation et à très bientôt sur {% brand %} !
 {% endif %}
 
 {% endblock body %}

--- a/itou/templates/apply/email/accept_for_proxy_subject.txt
+++ b/itou/templates/apply/email/accept_for_proxy_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Candidature acceptée et votre avis sur les emplois de l'inclusion
+Candidature acceptée et votre avis sur {% brand %}
 {% endblock %}

--- a/itou/templates/apply/email/new_for_employer_body.txt
+++ b/itou/templates/apply/email/new_for_employer_body.txt
@@ -51,7 +51,7 @@ Le candidat lui même.
 
 {% endif %}
 
-Candidature envoyée à l'entreprise {{ job_application.to_company.display_name }}, {{ job_application.to_company.city }}. Identifiant sur les emplois de l'inclusion : {{ job_application.to_company.pk }}.
+Candidature envoyée à l'entreprise {{ job_application.to_company.display_name }}, {{ job_application.to_company.city }}. Identifiant sur {% brand %} : {{ job_application.to_company.pk }}.
 
 --------------------
 {% if job_application.to_company.is_subject_to_iae_rules %}

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -2,7 +2,7 @@
 {% block body %}
 
 {% if job_application.to_company.is_subject_to_iae_rules %}
-Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion. Vous trouverez ci-dessous votre PASS IAE (il équivaut à l'agrément Pôle emploi conformément aux articles L 5132-1 à L 5132-17 du code du travail) :
+Merci d'avoir confirmé l'embauche d'un candidat sur {% brand %}. Vous trouverez ci-dessous votre PASS IAE (il équivaut à l'agrément Pôle emploi conformément aux articles L 5132-1 à L 5132-17 du code du travail) :
 
 PASS IAE N° : {{ job_application.approval.number_with_spaces }}
 Nombre de jours restants sur le PASS IAE débutant le {{ job_application.approval.start_at|date:"d/m/Y" }} : {{ job_application.approval.get_remainder_display }}*.
@@ -28,13 +28,13 @@ Votre contact : {{ itou_help_center_url }}
 Afin de nous aider à évaluer la performance de notre service, accepteriez-vous de répondre à quelques questions ?
 Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ siae_survey_link }}
 
-Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
+Merci de votre participation et à très bientôt sur {% brand %} !
 
 
 * Le reliquat est calculé sur la base d’un nombre de jours calendaires.
 Si le PASS IAE n'est pas suspendu, il décroit donc tous les jours (samedi, dimanche et jours fériés compris).
 {% else %}
-Merci d'avoir confirmé l'embauche d'un candidat sur les emplois de l'inclusion.
+Merci d'avoir confirmé l'embauche d'un candidat sur {% brand %}.
 
 Votre contact : {{ itou_help_center_url }}
 {% endif %}

--- a/itou/templates/approvals/email/deliver_subject.txt
+++ b/itou/templates/approvals/email/deliver_subject.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
 {% if job_application.to_company.is_subject_to_iae_rules %}
-PASS IAE pour {{ job_application.job_seeker.get_inverted_full_name }} et avis sur les emplois de l'inclusion
+PASS IAE pour {{ job_application.job_seeker.get_inverted_full_name }} et avis sur {% brand %}
 {% else %}
 Confirmation de l'embauche
 {% endif %}

--- a/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
+++ b/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
@@ -2,7 +2,7 @@
 {% block body %}
 Nouvelle embauche sur Itou.
 
-Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candidat via les emplois de l'inclusion :
+Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candidat via {% brand %} :
 
 *Candidat* :
 

--- a/itou/templates/approvals/email/prolongation_request/created_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/created_body.txt
@@ -25,7 +25,7 @@ L'employeur souhaite vous apporter des explications supplémentaires par télép
 - Motif de prolongation : {{ prolongation_request.get_reason_display }}
 {% if prolongation_request.report_file %}- Fiche bilan : {{ report_file_url }}{% endif %}
 
-Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur {{ prolongation_request.prescriber_organization.display_name }} sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
+Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur {{ prolongation_request.prescriber_organization.display_name }} sur {% brand %}, à la rubrique "Gérer mes prolongations de PASS IAE".
 
 Précisions en cas de refus :
 

--- a/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/employer_body.txt
@@ -25,5 +25,5 @@ Actions envisagées par le prescripteur :
 {% endif %}
 {% endif %}
 
-Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
+Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur {% brand %}.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
@@ -26,5 +26,5 @@ De votre côté, n’hésitez pas à prendre contact avec notre partenaire, l’
 Pour être rappelé par un conseiller : https://cloud.info.afpa.fr/afpa-plateforme-emploi-et-inclusion
 {% endif %}
 
-Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
+Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur {% brand %}.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/granted/employer_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/granted/employer_body.txt
@@ -9,5 +9,5 @@ Références :
 Numéro : {{ prolongation_request.approval.number_with_spaces }}
 Bénéficiaire : {{ prolongation_request.approval.user.get_inverted_full_name }}
 
-Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
+Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur {% brand %}.
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/granted/jobseeker_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/granted/jobseeker_body.txt
@@ -6,5 +6,5 @@ L’employeur {{ prolongation_request.declared_by_siae.display_name }} a sollici
 
 L’organisation {{ prolongation_request.prescriber_organization.display_name }} a accepté la prolongation du PASS IAE.
 
-Vous pouvez consulter la nouvelle date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
+Vous pouvez consulter la nouvelle date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur {% brand %}.
 {% endblock body %}

--- a/itou/templates/approvals/email/refuse_manually_body.txt
+++ b/itou/templates/approvals/email/refuse_manually_body.txt
@@ -12,7 +12,7 @@ Délai de carence non respecté, ce candidat a déjà bénéficié d'un parcours
 
 Vous avez la possibilité de contacter un prescripteur habilité pour exposer la situation de votre candidat.
 
-Si le prescripteur habilité est favorable à une dérogation de son délai de carence, il doit vous transmettre la candidature de {{ job_application.job_seeker.get_inverted_full_name }} via les emplois de l'inclusion. Vous pourrez ensuite demander l'obtention d'un PASS IAE.
+Si le prescripteur habilité est favorable à une dérogation de son délai de carence, il doit vous transmettre la candidature de {{ job_application.job_seeker.get_inverted_full_name }} via {% brand %}. Vous pourrez ensuite demander l'obtention d'un PASS IAE.
 
 Pour trouver les prescripteurs habilités proches de vous, pensez à utiliser le moteur de recherche depuis votre tableau de bord :
 {{ search_url }}

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -37,7 +37,7 @@
             <span class="d-block fw-bold">Références à rappeler :</span>
             <ul class="list-unstyled">
                 <li class="d-block">PASS IAE n° {{ approval.number|format_approval_number }}</li>
-                <li class="d-block">délivré par les emplois de l'inclusion</li>
+                <li class="d-block">délivré par {% brand %}</li>
                 <li class="d-block">Date de début : {{ approval.start_at|date:"d/m/Y" }}</li>
                 {% if approval.user.jobseeker_profile.pole_emploi_id %}
                     <li class="d-block">Identifiant France Travail : {{ approval.user.jobseeker_profile.pole_emploi_id }}</li>
@@ -60,6 +60,7 @@
                     Au vu de
                 {% endif %}
                 la situation sociale et professionnelle de {{ approval.user.get_inverted_full_name }}
+                {# TODO(branding): accord verbal avec la marque — réécrire la phrase avant le flip du nom #}
                 et de votre promesse d'embauche, les emplois de l'inclusion vous délivrent
                 un PASS IAE pour un parcours d'insertion par l'activité économique,
                 conformément aux dispositions des articles L 5132-1 à L 5132-17 du code du travail.

--- a/itou/templates/common/emails/add_admin_email_body.txt
+++ b/itou/templates/common/emails/add_admin_email_body.txt
@@ -3,7 +3,7 @@
 
 Bonjour {{ user.get_full_name }}
 
-Vous avez désormais le statut d’administrateur sur l’espace professionnel de votre organisation {{ structure.name }} ({{ structure.kind }}) sur les emplois de l’inclusion.
+Vous avez désormais le statut d’administrateur sur l’espace professionnel de votre organisation {{ structure.name }} ({{ structure.kind }}) sur {% brand %}.
 
 {% if documentation_link %}
 Ce statut vous permet d’avoir accès à certaines fonctionnalités, la liste complète est disponible ici : {{ documentation_link }}.

--- a/itou/templates/common/emails/auto_admin_attribution_email_body.txt
+++ b/itou/templates/common/emails/auto_admin_attribution_email_body.txt
@@ -3,7 +3,7 @@
 
 Bonjour {{ user.get_full_name }}
 
-L'espace de travail de votre structure {{ structure.name }} ({{ structure.kind }}) sur les emplois de l'inclusion ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
+L'espace de travail de votre structure {{ structure.name }} ({{ structure.kind }}) sur {% brand %} ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
 
 {% if documentation_link %}
 Ce statut vous permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : {{ documentation_link }}.

--- a/itou/templates/common/emails/member_deactivation_email_body.txt
+++ b/itou/templates/common/emails/member_deactivation_email_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+Un administrateur vous a retiré d'une structure sur {% brand %}
 
 Organisation :
 
@@ -11,6 +11,6 @@ Organisation :
 - Email de contact : {{ structure.email }}
 {% endif %}
 
-Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur {% brand %}.
 
 {% endblock body %}

--- a/itou/templates/common/emails/remove_admin_email_body.txt
+++ b/itou/templates/common/emails/remove_admin_email_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Un administrateur vous a retiré les droits d'administrateur d'une structure sur les emplois de l'inclusion
+Un administrateur vous a retiré les droits d'administrateur d'une structure sur {% brand %}
 
 Organisation :
 
@@ -12,6 +12,6 @@ Organisation :
 - Email de contact : {{ structure.email }}
 {% endif %}
 
-Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur {% brand %}.
 
 {% endblock body %}

--- a/itou/templates/common/emails/used_otp_backup_code_body.txt
+++ b/itou/templates/common/emails/used_otp_backup_code_body.txt
@@ -3,6 +3,6 @@
 
 Bonjour {{ user.get_full_name }}
 
-Un code de récupération vient d’être utilisé pour se connecter aux Emplois de l’inclusion. Si vous n’êtes pas à l’origine de cette action, merci de contacter au plus vite security@inclusion.gouv.fr en spécifiant l’adresse email concernée.
+Un code de récupération vient d’être utilisé pour se connecter {% brand "à" %}. Si vous n’êtes pas à l’origine de cette action, merci de contacter au plus vite security@inclusion.gouv.fr en spécifiant l’adresse email concernée.
 
 {% endblock body %}

--- a/itou/templates/common/emails/used_otp_backup_code_subject.txt
+++ b/itou/templates/common/emails/used_otp_backup_code_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Utilisation d'un code de récupération sur votre compte des Emplois de l’inclusion
+Utilisation d'un code de récupération sur votre compte {% brand "de" %}
 {% endblock %}

--- a/itou/templates/companies/create_siae.html
+++ b/itou/templates/companies/create_siae.html
@@ -17,7 +17,7 @@
                     ayant déjà un ou plusieurs membres, <b>demandez à l’un de ces membres de vous inviter depuis son tableau de bord</b>
                 </li>
                 <li>
-                    connue des services des emplois de l'inclusion mais n’ayant pas encore de membre : <a href="{% url 'signup:company_select' %}">utilisez ce formulaire</a>
+                    connue des services {% brand "de" %} mais n’ayant pas encore de membre : <a href="{% url 'signup:company_select' %}">utilisez ce formulaire</a>
                 </li>
             </ul>
             <p>Dans les autres cas, complétez le formulaire ci-dessous.</p>

--- a/itou/templates/companies/email/activate_your_account_body.txt
+++ b/itou/templates/companies/email/activate_your_account_body.txt
@@ -2,11 +2,11 @@
 {% block body %}
 Bonjour,
 
-Le compte de votre {{siae.kind}} SIRET {{siae.siret}} vient d’être créé sur les emplois de l’inclusion !
+Le compte de votre {{siae.kind}} SIRET {{siae.siret}} vient d’être créé sur {% brand %} !
 
 Pour activer le compte de l’entreprise, pouvoir embaucher, obtenir des PASS IAE et créer vos fiches salarié, activez votre compte en cliquant ici {{ signup_url }}
 
-Vous avez déjà un compte employeur sur les emplois de l’inclusion ?
+Vous avez déjà un compte employeur sur {% brand %} ?
 - demandez à un de vos collègues qui n’en a pas encore d’activer le compte
 - vous recevrez l’e-mail d’authentification nécessaire à la première connexion
 - Votre collègue rejoindra le compte de la SIAE.

--- a/itou/templates/companies/email/activate_your_account_subject.txt
+++ b/itou/templates/companies/email/activate_your_account_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Activez le compte de votre {{siae.kind}} {{siae.name}} sur les emplois de l'inclusion
+Activez le compte de votre {{siae.kind}} {{siae.name}} sur {% brand %}
 {% endblock %}

--- a/itou/templates/companies/email/new_signup_activation_email_to_official_contact_body.txt
+++ b/itou/templates/companies/email/new_signup_activation_email_to_official_contact_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Un nouvel utilisateur souhaite rejoindre votre structure sur les emplois de l'inclusion !
+Un nouvel utilisateur souhaite rejoindre votre structure sur {% brand %} !
 
 Organisation :
 

--- a/itou/templates/companies/email/old_job_description_deactivated_body.txt
+++ b/itou/templates/companies/email/old_job_description_deactivated_body.txt
@@ -5,7 +5,7 @@ Bonjour,
 Nous vous informons que votre fiche de poste intitulée {{ job_description.display_name }} à {{ job_description.display_location }} au sein de la structure {{ structure.kind }} {{ structure.display_name }} a été dépubliée automatiquement, car elle n’a pas été mise à jour depuis plus de 3 mois.
 
 En cas de besoin, vous pouvez réactiver cette fiche de poste depuis votre espace :
-Structure > Métiers et recrutements sur les Emplois de l’inclusion {{ base_url}}.
+Structure > Métiers et recrutements sur {% brand %} {{ base_url}}.
 
 Si cette fiche de poste n’est plus d’actualité, aucune action de votre part n’est nécessaire.
 

--- a/itou/templates/companies/email/spontaneous_jobapps_deactivated_body.txt
+++ b/itou/templates/companies/email/spontaneous_jobapps_deactivated_body.txt
@@ -6,7 +6,7 @@ Nous vous informons que la réception des candidatures spontanées pour la struc
 
 Si vous souhaitez continuer à recevoir des candidatures spontanées, vous pouvez réactiver cette fonctionnalité depuis votre espace :
 
-Structure > Métiers et recrutements sur les Emplois de l’inclusion
+Structure > Métiers et recrutements sur {% brand %}
 
 Si vous ne recrutez plus actuellement, aucune action de votre part n’est nécessaire.
 

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -89,7 +89,7 @@
         <div class="c-box--results__body">
             {% component_info borderless=True c_info__summary=c_info__summary extra_classes="mt-2" %}
                 {% fragment as c_info__summary %}
-                    Cet employeur n'est actuellement pas inscrit sur le site des emplois de l’inclusion, vous ne pouvez pas déposer de candidature en ligne
+                    Cet employeur n'est actuellement pas inscrit sur le site {% brand "de" %}, vous ne pouvez pas déposer de candidature en ligne
                 {% endfragment %}
             {% endcomponent_info %}
         </div>

--- a/itou/templates/companies/select_financial_annex.html
+++ b/itou/templates/companies/select_financial_annex.html
@@ -37,7 +37,7 @@
                                 {% endfragment %}
                                 {% fragment as c_info__detail %}
                                     <p>
-                                        Si votre annexe financière correspond à un SIREN différent de {{ request.current_organization.siren }} ou à un type de structure différent de {{ request.current_organization.kind }}, ou bien si elle n'apparaît pas dans la liste ci-dessus, <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" class="has-external-link" aria-label="Ouverture dans un nouvel onglet">contactez-nous via la rubrique correspondant à votre structure sur la documentation des emplois de l'inclusion</a>
+                                        Si votre annexe financière correspond à un SIREN différent de {{ request.current_organization.siren }} ou à un type de structure différent de {{ request.current_organization.kind }}, ou bien si elle n'apparaît pas dans la liste ci-dessus, <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" class="has-external-link" aria-label="Ouverture dans un nouvel onglet">contactez-nous via la rubrique correspondant à votre structure sur la documentation {% brand "de" %}</a>
                                     </p>
                                 {% endfragment %}
                             {% endcomponent_info %}

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -46,7 +46,7 @@
                         <div class="c-box mb-3 mb-md-4">
                             <h2 class="h3">APIs</h2>
                             <p>
-                                Une API (application programming interface ou « interface de programmation d’application ») est une interface logicielle qui permet de « connecter » le site des emplois de l’inclusion à un autre logiciel ou service afin d’échanger des données et des fonctionnalités.
+                                Une API (application programming interface ou « interface de programmation d’application ») est une interface logicielle qui permet de « connecter » le site {% brand "de" %} à un autre logiciel ou service afin d’échanger des données et des fonctionnalités.
                             </p>
                             <p>En tant qu’administrateur de structures, vous avez accès aux API suivantes :</p>
                             <ul>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -137,7 +137,7 @@
                 Webinaire thématique et prise en main
             {% endfragment %}
             {% fragment as content %}
-                <p class="mb-0">Optimiser ses pratiques de prescription avec les Emplois de l’inclusion : bonnes pratiques, évolutions du service et échanges autour de cas concrets.</p>
+                <p class="mb-0">Optimiser ses pratiques de prescription avec {% brand %} : bonnes pratiques, évolutions du service et échanges autour de cas concrets.</p>
             {% endfragment %}
             {% fragment as call_to_action %}
                 <a class="btn btn-sm btn-primary has-external-link" target="_blank" rel="noopener" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/49064754839441-Acc%C3%A9der-aux-webinaires">Je m'inscris</a>

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -39,7 +39,7 @@
                     </div>
                     {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail extra_classes="mb-3 mb-md-5" %}
                         {% fragment as c_info__summary %}
-                            Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion
+                            Rappel de l’adresse du salarié renseignée sur {% brand %}
                         {% endfragment %}
                         {% fragment as c_info__detail %}
                             {% if address_filled %}
@@ -49,7 +49,7 @@
                                     <li>{{ job_seeker.post_code }} {{ job_seeker.city }}</li>
                                 </ul>
                             {% else %}
-                                <p class="mb-0">Aucune adresse n'a été saisie sur les emplois de l'inclusion !</p>
+                                <p class="mb-0">Aucune adresse n'a été saisie sur {% brand %} !</p>
                             {% endif %}
                         {% endfragment %}
                     {% endcomponent_info %}

--- a/itou/templates/geiq_assessments/email/assessment_submission_body.txt
+++ b/itou/templates/geiq_assessments/email/assessment_submission_body.txt
@@ -3,7 +3,7 @@
 {% block body %}
 Bonjour,
 
-La structure `{{ assessment.label_geiq_name }}` a transmis son bilan d’exécution sur le site des Emplois de l’inclusion.
+La structure `{{ assessment.label_geiq_name }}` a transmis son bilan d’exécution sur le site {% brand "de" %}.
 
 Références du dossier :
 

--- a/itou/templates/includes/demo_accounts.html
+++ b/itou/templates/includes/demo_accounts.html
@@ -33,7 +33,7 @@
                     {% component_alert content=content variant="danger" icon=False %}
                         {% fragment as content %}
                             <p class="mb-0">
-                                L'environnement de démonstration des <b>emplois de l'inclusion</b> est limité à des fins de formation.
+                                L'environnement de démonstration de <b>{% brand %}</b> est limité à des fins de formation.
                                 <br>
                                 Les données, documents et e-mails envoyés depuis cet environnement n'ont <b>aucune valeur</b>.
                                 Ils sont susceptibles d'être <b>détruits à intervalle régulier</b>.

--- a/itou/templates/includes/demo_accounts.html
+++ b/itou/templates/includes/demo_accounts.html
@@ -33,7 +33,7 @@
                     {% component_alert content=content variant="danger" icon=False %}
                         {% fragment as content %}
                             <p class="mb-0">
-                                L'environnement de démonstration de <b>{% brand %}</b> est limité à des fins de formation.
+                                L'environnement de démonstration <b>{% brand "de" %}</b> est limité à des fins de formation.
                                 <br>
                                 Les données, documents et e-mails envoyés depuis cet environnement n'ont <b>aucune valeur</b>.
                                 Ils sont susceptibles d'être <b>détruits à intervalle régulier</b>.

--- a/itou/templates/includes/tarteaucitron_matomo.html
+++ b/itou/templates/includes/tarteaucitron_matomo.html
@@ -111,7 +111,7 @@
         {% else %}
             /* defaults to a stripped version (no suffix) of the page title. */
 
-            const title = document.title.replace(/- Les emplois de l'inclusion/g,'').trim();
+            const title = document.title.replace(/- {% brand %}/g,'').trim();
             window._paq.push(['setDocumentTitle', title]);
         {% endif %}
         /* beautify ignore:end */

--- a/itou/templates/invitations_views/email/invitation_establishment_body.txt
+++ b/itou/templates/invitations_views/email/invitation_establishment_body.txt
@@ -3,7 +3,7 @@
 
 Bonjour {{ first_name|title }} {{ last_name|upper }} !
 
-Vous avez été ajouté(e) à la structure {{ establishment.display_name }} sur les Emplois de l'inclusion. Cliquez sur le lien ci-dessous pour accéder à votre nouvel espace de travail.
+Vous avez été ajouté(e) à la structure {{ establishment.display_name }} sur {% brand %}. Cliquez sur le lien ci-dessous pour accéder à votre nouvel espace de travail.
 
 {{ acceptance_link }}
 

--- a/itou/templates/invitations_views/email/invitation_establishment_subject.txt
+++ b/itou/templates/invitations_views/email/invitation_establishment_subject.txt
@@ -1,6 +1,6 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
 
-{{ sender.get_full_name }} vous a ajouté(e) à l'organisation {{ establishment.display_name|truncatechars:80 }} sur les Emplois de l'inclusion.
+{{ sender.get_full_name }} vous a ajouté(e) à l'organisation {{ establishment.display_name|truncatechars:80 }} sur {% brand %}.
 
 {% endblock %}

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -15,7 +15,8 @@
                 </div>
                 <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
                     <a href="{% url 'home:hp' %}">
-                        <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="90" alt="Les emplois de l'inclusion">
+                        {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                        <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="90" alt="{% brand %}">
                     </a>
                 </div>
                 <div class="s-header__col s-header__col--nav col d-none d-lg-inline-flex d-lg-flex align-items-center justify-content-end pe-0 pe-xl-3">

--- a/itou/templates/layout/_header_authenticated.html
+++ b/itou/templates/layout/_header_authenticated.html
@@ -11,7 +11,8 @@
             <div class="s-header-authenticated__row row">
                 <div class="s-header-authenticated__col s-header-authenticated__col--logo-service col-auto d-flex align-items-center pe-0">
                     <a href="{% url 'home:hp' %}">
-                        <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion" height="90">
+                        {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                        <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="{% brand %}" height="90">
                     </a>
                 </div>
                 <div class="s-header-authenticated__col s-header-authenticated__col--nav col d-flex align-items-center justify-content-end pe-0">
@@ -80,7 +81,8 @@
         <div class="offcanvas-footer flex-column align-items-stretch">
             <div class="offcanvas-footer__legal">
                 <div class="d-none d-xl-block">
-                    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="Les emplois de l'inclusion" height="50">
+                    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" alt="{% brand %}" height="50">
                 </div>
                 <ul>
                     <li>

--- a/itou/templates/layout/_header_help_dropdown_content.html
+++ b/itou/templates/layout/_header_help_dropdown_content.html
@@ -39,6 +39,6 @@
         </li>
     {% endif %}
     <li>
-        <a href="{% url 'announcements:news' %}" class="dropdown-item" aria-label="Les nouveautés du site des emplois de l'inclusion" {% matomo_event "help" "clic" "header_nouveautes" %}>Nouveautés</a>
+        <a href="{% url 'announcements:news' %}" class="dropdown-item" aria-label="Les nouveautés du site {% brand "de" %}" {% matomo_event "help" "clic" "header_nouveautes" %}>Nouveautés</a>
     </li>
 </ul>

--- a/itou/templates/layout/_header_print.html
+++ b/itou/templates/layout/_header_print.html
@@ -7,7 +7,8 @@
                 <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" height="70" alt="République Française">
             </div>
             <div class="col d-flex align-items-center">
-                <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="60" alt="Les emplois de l'inclusion">
+                {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="60" alt="{% brand %}">
             </div>
             <div class="col-auto d-flex align-items-center fs-sm d-none d-print-inline-flex">Imprimé le {% now "d F Y" %}</div>
         </div>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -6,30 +6,33 @@
 <html lang="fr">
     <head>
         <meta charset="utf-8">
-        <title>{% block title %}- Les emplois de l'inclusion{% endblock %}</title>
+        <title>{% block title %}- {% brand %}{% endblock %}</title>
         {% block meta_description %}
             <meta name="description"
+                  {# TODO(branding): accord verbal avec la marque — réécrire la phrase avant le flip du nom #}
                   content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
         {% endblock %}
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         {# https://metatags.io #}
-        <meta name="title" content="Les emplois de l'inclusion">
+        <meta name="title" content="{% brand %}">
         {# Project uses custom styles for indicators, CSP compatibility #}
         <meta name="htmx-config" content='{"includeIndicatorStyles": false, "allowScriptTags":false, "requestClass": "has-spinner-loading"}'>
         {# https://metatags.io Open Graph / Facebook #}
         <meta property="og:type" content="website">
         <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
-        <meta property="og:title" content="Les emplois de l'inclusion">
+        <meta property="og:title" content="{% brand %}">
         <meta property="og:description"
               content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
+        {# TODO(branding): image de partage (logo_metatags.png) à refaire avec le nouveau logo #}
         <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
         {# https://metatags.io Twitter #}
         <meta property="twitter:card" content="summary_large_image">
         <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
-        <meta property="twitter:title" content="Les emplois de l'inclusion">
+        <meta property="twitter:title" content="{% brand %}">
         <meta property="twitter:description"
               content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
+        {# TODO(branding): image de partage (logo_metatags.png) à refaire avec le nouveau logo #}
         <meta property="twitter:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
 
         <link rel="shortcut icon" href="{% static_theme_images "favicon.ico" %}" type="image/ico">

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -7,10 +7,12 @@
     <head>
         <meta charset="utf-8">
         <title>{% block title %}- {% brand %}{% endblock %}</title>
+        {# Texte inséré tel quel dans un attribut HTML (non échappé) : pas de guillemet double ni d'esperluette. #}
+        {% fragment as meta_description %}
+            {% brand %} facilite l'orientation, l'accompagnement socio-professionnel et le retour à l'emploi des personnes en situation d'exclusion.
+        {% endfragment %}
         {% block meta_description %}
-            <meta name="description"
-                  {# TODO(branding): accord verbal avec la marque — réécrire la phrase avant le flip du nom #}
-                  content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
+            <meta name="description" content="{{ meta_description }}">
         {% endblock %}
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -22,16 +24,14 @@
         <meta property="og:type" content="website">
         <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
         <meta property="og:title" content="{% brand %}">
-        <meta property="og:description"
-              content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
+        <meta property="og:description" content="{{ meta_description }}">
         {# TODO(branding): image de partage (logo_metatags.png) à refaire avec le nouveau logo #}
         <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
         {# https://metatags.io Twitter #}
         <meta property="twitter:card" content="summary_large_image">
         <meta property="twitter:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
         <meta property="twitter:title" content="{% brand %}">
-        <meta property="twitter:description"
-              content="Les emplois de l'inclusion facilitent le retour à l'emploi des personnes en situation d'exclusion par l'orientation et le recrutement auprès d'employeurs inclusifs (structures de l'insertion par l'activité économique et du secteur adapté)">
+        <meta property="twitter:description" content="{{ meta_description }}">
         {# TODO(branding): image de partage (logo_metatags.png) à refaire avec le nouveau logo #}
         <meta property="twitter:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
 

--- a/itou/templates/layout/base_email_signature.txt
+++ b/itou/templates/layout/base_email_signature.txt
@@ -1,4 +1,4 @@
 ---
 {% if itou_environment != "PROD" %}[{{ itou_environment }}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{ itou_environment }}]{% endif %}
-Les emplois de l'inclusion
+{% brand %}
 {{ base_url }}

--- a/itou/templates/layout/base_printable.html
+++ b/itou/templates/layout/base_printable.html
@@ -4,7 +4,7 @@
 <html lang="fr">
     <head>
         <meta charset="utf-8">
-        <title>{% block title %}- Les emplois de l'inclusion{% endblock %}</title>
+        <title>{% block title %}- {% brand %}{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         {% block meta_description %}{% endblock %}
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}">

--- a/itou/templates/logout/warning.html
+++ b/itou/templates/logout/warning.html
@@ -21,9 +21,7 @@
                 </div>
                 <div class="s-section__col col-12 col-lg-10 bg-lg-white">
                     {% if warning == LogoutWarning.FT_NO_FT_ORGANIZATION %}
-                        <p>
-                            En tant qu’agent France Travail vous devez appartenir à une agence pour vous connecter aux Emplois de l’inclusion.
-                        </p>
+                        <p>En tant qu’agent France Travail vous devez appartenir à une agence pour vous connecter {% brand "à" %}.</p>
                         <p>Veuillez vous faire inviter par un collaborateur de votre agence afin d’accéder au service.</p>
                     {% elif warning == LogoutWarning.NO_ORGANIZATION %}
                         <p>

--- a/itou/templates/nexus/emplois_inactive.html
+++ b/itou/templates/nexus/emplois_inactive.html
@@ -6,12 +6,14 @@
 {% block title %}Fiches de poste {{ block.super }}{% endblock %}
 
 {% block service_title %}
-    <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="Les emplois de l’inclusion">
+    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+    <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="{% brand %}">
     Fiches de poste
 {% endblock %}
 
 {% block service_logo %}
-    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="50" alt="Les emplois de l’inclusion">
+    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="50" alt="{% brand %}">
 {% endblock %}
 
 {% block description %}
@@ -34,7 +36,7 @@
     <br>
     <a href="{% url "dashboard:index" %}"
        class="btn btn-sm btn-link has-external-link d-inline-block mt-3"
-       aria-label="Découvrir Les emplois de l’inclusion (lien externe)"
+       aria-label="Découvrir {% brand %} (lien externe)"
        target="_blank"
-       {% matomo_event "nexus" "decouvrir-service" Service.EMPLOIS %}>Découvrir Les emplois de l’inclusion</a>
+       {% matomo_event "nexus" "decouvrir-service" Service.EMPLOIS %}>Découvrir {% brand %}</a>
 {% endblock %}

--- a/itou/templates/nexus/emplois_job_descriptions.html
+++ b/itou/templates/nexus/emplois_job_descriptions.html
@@ -18,7 +18,8 @@
                     <div class="c-title align-items-center">
                         <div class="c-title__main">
                             <h1>
-                                <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="Les emplois de l’inclusion">
+                                {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                                <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="{% brand %}">
                                 Fiches de poste
                                 <span class="badge badge-sm rounded-pill bg-info-lighter text-info">
                                     <i class="ri-check-line" aria-hidden="true"></i>

--- a/itou/templates/nexus/emplois_no_companies.html
+++ b/itou/templates/nexus/emplois_no_companies.html
@@ -7,12 +7,14 @@
 {% block title %}Fiches de poste {{ block.super }}{% endblock %}
 
 {% block service_title %}
-    <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="Les emplois de l’inclusion">
+    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+    <img src="{% static_theme_images 'logo-emploi-inclusion-mono.svg' %}" height="35" width="35" alt="{% brand %}">
     Fiches de poste
 {% endblock %}
 
 {% block service_logo %}
-    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="50" alt="Les emplois de l’inclusion">
+    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+    <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="50" alt="{% brand %}">
 {% endblock %}
 
 {% block description %}
@@ -27,7 +29,7 @@
     <br>
     <a href="{% url "dashboard:index" %}"
        class="btn btn-sm btn-link has-external-link d-inline-block mt-3"
-       aria-label="Découvrir Les emplois de l’inclusion (lien externe)"
+       aria-label="Découvrir {% brand %} (lien externe)"
        target="_blank"
-       {% matomo_event "nexus" "decouvrir-service" Service.EMPLOIS %}>Découvrir Les emplois de l’inclusion</a>
+       {% matomo_event "nexus" "decouvrir-service" Service.EMPLOIS %}>Découvrir {% brand %}</a>
 {% endblock %}

--- a/itou/templates/nexus/homepage.html
+++ b/itou/templates/nexus/homepage.html
@@ -34,7 +34,10 @@
                         <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 row-cols-xxxl-4 mt-3 mt-md-4">
                             {% if Service.EMPLOIS in activated_services %}
                                 <div class="col mb-3 mb-md-4">
-                                    {% component_box_nexus_activated_service name="Les Emplois de l’inclusion" logo="logo-emploi-inclusion-mono.svg" url=emplois_url aria_label="Accéder aux Emplois de l’inclusion" service=Service.EMPLOIS %}
+                                    {% brand as brand_name %}
+                                    {% brand "à" as brand_a %}
+                                    {# TODO(branding): logo à basculer (logo-plateforme-inclusion) au flip du nom #}
+                                    {% component_box_nexus_activated_service name=brand_name logo="logo-emploi-inclusion-mono.svg" url=emplois_url aria_label="Accéder "|add:brand_a service=Service.EMPLOIS %}
                                     {% endcomponent_box_nexus_activated_service %}
                                 </div>
                             {% endif %}

--- a/itou/templates/nexus/layout/base.html
+++ b/itou/templates/nexus/layout/base.html
@@ -13,6 +13,7 @@
         <meta property="og:url" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}">
         <meta property="og:title" content="Plateforme de l’inclusion">
         <meta property="og:description" content="La Plateforme de l’inclusion facilite le retour à l'emploi des personnes en situation d'exclusion.">
+        {# TODO(branding): image de partage (logo_metatags.png) à refaire avec le nouveau logo #}
         <meta property="og:image" content="{{ ITOU_PROTOCOL }}://{{ ITOU_FQDN }}{% static "img/logo_metatags.png" %}">
 
         <link rel="shortcut icon" href="{% static_theme_images "favicon.ico" %}" type="image/ico">

--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -20,6 +20,7 @@
             <p class="mb-0">
                 Pour garantir la sécurité des données des personnes
                 accompagnées, la double authentification est obligatoire sur la
+                {# TODO(branding): « la plateforme La plateforme de l’inclusion » serait maladroit — réécrire la phrase avant le flip du nom #}
                 plateforme Les emplois de l’inclusion.
                 <br>
                 Configurez-la pour accéder à votre espace.

--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -38,6 +38,7 @@
                 <p class="mb-0">
                     Pour garantir la sécurité des données des personnes
                     accompagnées, la double authentification est obligatoire sur la
+                    {# TODO(branding): « la plateforme La plateforme de l’inclusion » serait maladroit — réécrire la phrase avant le flip du nom #}
                     plateforme Les emplois de l’inclusion.
                     <br>
                     Configurez-la pour accéder à votre espace.

--- a/itou/templates/otp_views/enrollment_step_0_intro.html
+++ b/itou/templates/otp_views/enrollment_step_0_intro.html
@@ -37,9 +37,7 @@
             {% fragment as content %}
                 <p class="mb-0">
                     Pour garantir la sécurité des données des personnes
-                    accompagnées, la double authentification est obligatoire sur la
-                    {# TODO(branding): « la plateforme La plateforme de l’inclusion » serait maladroit — réécrire la phrase avant le flip du nom #}
-                    plateforme Les emplois de l’inclusion.
+                    accompagnées, la double authentification est obligatoire sur {% brand %}.
                     <br>
                     Configurez-la pour accéder à votre espace.
                 </p>

--- a/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
+++ b/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
@@ -162,7 +162,7 @@
                         </li>
                         <li>Créez un compte sur le site du gestionnaire choisi.</li>
                         <li>
-                            Une fois connecté, créez une nouvelle entrée pour Les emplois de l’inclusion en y renseignant votre identifiant et mot de passe.
+                            Une fois connecté, créez une nouvelle entrée pour {% brand %} en y renseignant votre identifiant et mot de passe.
                         </li>
                         <li>
                             Dans cette fiche, cherchez l’option « Authentification à deux facteurs », « Code TOTP » ou « One-Time Password » selon le gestionnaire.

--- a/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
+++ b/itou/templates/otp_views/enrollment_step_1_choose_device_type.html
@@ -166,7 +166,7 @@
                         </li>
                         <li>Créez un compte sur le site du gestionnaire choisi.</li>
                         <li>
-                            Une fois connecté, créez une nouvelle entrée pour Les emplois de l’inclusion en y renseignant votre identifiant et mot de passe.
+                            Une fois connecté, créez une nouvelle entrée pour {% brand %} en y renseignant votre identifiant et mot de passe.
                         </li>
                         <li>
                             Dans cette fiche, cherchez l’option « Authentification à deux facteurs », « Code TOTP » ou « One-Time Password » selon le gestionnaire.

--- a/itou/templates/prescribers/email/validated_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/validated_prescriber_organization_email_body.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_body.txt" %}
 {% block body %}
 
-Merci de votre inscription. L'habilitation de votre organisation est maintenant vérifiée. Nous vous souhaitons bienvenue sur les emplois de l'inclusion !
+Merci de votre inscription. L'habilitation de votre organisation est maintenant vérifiée. Nous vous souhaitons bienvenue sur {% brand %} !
 
 *Organisation* :
 

--- a/itou/templates/search/includes/prescribers_search_results.html
+++ b/itou/templates/search/includes/prescribers_search_results.html
@@ -44,6 +44,6 @@
     <title>
         {% include "search/includes/prescribers_search_title.html" with city=city distance=distance only %}
         {# Cannot use block in includes #}
-        - Les emplois de l'inclusion
+        - {% brand %}
     </title>
 {% endif %}

--- a/itou/templates/search/includes/siaes_search_results.html
+++ b/itou/templates/search/includes/siaes_search_results.html
@@ -19,7 +19,7 @@
     <title>
         {% include "search/includes/siaes_search_title.html" %}
         {# Cannot use block in includes #}
-        - Les emplois de l'inclusion
+        - {% brand %}
     </title>
     {% include "search/includes/siaes_search_subtitle.html" %}
     {% include "search/includes/siaes_search_top.html" %}

--- a/itou/templates/search/includes/siaes_search_top.html
+++ b/itou/templates/search/includes/siaes_search_top.html
@@ -67,7 +67,7 @@
                             <div class="modal-body">
                                 <p class="fw-bold">Pour les résultats des postes ouverts au recrutement, l’ordre de priorité est le suivant&nbsp;:</p>
                                 <ol>
-                                    <li>Les postes des emplois de l’inclusion</li>
+                                    <li>Les postes {% brand "de" %}</li>
                                     <li>Les postes mis à jour ou créés récemment</li>
                                 </ol>
                             </div>

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -1,7 +1,9 @@
 {% extends "layout/base.html" %}
 {% load static %}
 
-{% block title %}Les emplois de l'inclusion{% endblock %}
+{% block title %}
+    {% brand %}
+{% endblock %}
 
 {% block body_class %}p-home{% endblock %}
 

--- a/itou/templates/siae_evaluations/email/to_institution_campaign_close_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_campaign_close_body.txt
@@ -5,7 +5,7 @@ Bonjour,
 Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
 Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
 
-Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+Veuillez vous connecter sur votre espace {% brand "de" %} afin d’effectuer cette démarche.
 {{ evaluated_siaes_list_url }}
 
 Cordialement,

--- a/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_selected_siae_body.txt
@@ -12,7 +12,7 @@ Les SIAE disposent d’un délai de 6 semaines pour transmettre les justificatif
 
 Les DDETS disposent d’un délai supplémentaire pour contrôler les justificatifs.
 
-Vous trouverez le calendrier de la campagne de contrôle a posteriori dans votre espace des emplois de l’inclusion.
+Vous trouverez le calendrier de la campagne de contrôle a posteriori dans votre espace {% brand "de" %}.
 
 Comment ça marche ?
 

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_body.txt
@@ -4,7 +4,7 @@ Bonjour,
 
 La phase de transmission des justificatifs par les SIAE est désormais terminée. Les DDETS disposent d’un délai supplémentaire* pour étudier les justificatifs et valider le contrôle de chaque SIAE.
 
-* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel {% brand "de" %}.
 
 Pour chaque SIAE contrôlée vous devez :
 - accepter ou refuser l’intégralité des justificatifs soumis

--- a/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
+++ b/itou/templates/siae_evaluations/email/to_institution_siaes_submission_frozen_reminder_body.txt
@@ -6,7 +6,7 @@ Une ou plusieurs SIAE qui ont transmis leurs justificatifs n’ont pas encore é
 
 En tant que membre de l’organisation {{ institution_name }}, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
 
-* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+* Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel {% brand "de" %}.
 
 Nous vous rappelons que pour chaque SIAE contrôlée vous devez :
 - accepter ou refuser l’intégralité des justificatifs soumis

--- a/itou/templates/siae_evaluations/includes/recommendations_modal.html
+++ b/itou/templates/siae_evaluations/includes/recommendations_modal.html
@@ -26,11 +26,11 @@
                     <li class="mb-3">
                         <strong>Notification de la sanction</strong>
                         <br>
-                        Pour la sanction « Participation à une session de présentation de l’auto-prescription », vous êtes invités à préciser directement dans les emplois de l’inclusion les motivations de la décision.
-                        Une notification e-mail sera automatiquement transmise à la SIAE par les emplois de l’inclusion pour ce type de sanction, ainsi qu’en l’absence de sanction.
+                        Pour la sanction « Participation à une session de présentation de l’auto-prescription », vous êtes invités à préciser directement dans {% brand %} les motivations de la décision.
+                        Une notification e-mail sera automatiquement transmise à la SIAE par {% brand %} pour ce type de sanction, ainsi qu’en l’absence de sanction.
                         <br>
                         <br>
-                        Les sanctions consistant à suspendre/retirer la capacité d’auto-prescription ou à supprimer tout ou partie de l’aide au poste ne font pas l’objet d’une notification à la SIAE par e-mail par les Emplois de l’inclusion, ni d’une information directement sur leur espace des Emplois de l’inclusion. La décision doit être notifiée à la SIAE par la DDETS par l’envoi d’une lettre recommandée avec accusé de réception ou par remise en main propre contre signature. Si vous sélectionnez l’une de ces sanctions, un modèle DGEFP de décision de sanction vous sera proposé à la fin de ce formulaire.
+                        Les sanctions consistant à suspendre/retirer la capacité d’auto-prescription ou à supprimer tout ou partie de l’aide au poste ne font pas l’objet d’une notification à la SIAE par e-mail par {% brand %}, ni d’une information directement sur leur espace {% brand "de" %}. La décision doit être notifiée à la SIAE par la DDETS par l’envoi d’une lettre recommandée avec accusé de réception ou par remise en main propre contre signature. Si vous sélectionnez l’une de ces sanctions, un modèle DGEFP de décision de sanction vous sera proposé à la fin de ce formulaire.
                     </li>
                 </ol>
             </div>

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -6,7 +6,8 @@
     <div class="c-form">
         <h3>Ce service est-il adapté à votre situation ?</h3>
         <p>
-            Les Emplois de l’inclusion met en relation les personnes éloignées de l’emploi avec des employeurs dont la mission est d’apporter un accompagnement socioprofessionnel pour les aider à accéder à l’emploi durable.
+            {# TODO(branding): périmètre périmé (emplois uniquement) — copy à réécrire #}
+            {% brand %} met en relation les personnes éloignées de l’emploi avec des employeurs dont la mission est d’apporter un accompagnement socioprofessionnel pour les aider à accéder à l’emploi durable.
         </p>
         <p>
             Avant de poursuivre votre inscription, <strong>vérifiez que vous remplissez les conditions d’accès à ce type d’emploi</strong>. En cas de doute, demandez à votre conseiller à l’emploi.

--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -28,6 +28,7 @@
     aria-label="schéma pluriannuel d’accessibilité 2023-2026, ouverture dans une nouvelle fenêtre">schéma pluriannuel d’accessibilité 2023-2026</a>.
             </p>
             <p>
+                {# TODO(branding): page RGAA — nom ET domaine à traiter avec le juridique, hors PR de tokenisation #}
                 Cette déclaration d'accessibilité s'applique au site web <b>Les emplois de l'inclusion</b>.
             </p>
         {% endfragment %}

--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -29,6 +29,7 @@
     aria-label="Schéma pluriannuel d’accessibilité 2025-2027, ouverture dans une nouvelle fenêtre">schéma pluriannuel d’accessibilité 2025-2027</a>.
             </p>
             <p>
+                {# TODO(branding): page RGAA — nom ET domaine à traiter avec le juridique, hors PR de tokenisation #}
                 Cette déclaration d'accessibilité s'applique au site web <b>Les emplois de l'inclusion</b>.
             </p>
         {% endfragment %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -16,7 +16,7 @@
             {% endif %}
             {% if is_stats_public %}
                 <p>
-                    Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
+                    Cette page a pour objectif de présenter l'impact {% brand "de" %}. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
                     <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" class="has-external-link" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">pilotage de l'inclusion</a>
                 </p>
             {% endif %}

--- a/itou/templates/users/emails/check_authorized_members_email_body.txt
+++ b/itou/templates/users/emails/check_authorized_members_email_body.txt
@@ -4,7 +4,7 @@ Bonjour,
 
 En tant qu’administrateur de l’organisation {{ structure.name }}, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
 
-RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : {{ members_url }}
+RDV sur votre espace {% brand "de" %} à la rubrique “Gérer les collaborateurs” : {{ members_url }}
 
 Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
 

--- a/itou/templates/welcoming_tour/employer.html
+++ b/itou/templates/welcoming_tour/employer.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 
-{% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
+{% block title %}Bienvenue sur {% brand %} ! {{ block.super }}{% endblock %}
 
 {% block content %}
     <section class="s-section">
@@ -18,7 +18,7 @@
                         <div class="carousel-inner pb-5">
                             <div class="carousel-item active">
                                 <div class="d-block w-100 text-center">
-                                    <h1 class="h1-hero-c1">Bienvenue sur les emplois de l'inclusion !</h1>
+                                    <h1 class="h1-hero-c1">Bienvenue sur {% brand %} !</h1>
                                     <figure class="mx-auto mb-3 w-sm-33">
                                         <img src="{% static 'img/welcoming_tour/employeur_1.svg' %}" loading="lazy" class="img-fitcover img-fluid" alt="">
                                     </figure>
@@ -41,7 +41,7 @@
                                         <img src="{% static 'img/welcoming_tour/employeur_2.svg' %}" loading="lazy" class="img-fitcover img-fluid" alt="">
                                     </figure>
                                     <p class="lead mb-5">
-                                        Grâce aux emplois de l'inclusion, disposez d’une plus large diffusion de vos offres
+                                        Grâce {% brand "à" %}, disposez d’une plus large diffusion de vos offres
                                         <br class="d-none d-md-inline">
                                         auprès des candidats à l’insertion de votre région.
                                         <br>

--- a/itou/templates/welcoming_tour/job_seeker.html
+++ b/itou/templates/welcoming_tour/job_seeker.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 
-{% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
+{% block title %}Bienvenue sur {% brand %} ! {{ block.super }}{% endblock %}
 
 {% block content %}
     <section class="s-section">
@@ -17,11 +17,12 @@
                         <div class="carousel-inner pb-5">
                             <div class="carousel-item active">
                                 <div class="d-block w-100 text-center">
-                                    <h1 class="h1-hero-c1">Bienvenue sur les emplois de l'inclusion !</h1>
+                                    <h1 class="h1-hero-c1">Bienvenue sur {% brand %} !</h1>
                                     <figure class="mx-auto mb-3 w-sm-33">
                                         <img src="{% static 'img/welcoming_tour/candidat_1.svg' %}" loading="lazy" class="img-fitcover img-fluid" alt="">
                                     </figure>
                                     <p class="lead pb-5">
+                                        {# TODO(branding): accord verbal avec la marque — réécrire la phrase avant le flip du nom #}
                                         Les emplois de l'inclusion m’aident dans ma recherche d’emploi en insertion.
                                         <br>
                                         Je trouve les offres proches de chez moi, et je contacte directement les employeurs.
@@ -44,6 +45,7 @@
                                     <p class="lead">
                                         Une fois inscrit, je trouve les offres d’insertion proches de moi, et j’envoie mes candidatures aux employeurs.
                                         <br>
+                                        {# TODO(branding): accord verbal avec la marque — réécrire la phrase avant le flip du nom #}
                                         Les emplois de l'inclusion m’informent par mail quand ma candidature est acceptée.
                                     </p>
                                     <p class="lead mb-5">

--- a/itou/templates/welcoming_tour/prescriber.html
+++ b/itou/templates/welcoming_tour/prescriber.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 
-{% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
+{% block title %}Bienvenue sur {% brand %} ! {{ block.super }}{% endblock %}
 
 {% block content %}
     <section class="s-section">
@@ -18,7 +18,7 @@
                         <div class="carousel-inner pb-5">
                             <div class="carousel-item active">
                                 <div class="d-block w-100 text-center">
-                                    <h1 class="h1-hero-c1">Bienvenue sur les emplois de l'inclusion !</h1>
+                                    <h1 class="h1-hero-c1">Bienvenue sur {% brand %} !</h1>
                                     <figure class="mx-auto mb-3 w-sm-33">
                                         <img src="{% static 'img/welcoming_tour/prescripteur_1.svg' %}" loading="lazy" class="img-fitcover img-fluid" alt="">
                                     </figure>

--- a/itou/utils/brand.py
+++ b/itou/utils/brand.py
@@ -1,0 +1,17 @@
+"""Single source of truth for the product name.
+
+The whole name, article included, is treated as an invariant proper noun
+(capital initial even mid-sentence). The "de" and "à" forms exist because
+the article contraction depends on the name's gender and number: renaming
+the product only requires updating this mapping.
+"""
+
+FORMS = {
+    None: "Les emplois de l’inclusion",
+    "de": "des Emplois de l’inclusion",
+    "à": "aux Emplois de l’inclusion",
+}
+
+
+def product_name(prep=None):
+    return FORMS[prep]

--- a/itou/utils/templatetags/branding.py
+++ b/itou/utils/templatetags/branding.py
@@ -1,0 +1,13 @@
+"""https://docs.djangoproject.com/en/dev/howto/custom-template-tags/"""
+
+from django import template
+
+from itou.utils.brand import product_name
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def brand(prep=None):
+    return product_name(prep)

--- a/itou/utils/templatetags/nexus.py
+++ b/itou/utils/templatetags/nexus.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from itou.nexus.enums import Service
+from itou.utils.brand import product_name
 from itou.utils.enums import ItouEnvironment
 from itou.utils.templatetags.matomo import matomo_event
 from itou.utils.templatetags.url_add_query import autologin_proconnect
@@ -21,9 +22,9 @@ def get_template_context(context, service):
     }
     services_context = {
         Service.EMPLOIS: {
-            "name": "Les Emplois de l’inclusion",
+            "name": product_name(),
             "description": "Le service de recrutement et de gestion des PASS IAE.",
-            "logo": "logo-emploi-inclusion-mono.svg",
+            "logo": "logo-emploi-inclusion-mono.svg",  # TODO(branding): logo à basculer au flip du nom
             "etoile": "nexus/nx-forme-etoile-emplois.png",
             "items_short": [
                 "Publiez vos recrutements",
@@ -253,8 +254,8 @@ def new_service(context, service):
 def get_services_context():
     return {
         Service.EMPLOIS: {
-            "name": "Les Emplois de l’inclusion",
-            "logo": "logo-emploi-inclusion.svg",
+            "name": product_name(),
+            "logo": "logo-emploi-inclusion.svg",  # TODO(branding): logo à basculer au flip du nom
             "one_click_activation": False,
         },
         Service.DORA: {

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -30,6 +30,7 @@ from itou.prescribers.enums import PrescriberAuthorizationStatus
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import UserKind
 from itou.users.models import User
+from itou.utils.brand import product_name
 from itou.utils.constants import MB
 from itou.utils.db import or_queries
 from itou.utils.validators import MaxDateValidator, MinDateValidator
@@ -391,10 +392,11 @@ class CreateProlongationRequestForm(CreateProlongationForm):
                 self.add_error(
                     "email",
                     format_html(
-                        "Cet utilisateur n’est pas inscrit en tant que prescripteur habilité sur les "
-                        'emplois de l’inclusion, vous pouvez <a href="{}" rel="noopener" target="_blank" '
+                        "Cet utilisateur n’est pas inscrit en tant que prescripteur habilité sur {}, "
+                        'vous pouvez <a href="{}" rel="noopener" target="_blank" '
                         'aria-label="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)">retrouver ici'
                         "</a> des prescripteurs habilités autour de chez vous.",
+                        product_name(),
                         reverse("search:prescribers_home"),
                     ),
                 )

--- a/tests/approvals/__snapshots__/test_admin.ambr
+++ b/tests/approvals/__snapshots__/test_admin.ambr
@@ -26,14 +26,14 @@
   
   Vous avez la possibilité de contacter un prescripteur habilité pour exposer la situation de votre candidat.
   
-  Si le prescripteur habilité est favorable à une dérogation de son délai de carence, il doit vous transmettre la candidature de DUPONT Jean via les emplois de l'inclusion. Vous pourrez ensuite demander l'obtention d'un PASS IAE.
+  Si le prescripteur habilité est favorable à une dérogation de son délai de carence, il doit vous transmettre la candidature de DUPONT Jean via Les emplois de l’inclusion. Vous pourrez ensuite demander l'obtention d'un PASS IAE.
   
   Pour trouver les prescripteurs habilités proches de vous, pensez à utiliser le moteur de recherche depuis votre tableau de bord :
   http://localhost:8000/search/prescribers
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -24,7 +24,7 @@
   - Motif de prolongation : 50 ans et plus
   - Fiche bilan : http://localhost:8000/approvals/prolongation/request/666/report-file/
   
-  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
+  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur Les emplois de l’inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
   
   Précisions en cas de refus :
   
@@ -45,7 +45,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -83,7 +83,7 @@
   - Motif de prolongation : 50 ans et plus
   - Fiche bilan : http://localhost:8000/approvals/prolongation/request/666/report-file/
   
-  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
+  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur Les emplois de l’inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
   
   Précisions en cas de refus :
   
@@ -104,7 +104,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -135,11 +135,11 @@
   
   - Précisions : [proposed_actions_explanation]
   
-  Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
+  Vous pouvez consulter la date de fin prévisionnelle du PASS IAE dans votre espace employeur sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -171,11 +171,11 @@
   De votre côté, n’hésitez pas à prendre contact avec notre partenaire, l’Afpa, l’organisme de référence pour la formation en France. Ils pourront vous conseiller et trouver avec vous la formation dont vous avez peut-être besoin pour trouver rapidement un emploi.
   Pour être rappelé par un conseiller : https://cloud.info.afpa.fr/afpa-plateforme-emploi-et-inclusion
   
-  Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
+  Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -201,11 +201,11 @@
   
   - Précisions : [proposed_actions_explanation]
   
-  Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
+  Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -222,11 +222,11 @@
   Numéro : 99999 99 99999
   Bénéficiaire : DOE Jane
   
-  Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur les emplois de l’inclusion.
+  Vous pouvez consulter la nouvelle date de fin prévisionnelle du PASS IAE dans votre espace employeur sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -241,11 +241,11 @@
   
   L’organisation Pres. Org. a accepté la prolongation du PASS IAE.
   
-  Vous pouvez consulter la nouvelle date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
+  Vous pouvez consulter la nouvelle date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/approvals/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/approvals/__snapshots__/test_prolongation_requests.ambr
@@ -44,7 +44,7 @@
   - Motif de prolongation : 50 ans et plus
   - Fiche bilan : http://localhost:8000/approvals/prolongation/request/666/report-file/
   
-  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur les emplois de l'inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
+  Vous pouvez valider ou refuser cette prolongation en vous connectant à votre espace prescripteur Pres. Org. sur Les emplois de l’inclusion, à la rubrique "Gérer mes prolongations de PASS IAE".
   
   Précisions en cas de refus :
   
@@ -65,7 +65,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -26,18 +26,18 @@
 # name: TestAnonymizeJobseekersManagementCommand.test_anonymize_notification_of_inactive_jobseekers_after_grace_period[is_active_jobseeker][archived_jobseeker_email_body]
   '''
   Bonjour Johanna ANDREWS,
-  Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion associé à l’email jobseeker@example.com serait supprimé.
+  Le XX/XX/XXXX, nous vous avons informé que votre compte sur Les emplois de l’inclusion associé à l’email jobseeker@example.com serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
   En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_anonymize_notification_of_inactive_jobseekers_after_grace_period[is_active_jobseeker][archived_jobseeker_email_subject]
-  '[TEST] Suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[anonymized_jobseeker]
   list([
@@ -806,18 +806,18 @@
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_body]
   '''
   Bonjour Micheline DUBOIS,
-  Le 17/06/2025, nous vous avons informé que votre compte sur les Emplois de l’inclusion associé à l’email micheline.dubois@example.com serait supprimé.
+  Le 17/06/2025, nous vous avons informé que votre compte sur Les emplois de l’inclusion associé à l’email micheline.dubois@example.com serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
   En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_subject]
-  '[TEST] Suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[anonymized_professionals_with_annotations]
   list([
@@ -3595,64 +3595,64 @@
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_contact][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_contact][inactive_jobseeker_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_body]
   '''
   Bonjour Micheline DUBOIS,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse micheline.dubois@example.com depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse micheline.dubois@example.com depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -26,18 +26,18 @@
 # name: TestAnonymizeJobseekersManagementCommand.test_anonymize_notification_of_inactive_jobseekers_after_grace_period[is_active_jobseeker][archived_jobseeker_email_body]
   '''
   Bonjour Johanna ANDREWS,
-  Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion associé à l’email jobseeker@example.com serait supprimé.
+  Le XX/XX/XXXX, nous vous avons informé que votre compte sur Les emplois de l’inclusion associé à l’email jobseeker@example.com serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
   En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_anonymize_notification_of_inactive_jobseekers_after_grace_period[is_active_jobseeker][archived_jobseeker_email_subject]
-  '[TEST] Suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[anonymized_jobseeker]
   list([
@@ -806,18 +806,18 @@
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_body]
   '''
   Bonjour Micheline DUBOIS,
-  Le 17/06/2025, nous vous avons informé que votre compte sur les Emplois de l’inclusion associé à l’email micheline.dubois@example.com serait supprimé.
+  Le 17/06/2025, nous vous avons informé que votre compte sur Les emplois de l’inclusion associé à l’email micheline.dubois@example.com serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
   En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_subject]
-  '[TEST] Suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[anonymized_professionals_with_annotations]
   list([
@@ -3566,48 +3566,48 @@
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse jane.doe@test.local depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---
 # name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_body]
   '''
   Bonjour Micheline DUBOIS,
-  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion associé à l’adresse micheline.dubois@example.com depuis le XX/XX/XXXX.
+  Nous n’avons détecté aucune activité sur votre compte sur Les emplois de l’inclusion associé à l’adresse micheline.dubois@example.com depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
   Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_subject]
-  '[TEST] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+  '[TEST] Information avant suppression de votre compte sur Les emplois de l’inclusion'
 # ---

--- a/tests/companies/__snapshots__/test_management_commands.ambr
+++ b/tests/companies/__snapshots__/test_management_commands.ambr
@@ -594,7 +594,7 @@
   Nous vous informons que votre fiche de poste intitulée Agent / Agente cariste de livraison ferroviaire à Vannes - 56 au sein de la structure EI ACME Inc. a été dépubliée automatiquement, car elle n’a pas été mise à jour depuis plus de 3 mois.
   
   En cas de besoin, vous pouvez réactiver cette fiche de poste depuis votre espace :
-  Structure > Métiers et recrutements sur les Emplois de l’inclusion http://localhost:8000/.
+  Structure > Métiers et recrutements sur Les emplois de l’inclusion http://localhost:8000/.
   
   Si cette fiche de poste n’est plus d’actualité, aucune action de votre part n’est nécessaire.
   
@@ -604,7 +604,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1111,7 +1111,7 @@
   
   Si vous souhaitez continuer à recevoir des candidatures spontanées, vous pouvez réactiver cette fonctionnalité depuis votre espace :
   
-  Structure > Métiers et recrutements sur les Emplois de l’inclusion
+  Structure > Métiers et recrutements sur Les emplois de l’inclusion
   
   Si vous ne recrutez plus actuellement, aucune action de votre part n’est nécessaire.
   
@@ -1121,7 +1121,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -245,7 +245,7 @@ class TestImportSiaeManagementCommands:
         assert len(mailoutbox) == 6
         assert reverse("signup:company_select") in mailoutbox[0].body
         assert collections.Counter(mail.subject for mail in mailoutbox) == collections.Counter(
-            f"[TEST] Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"
+            f"[TEST] Activez le compte de votre {kind} {name} sur Les emplois de l’inclusion"
             for (kind, name) in Company.objects.values_list("kind", "name")
         )
 

--- a/tests/job_applications/__snapshots__/tests.ambr
+++ b/tests/job_applications/__snapshots__/tests.ambr
@@ -11,7 +11,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -33,7 +33,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -49,7 +49,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -75,7 +75,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -95,7 +95,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -117,7 +117,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -137,7 +137,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -163,7 +163,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1365,7 +1365,7 @@ class TestJobApplicationNotifications:
         assert len(email.to) == 1
         assert len(email.bcc) == 0
         # Subject.
-        assert "Candidature acceptée et votre avis sur les emplois de l'inclusion" in email.subject
+        assert "Candidature acceptée et votre avis sur Les emplois de l’inclusion" in email.subject
         # Body.
         assertion = assertIn if is_authorized_prescriber else assertNotInCaseFolded
         assertion(job_application.job_seeker.get_inverted_full_name(), email.body)
@@ -1572,8 +1572,8 @@ class TestJobApplicationNotifications:
         email = job_application.notifications_deliver_approval(job_application.to_company.members.first()).build()
 
         assert (
-            f"[TEST] PASS IAE pour {job_application.job_seeker.get_inverted_full_name()} et avis sur les emplois "
-            "de l'inclusion" == email.subject
+            f"[TEST] PASS IAE pour {job_application.job_seeker.get_inverted_full_name()} et avis sur Les emplois "
+            "de l’inclusion" == email.subject
         )
         assert "PASS IAE" in email.body
 
@@ -1729,7 +1729,7 @@ class TestJobApplicationNotifications:
 
 class TestJobApplicationWorkflow:
     SENT_PASS_EMAIL_SUBJECT = "PASS IAE pour"
-    ACCEPT_EMAIL_SUBJECT_PROXY = "Candidature acceptée et votre avis sur les emplois de l'inclusion"
+    ACCEPT_EMAIL_SUBJECT_PROXY = "Candidature acceptée et votre avis sur Les emplois de l’inclusion"
     ACCEPT_EMAIL_SUBJECT_JOB_SEEKER = "Candidature acceptée"
 
     @pytest.fixture(autouse=True)

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -465,7 +465,7 @@ class TestFranceConnect:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "La connexion via FranceConnect a fonctionné mais le compte lié sur les Emplois de l’inclusion"
+                        "La connexion via FranceConnect a fonctionné mais le compte lié sur Les emplois de l’inclusion"
                         " est désactivé. Veuillez vous rapprocher du support pour débloquer la situation en suivant "
                         '<a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr">ce lien</a> et en leur '
                         f"fournissant l’identifiant public de ce compte : {user.public_id}."

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -471,7 +471,7 @@ class TestFranceConnect:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "La connexion via FranceConnect a fonctionné mais le compte lié sur les Emplois de l’inclusion"
+                        "La connexion via FranceConnect a fonctionné mais le compte lié sur Les emplois de l’inclusion"
                         " est désactivé. Veuillez vous rapprocher du support pour débloquer la situation en suivant "
                         '<a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr">ce lien</a> et en leur '
                         f"fournissant l’identifiant public de ce compte : {user.public_id}."

--- a/tests/openid_connect/ft_connect/tests.py
+++ b/tests/openid_connect/ft_connect/tests.py
@@ -322,7 +322,7 @@ class TestPoleEmploiConnect:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "La connexion via Pôle emploi Connect a fonctionné mais le compte lié sur les Emplois de "
+                        "La connexion via Pôle emploi Connect a fonctionné mais le compte lié sur Les emplois de "
                         "l’inclusion est désactivé. Veuillez vous rapprocher du support pour débloquer la situation "
                         'en suivant <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr">ce lien</a> et en leur'
                         f" fournissant l’identifiant public de ce compte : {user.public_id}."

--- a/tests/openid_connect/ft_connect/tests.py
+++ b/tests/openid_connect/ft_connect/tests.py
@@ -334,7 +334,7 @@ class TestPoleEmploiConnect:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "La connexion via France Travail Connect a fonctionné mais le compte lié sur les Emplois de "
+                        "La connexion via France Travail Connect a fonctionné mais le compte lié sur Les emplois de "
                         "l’inclusion est désactivé. Veuillez vous rapprocher du support pour débloquer la situation "
                         'en suivant <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr">ce lien</a> et en leur'
                         f" fournissant l’identifiant public de ce compte : {user.public_id}."

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -408,7 +408,7 @@ class TestProConnectCallbackView:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "La connexion via ProConnect a fonctionné mais le compte lié sur les Emplois de l’inclusion "
+                        "La connexion via ProConnect a fonctionné mais le compte lié sur Les emplois de l’inclusion "
                         "est désactivé. Veuillez vous rapprocher du support pour débloquer la situation en suivant "
                         '<a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr">ce lien</a> et en leur '
                         f"fournissant l’identifiant public de ce compte : {user.public_id}."

--- a/tests/siae_evaluations/__snapshots__/test_emails.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_emails.ambr
@@ -13,7 +13,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -24,14 +24,14 @@
   Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
-  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  Veuillez vous connecter sur votre espace des Emplois de l’inclusion afin d’effectuer cette démarche.
   http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1/
   
   Cordialement,
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -47,7 +47,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
@@ -7,7 +7,7 @@
   
   En tant que membre de l’organisation DDETS 01, nous vous invitons à finaliser ce contrôle. Sans réponse de votre part avant la fin de cette phase*, le résultat du contrôle des SIAE non contrôlées sera par défaut positif.
   
-  * Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des emplois de l’inclusion.
+  * Pour plus de détails sur la durée de chaque phase, vous pouvez consulter le calendrier disponible dans votre espace professionnel des Emplois de l’inclusion.
   
   Nous vous rappelons que pour chaque SIAE contrôlée vous devez :
   - accepter ou refuser l’intégralité des justificatifs soumis
@@ -17,7 +17,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -105,7 +105,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -125,7 +125,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -136,14 +136,14 @@
   Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
-  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  Veuillez vous connecter sur votre espace des Emplois de l’inclusion afin d’effectuer cette démarche.
   http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -161,7 +161,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -172,14 +172,14 @@
   Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
-  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  Veuillez vous connecter sur votre espace des Emplois de l’inclusion afin d’effectuer cette démarche.
   http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -793,7 +793,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -811,7 +811,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -839,7 +839,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -861,7 +861,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -883,7 +883,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -907,7 +907,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -923,7 +923,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -941,7 +941,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -957,7 +957,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -977,7 +977,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -999,7 +999,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1023,7 +1023,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -129,7 +129,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -149,7 +149,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -160,14 +160,14 @@
   Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
-  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  Veuillez vous connecter sur votre espace des Emplois de l’inclusion afin d’effectuer cette démarche.
   http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -185,7 +185,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -196,14 +196,14 @@
   Suite au dernier contrôle a posteriori, une ou plusieurs SIAE de votre département ont obtenu un résultat négatif.
   Conformément au  Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, les manquements constatés ainsi que les sanctions envisagées doivent être notifiés aux SIAE.
   
-  Veuillez vous connecter sur votre espace des emplois de l’inclusion afin d’effectuer cette démarche.
+  Veuillez vous connecter sur votre espace des Emplois de l’inclusion afin d’effectuer cette démarche.
   http://localhost:8000/siae_evaluation/institution_evaluated_siae_list/1000/
   
   Cordialement,
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -919,7 +919,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -937,7 +937,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -965,7 +965,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -987,7 +987,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1009,7 +1009,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1033,7 +1033,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1049,7 +1049,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1067,7 +1067,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1083,7 +1083,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1103,7 +1103,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1125,7 +1125,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1149,7 +1149,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/users/__snapshots__/test_management_commands.ambr
+++ b/tests/users/__snapshots__/test_management_commands.ambr
@@ -3,7 +3,7 @@
   '''
   Bonjour John DOE
   
-  L'espace de travail de votre structure ACME Inc. (EI) sur les emplois de l'inclusion ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
+  L'espace de travail de votre structure ACME Inc. (EI) sur Les emplois de l’inclusion ne disposait plus d'administrateur actif. Nous vous avons donc attribué automatiquement ce rôle afin d'en assurer la gestion.
   
   Ce statut vous permet d'avoir accès à certaines fonctionnalités, la liste complète est disponible ici : https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738355467409.
   
@@ -11,7 +11,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -298,7 +298,7 @@
   
   En tant qu’administrateur de l’organisation Company 1, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
   
-  RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/company/colleagues
+  RDV sur votre espace des Emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/company/colleagues
   
   Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
   
@@ -310,7 +310,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -320,7 +320,7 @@
   
   En tant qu’administrateur de l’organisation Institution 1, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
   
-  RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/institutions/colleagues
+  RDV sur votre espace des Emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/institutions/colleagues
   
   Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
   
@@ -332,7 +332,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -342,7 +342,7 @@
   
   En tant qu’administrateur de l’organisation Organization 1, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
   
-  RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
+  RDV sur votre espace des Emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
   
   Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
   
@@ -354,7 +354,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -364,7 +364,7 @@
   
   En tant qu’administrateur de l’organisation Organization 1, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
   
-  RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
+  RDV sur votre espace des Emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
   
   Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
   
@@ -376,7 +376,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -386,7 +386,7 @@
   
   En tant qu’administrateur de l’organisation Organization 1, nous vous invitons à vérifier la liste des membres afin de vous assurer que seuls les collaborateurs qui travaillent au sein de cette organisation puissent accéder à votre espace de travail.
   
-  RDV sur votre espace des emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
+  RDV sur votre espace des Emplois de l’inclusion à la rubrique “Gérer les collaborateurs” : http://localhost:8000/prescribers/colleagues
   
   Si un collaborateur a quitté votre organisation, vous devez le retirer des membres en cliquant sur le bouton d’action situé à droite, puis sur l’option “retirer de la structure”.
   
@@ -396,7 +396,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/users/__snapshots__/test_models.ambr
+++ b/tests/users/__snapshots__/test_models.ambr
@@ -165,7 +165,7 @@
   '''
   Bonjour Monsieur John DOE,
   
-  Votre compte candidat vient d’être créé sur les Emplois de l’inclusion par Pierre DUPONT de Pres. Org..
+  Votre compte candidat vient d’être créé sur Les emplois de l’inclusion par Pierre DUPONT de Pres. Org..
   
   Pour finaliser votre inscription, merci de cliquer sur le lien suivant : [RESET PASSWORD LINK REMOVED]. Ce lien expirera dans 14 jours.
   Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité à définir un mot de passe pour votre compte candidat.
@@ -174,7 +174,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/users/__snapshots__/test_models.ambr
+++ b/tests/users/__snapshots__/test_models.ambr
@@ -195,7 +195,7 @@
   '''
   Bonjour Monsieur John DOE,
   
-  Votre compte candidat vient d’être créé sur les Emplois de l’inclusion par Pierre DUPONT de Pres. Org..
+  Votre compte candidat vient d’être créé sur Les emplois de l’inclusion par Pierre DUPONT de Pres. Org..
   
   Pour finaliser votre inscription, merci de cliquer sur le lien suivant : [RESET PASSWORD LINK REMOVED]. Ce lien expirera dans 14 jours.
   Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité à définir un mot de passe pour votre compte candidat.
@@ -204,7 +204,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/utils/test_brand.py
+++ b/tests/utils/test_brand.py
@@ -1,0 +1,19 @@
+from django.template import Context, Template
+
+from itou.utils.brand import product_name
+
+
+# These assertions are deliberately literal: they are the proof that the
+# user-facing product name changed when the brand mapping is updated.
+def test_product_name():
+    assert product_name() == "Les emplois de l’inclusion"
+    assert product_name("de") == "des Emplois de l’inclusion"
+    assert product_name("à") == "aux Emplois de l’inclusion"
+
+
+def test_brand_template_tag_is_builtin():
+    template = Template("Bienvenue sur {% brand %}, le site {% brand 'de' %} : parlez {% brand 'à' %}.")
+    assert template.render(Context()) == (
+        "Bienvenue sur Les emplois de l’inclusion, le site des Emplois de l’inclusion : "
+        "parlez aux Emplois de l’inclusion."
+    )

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -466,7 +466,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -477,7 +477,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -799,7 +799,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -810,7 +810,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -1099,7 +1099,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -1110,7 +1110,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -1489,7 +1489,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -1500,7 +1500,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -1866,7 +1866,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -1877,7 +1877,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -2135,7 +2135,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -2146,7 +2146,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -2272,7 +2272,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -2578,7 +2578,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -2589,7 +2589,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -2890,7 +2890,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -2901,7 +2901,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>
@@ -3204,7 +3204,7 @@
                           </a>
                       </li>
                       <li>
-                          <a aria-label="Les nouveautés du site des emplois de l'inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
+                          <a aria-label="Les nouveautés du site des Emplois de l’inclusion" class="dropdown-item" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_nouveautes" href="/announcements/news/">
                               Nouveautés
                           </a>
                       </li>
@@ -3215,7 +3215,7 @@
       <div class="offcanvas-footer flex-column align-items-stretch">
           <div class="offcanvas-footer__legal">
               <div class="d-none d-xl-block">
-                  <img alt="Les emplois de l'inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
+                  <img alt="Les emplois de l’inclusion" height="50" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion.svg"/>
               </div>
               <ul>
                   <li>

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1155,7 +1155,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1178,7 +1178,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1197,7 +1197,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1212,7 +1212,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1231,7 +1231,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1246,7 +1246,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1265,7 +1265,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5659,7 +5659,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5682,7 +5682,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5701,7 +5701,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5716,7 +5716,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5735,7 +5735,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5750,7 +5750,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5769,7 +5769,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1155,7 +1155,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1178,7 +1178,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1197,7 +1197,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1212,7 +1212,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1231,7 +1231,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1246,7 +1246,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -1265,7 +1265,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5906,7 +5906,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5929,7 +5929,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5948,7 +5948,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5967,7 +5967,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -5990,7 +5990,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -6009,7 +6009,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -6032,7 +6032,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -2,7 +2,7 @@
 # name: TestApprovalProlongation.test_check_invalid_prescriber[unknown authorized prescriber]
   '''
   <div class="invalid-feedback d-block">
-      Cet utilisateur n’est pas inscrit en tant que prescripteur habilité sur les emplois de l’inclusion, vous pouvez
+      Cet utilisateur n’est pas inscrit en tant que prescripteur habilité sur Les emplois de l’inclusion, vous pouvez
       <a aria-label="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)" href="/search/prescribers" rel="noopener" target="_blank">
           retrouver ici
       </a>

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -3,7 +3,7 @@
   '''
   Bonjour John DOE
   
-  Vous avez désormais le statut d’administrateur sur l’espace professionnel de votre organisation ACME Inc. (EI) sur les emplois de l’inclusion.
+  Vous avez désormais le statut d’administrateur sur l’espace professionnel de votre organisation ACME Inc. (EI) sur Les emplois de l’inclusion.
   
   Ce statut vous permet d’avoir accès à certaines fonctionnalités, la liste complète est disponible ici : https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738355467409.
   
@@ -11,7 +11,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -185,7 +185,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -194,7 +194,7 @@
 # ---
 # name: TestUserMembershipDeactivation.test_deactivate_user
   '''
-  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion
   
   Organisation :
   
@@ -203,11 +203,11 @@
   
   - Email de contact : petitspaniers@mailinator.com
   
-  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/companies_views/test_members_views.py
+++ b/tests/www/companies_views/test_members_views.py
@@ -195,7 +195,7 @@ class TestUserMembershipDeactivation:
         assert len(mailoutbox) == 1
         email = mailoutbox[0]
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {company.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to[0] == guest.email
         assert email.body == snapshot
         received_invitation.refresh_from_db()
@@ -290,7 +290,7 @@ class TestUserMembershipDeactivation:
         ) in caplog.messages
         [email] = mailoutbox
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {company.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to == [other_admin_membership.user.email]
         invitation.refresh_from_db()
         assert invitation.has_expired is True

--- a/tests/www/dashboard/__snapshots__/test_api_token.ambr
+++ b/tests/www/dashboard/__snapshots__/test_api_token.ambr
@@ -87,7 +87,7 @@
                                   APIs
                               </h2>
                               <p>
-                                  Une API (application programming interface ou « interface de programmation d’application ») est une interface logicielle qui permet de « connecter » le site des emplois de l’inclusion à un autre logiciel ou service afin d’échanger des données et des fonctionnalités.
+                                  Une API (application programming interface ou « interface de programmation d’application ») est une interface logicielle qui permet de « connecter » le site des Emplois de l’inclusion à un autre logiciel ou service afin d’échanger des données et des fonctionnalités.
                               </p>
                               <p>
                                   En tant qu’administrateur de structures, vous avez accès aux API suivantes :

--- a/tests/www/dashboard/test_api_token.py
+++ b/tests/www/dashboard/test_api_token.py
@@ -39,7 +39,7 @@ def test_api_token_view_for_company_admin(client, mailoutbox):
         [messages.Message(messages.SUCCESS, "Votre nouveau token a été créé avec succès.", extra_tags="toast")],
     )
     [email] = mailoutbox
-    assert email.subject.endswith("Génération d’un nouveau token d’API sur les Emplois de l'inclusion")
+    assert email.subject.endswith("Génération d’un nouveau token d’API sur Les emplois de l’inclusion")
     assert user_ip_address in email.body
 
     # Check multi-posts
@@ -99,7 +99,7 @@ def test_api_token_view_regenerate(client, mailoutbox):
     assertContains(response, token.key)
     assertContains(response, "Il est indispensable de le copier afin de le sauvegarder")
     [email] = mailoutbox
-    assert email.subject.endswith("Génération d’un nouveau token d’API sur les Emplois de l'inclusion")
+    assert email.subject.endswith("Génération d’un nouveau token d’API sur Les emplois de l’inclusion")
 
     response = client.post(API_TOKEN_URL, {"action": "regenerate"})
     # Previous token has been deleted
@@ -108,7 +108,7 @@ def test_api_token_view_regenerate(client, mailoutbox):
     new_token = Token.objects.filter(user=employer).get()
     assert len(mailoutbox) == 2
     new_email = mailoutbox[-1]
-    assert new_email.subject.endswith("Génération d’un nouveau token d’API sur les Emplois de l'inclusion")
+    assert new_email.subject.endswith("Génération d’un nouveau token d’API sur Les emplois de l’inclusion")
     assertContains(response, new_token.key)
     assertContains(response, "Il est indispensable de le copier afin de le sauvegarder")
     assertMessages(

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -260,7 +260,7 @@ class TestEditJobSeekerInfo:
         assert email.to == [job_seeker.email]
         assert len(email.bcc) == 0
         # Subject
-        assert "Vos données personnelles ont été mises à jour sur les Emplois de l'inclusion" in email.subject
+        assert "Vos données personnelles ont été mises à jour sur Les emplois de l’inclusion" in email.subject
         # Body
         assert job_seeker.get_full_name() in email.body
         assert job_application.to_company.name in email.body
@@ -275,7 +275,7 @@ class TestEditJobSeekerInfo:
         assert email.to == [job_seeker.email, old_email_address]
         assert len(email.bcc) == 0
         # Subject
-        assert "Votre adresse e-mail a été mise à jour sur les Emplois de l'inclusion" in email.subject
+        assert "Votre adresse e-mail a été mise à jour sur Les emplois de l’inclusion" in email.subject
         # Body
         assert job_seeker.get_full_name() in email.body
         assert job_application.to_company.name in email.body

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -596,7 +596,7 @@ class TestCreateEmployeeRecordStep1(CreateEmployeeRecordTestMixin):
 
 
 class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
-    NO_ADDRESS_FILLED_IN = "Aucune adresse n'a été saisie sur les emplois de l'inclusion !"
+    NO_ADDRESS_FILLED_IN = "Aucune adresse n'a été saisie sur Les emplois de l’inclusion !"
     ADDRESS_COULD_NOT_BE_AUTO_CHECKED = "L'adresse du salarié n'a pu être vérifiée automatiquement."
     ERRONEOUS_ADDRESS_COULD_LEAD_TO_ERROR = (
         "Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié."

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1317,7 +1317,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1316,7 +1316,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -17,7 +17,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -43,7 +43,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -77,7 +77,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -99,7 +99,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -2312,7 +2312,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/institutions_views/__snapshots__/test_views.ambr
+++ b/tests/www/institutions_views/__snapshots__/test_views.ambr
@@ -1,18 +1,18 @@
 # serializer version: 1
 # name: TestMembers.test_deactivate_user
   '''
-  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion
   
   Organisation :
   
   - Nom : DDETS 14
   - Type : DDETS IAE
   
-  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -183,7 +183,7 @@ class TestMembers:
         # User must have been notified of deactivation (we're human after all)
         [email] = mailoutbox
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {institution.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to == [guest_membership.user.email]
         assert email.body == snapshot
         received_invitation.refresh_from_db()
@@ -267,7 +267,7 @@ class TestMembers:
         ) in caplog.messages
         [email] = mailoutbox
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {institution.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to == [other_admin_membership.user.email]
         invitation.refresh_from_db()
         assert invitation.has_expired is True

--- a/tests/www/job_seekers_views/test_nir_modification_request.py
+++ b/tests/www/job_seekers_views/test_nir_modification_request.py
@@ -77,7 +77,7 @@ def test_nir_modification_request_title_blocks_reflects_actor(client, is_proxy):
     soup = parse_response_to_soup(response)
     title = f"Demande de régularisation NIR{name_fragment}"
     assert title == soup.select_one("h1").text.strip()
-    title += " - Les emplois de l'inclusion"
+    title += " - Les emplois de l’inclusion"
     assert title == soup.select_one("title").text.strip()
 
 

--- a/tests/www/nexus/__snapshots__/test_views.ambr
+++ b/tests/www/nexus/__snapshots__/test_views.ambr
@@ -411,10 +411,10 @@
                           <div class="col mb-3 mb-md-4">
                               <div class="c-box h-100">
                                   <div class="d-flex align-items-center gap-3">
-                                      <img alt="Les Emplois de l’inclusion" height="35" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion-mono.svg" width="35"/>
+                                      <img alt="Les emplois de l’inclusion" height="35" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion-mono.svg" width="35"/>
                                       <div>
                                           <strong class="d-block fs-lg">
-                                              Les Emplois de l’inclusion
+                                              Les emplois de l’inclusion
                                           </strong>
                                           <p class="mb-0 fs-sm">
                                               Plateforme de l’inclusion
@@ -540,10 +540,10 @@
                           <div class="col mb-3 mb-md-4">
                               <div class="c-box h-100">
                                   <div class="d-flex align-items-center gap-3">
-                                      <img alt="Les Emplois de l’inclusion" height="35" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion-mono.svg" width="35"/>
+                                      <img alt="Les emplois de l’inclusion" height="35" src="/static/vendor/theme-inclusion/images/logo-emploi-inclusion-mono.svg" width="35"/>
                                       <div>
                                           <strong class="d-block fs-lg">
-                                              Les Emplois de l’inclusion
+                                              Les emplois de l’inclusion
                                           </strong>
                                           <p class="mb-0 fs-sm">
                                               Plateforme de l’inclusion

--- a/tests/www/prescribers_views/__snapshots__/test_members.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_members.ambr
@@ -129,7 +129,7 @@
 # ---
 # name: TestUserMembershipDeactivation.test_deactivate_user
   '''
-  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion
   
   Organisation :
   
@@ -138,11 +138,11 @@
   
   - Email de contact : ml@mailinator.com
   
-  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur Les emplois de l’inclusion.
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -209,7 +209,7 @@ class TestUserMembershipDeactivation:
         assert len(mailoutbox) == 1
         email = mailoutbox[0]
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to[0] == guest.email
         assert email.body == snapshot
         received_invitation.refresh_from_db()
@@ -309,7 +309,7 @@ class TestUserMembershipDeactivation:
         ) in caplog.messages
         [email] = mailoutbox
         assert f"[TEST] [Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
-        assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
+        assert "Un administrateur vous a retiré d'une structure sur Les emplois de l’inclusion" in email.body
         assert email.to == [other_admin_membership.user.email]
         invitation.refresh_from_db()
         assert invitation.has_expired is True

--- a/tests/www/search_views/test_services.py
+++ b/tests/www/search_views/test_services.py
@@ -69,7 +69,7 @@ class TestSearchServices:
             self.URL, {"city": vannes.slug, "category": CATEGORY, "reception": ServiceSearchForm.RECEPTION_ALL_VALUE}
         )
         assertContains(response, "2 résultats")
-        expected_title = f"Services d'insertion « {CATEGORY.label} » autour de {vannes} - Les emplois de l'inclusion"
+        expected_title = f"Services d'insertion « {CATEGORY.label} » autour de {vannes} - Les emplois de l’inclusion"
         assertContains(response, f"<title>{expected_title}</title>", html=True, count=1)
         assert pretty_indented(parse_response_to_soup(response, selector="#services-search-results")) == snapshot()
 

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -325,7 +325,7 @@ class TestSearchCompany:
     def test_has_no_active_members(self, client):
         create_test_romes_and_appellations(["N1101"], appellations_per_rome=1)
         no_hiring_str = (
-            "Cet employeur n'est actuellement pas inscrit sur le site des emplois de l’inclusion, "
+            "Cet employeur n'est actuellement pas inscrit sur le site des Emplois de l’inclusion, "
             "vous ne pouvez pas déposer de candidature en ligne"
         )
         city = create_city_saint_andre()
@@ -633,7 +633,7 @@ class TestSearchPrescriber:
 
         assertContains(
             response,
-            "<title>Prescripteurs habilités à 15 km du centre de Guérande (44) - Les emplois de l'inclusion</title>",
+            "<title>Prescripteurs habilités à 15 km du centre de Guérande (44) - Les emplois de l’inclusion</title>",
             html=True,
             count=1,
         )
@@ -653,7 +653,7 @@ class TestSearchPrescriber:
         response = client.get(url)
         assertContains(
             response,
-            "<title>Rechercher des prescripteurs habilités - Les emplois de l'inclusion</title>",
+            "<title>Rechercher des prescripteurs habilités - Les emplois de l’inclusion</title>",
             html=True,
             count=1,
         )

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -332,7 +332,7 @@ class TestSearchCompany:
     def test_has_no_active_members(self, client):
         create_test_romes_and_appellations(["N1101"], appellations_per_rome=1)
         no_hiring_str = (
-            "Cet employeur n'est actuellement pas inscrit sur le site des emplois de l’inclusion, "
+            "Cet employeur n'est actuellement pas inscrit sur le site des Emplois de l’inclusion, "
             "vous ne pouvez pas déposer de candidature en ligne"
         )
         city = create_city_saint_andre()
@@ -640,7 +640,7 @@ class TestSearchPrescriber:
 
         assertContains(
             response,
-            "<title>Prescripteurs habilités à 15 km du centre de Guérande (44) - Les emplois de l'inclusion</title>",
+            "<title>Prescripteurs habilités à 15 km du centre de Guérande (44) - Les emplois de l’inclusion</title>",
             html=True,
             count=1,
         )
@@ -660,7 +660,7 @@ class TestSearchPrescriber:
         response = client.get(url)
         assertContains(
             response,
-            "<title>Rechercher des prescripteurs habilités - Les emplois de l'inclusion</title>",
+            "<title>Rechercher des prescripteurs habilités - Les emplois de l’inclusion</title>",
             html=True,
             count=1,
         )

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2506,7 +2506,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "---\n"
             "[TEST] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [TEST]\n"
-            "Les emplois de l'inclusion\n"
+            "Les emplois de l’inclusion\n"
             "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == "RDV le lundi 8 à 15h à la DDETS"
@@ -3396,7 +3396,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "---\n"
             "[TEST] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [TEST]\n"
-            "Les emplois de l'inclusion\n"
+            "Les emplois de l’inclusion\n"
             "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2511,7 +2511,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "---\n"
             "[TEST] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [TEST]\n"
-            "Les emplois de l'inclusion\n"
+            "Les emplois de l’inclusion\n"
             "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == "RDV le lundi 8 à 15h à la DDETS"
@@ -3402,7 +3402,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "---\n"
             "[TEST] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [TEST]\n"
-            "Les emplois de l'inclusion\n"
+            "Les emplois de l’inclusion\n"
             "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -9,7 +9,7 @@
   
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
-  Les emplois de l'inclusion
+  Les emplois de l’inclusion
   http://localhost:8000/
   '''
 # ---
@@ -167,7 +167,7 @@
   '''
   Bonjour,
   
-  Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (http://localhost:8000/).
+  Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur Les emplois de l’inclusion (http://localhost:8000/).
   
   Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
   
@@ -175,13 +175,13 @@
   
   Si vous avez fait cette demande de nouveau mot de passe :
   
-  - Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
+  - Assurez-vous que vous n’aviez pas créé votre compte sur Les emplois de l’inclusion depuis une autre adresse e-mail.
   - Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
   
   http://localhost:8000/signup/
   
   Cordialement,
   
-  L’équipe des emplois de l’inclusion
+  L’équipe des Emplois de l’inclusion
   '''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le site s'appelle Les emplois de l'inclusion (ou les Emplois de l'inclusion, ou les emplois de l'inclusion, ou les Emplois, ou les emplois, passons). Début septembre, on va le renommer en La plateforme de l'inclusion. Cette PR prépare cette bascule, qui concerne :

- textes visibles dans l'interface
- logos
- certains commentaires et documentations d'API
- les tests qui concernent l'interface

Cette bascule ne concerne pas :

- les documents juridiques (qui sont versionnés et qui seront l'objet d'une nouvelle rédaction)
- les identifiants dans le code (pour le tracking Matomo par exemple)
- l'historique

## :cake: Comment ? <!-- optionnel -->

En ne changeant rien. Cette PR ne change pas la marque, mais prépare sa bascule. Son seul effet va être d'harmoniser les façons d'écrire « Les emplois de l'inclusion ».

Deux chemins :

- un tag `brand` pour les templates, qui insère le bon nom de marque, proprement décliné (c’est-à-dire en anticipant les « **des** Emplois de l'inclusion » ou les « **aux** Emplois de l'inclusion »).
- différents `TODO(branding)` pour les choses qui nécessiteront une action ultérieure (remplacer une image, réécrire un texte).

La grande bascule impliquera de ne changer qu'un fichier + de résoudre ces todo.

On pourrait aussi, soit :

- mettre `TODO(branding)` partout, et se passer du tag.
- ne rien faire, et faire une seule PR qui change directement le texte en « La plateforme de l'inclusion ».

Cette PR apporte un léger gain de temps et de paix d'esprit en anticipant, mais si la complexité ne vaut pas la chandelle, on pourra passer par un autre chemin.

## :desert_island: Comment tester ?

Cette PR ne doit pas avoir d'effet visible (modulo des variantes de majuscules). On testera en regardant les emails et le corps de l'interface.

Changelog -> interface