### PR TITLE
Construire les URLs absolus avec request.get_host si possible

### DIFF
--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -49,7 +49,7 @@ def get_es256_key():
 def france_connect_authorize(request):
     # The redirect_uri should be defined in the FC settings to be allowed
     # NB: the integration platform allows "http://127.0.0.1:8000/franceconnect/callback"
-    redirect_uri = get_absolute_url(reverse("france_connect:callback"))
+    redirect_uri = get_absolute_url(reverse("france_connect:callback"), host=request.get_host())
     nonce = crypto.get_random_string(32)
     state = FranceConnectState.save_state(nonce=nonce)
     data = {
@@ -107,7 +107,7 @@ def france_connect_callback(request):
         )
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
-    redirect_uri = get_absolute_url(reverse("france_connect:callback"))
+    redirect_uri = get_absolute_url(reverse("france_connect:callback"), host=request.get_host())
     data = {
         "client_id": settings.FRANCE_CONNECT_CLIENT_ID,
         "client_secret": settings.FRANCE_CONNECT_CLIENT_SECRET,
@@ -241,7 +241,7 @@ def france_connect_logout(request):
     params = {
         "id_token_hint": id_token,
         "state": state,
-        "post_logout_redirect_uri": get_absolute_url(reverse("search:employers_home")),
+        "post_logout_redirect_uri": get_absolute_url(reverse("search:employers_home"), host=request.get_host()),
     }
     complete_url = f"{constants.FRANCE_CONNECT_ENDPOINT_LOGOUT}?{urlencode(params)}"
     return HttpResponseRedirect(complete_url)

--- a/itou/openid_connect/ft_connect/views.py
+++ b/itou/openid_connect/ft_connect/views.py
@@ -45,7 +45,7 @@ def _redirect_to_job_seeker_login_on_error(error_msg, request, extra_tags=""):
 def pe_connect_authorize(request):
     # The redirect_uri should be defined in the PEAMU settings to be allowed
     # NB: the integration platform allows "http://127.0.0.1:8000/pe_connect/callback"
-    redirect_uri = get_absolute_url(reverse("ft_connect:callback"))
+    redirect_uri = get_absolute_url(reverse("ft_connect:callback"), host=request.get_host())
     nonce = crypto.get_random_string(12)
     state = PoleEmploiConnectState.save_state(nonce=nonce)
     data = {
@@ -81,7 +81,7 @@ def pe_connect_callback(request):
         )
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
-    redirect_uri = get_absolute_url(reverse("ft_connect:callback"))
+    redirect_uri = get_absolute_url(reverse("ft_connect:callback"), host=request.get_host())
 
     data = {
         "client_id": settings.API_ESD["KEY"],
@@ -218,7 +218,7 @@ def pe_connect_logout(request):
 
     params = {
         "id_token_hint": id_token,
-        "redirect_uri": get_absolute_url(reverse("search:employers_home")),
+        "redirect_uri": get_absolute_url(reverse("search:employers_home"), host=request.get_host()),
     }
     url = constants.PE_CONNECT_ENDPOINT_LOGOUT
     complete_url = f"{url}?{urlencode(params)}"

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -64,8 +64,8 @@ def _redirect_to_login_page_on_error(error_msg=None, request=None):
     return HttpResponseRedirect(reverse("search:employers_home"))
 
 
-def _generate_pro_params_from_session(pc_data):
-    redirect_uri = get_absolute_url(reverse("pro_connect:callback"))
+def _generate_pro_params_from_session(pc_data, host):
+    redirect_uri = get_absolute_url(reverse("pro_connect:callback"), host=host)
     nonce = crypto.get_random_string(length=12)
     state = ProConnectState.save_state(data=pc_data, nonce=nonce)
     data = {
@@ -142,7 +142,7 @@ def pro_connect_authorize(request):
     if user_email := request.GET.get("user_email"):
         pc_data.user_email = user_email
 
-    data = _generate_pro_params_from_session(dataclasses.asdict(pc_data))
+    data = _generate_pro_params_from_session(dataclasses.asdict(pc_data), request.get_host())
 
     base_url = constants.PRO_CONNECT_ENDPOINT_AUTHORIZE
     return HttpResponseRedirect(f"{base_url}?{urlencode(data)}")
@@ -150,7 +150,7 @@ def pro_connect_authorize(request):
 
 def _get_token(request, code):
     # Retrieve token from ProConnect
-    token_redirect_uri = get_absolute_url(reverse("pro_connect:callback"))
+    token_redirect_uri = get_absolute_url(reverse("pro_connect:callback"), host=request.get_host())
     data = {
         "client_id": constants.PRO_CONNECT_CLIENT_ID,
         "client_secret": constants.PRO_CONNECT_CLIENT_SECRET,
@@ -402,7 +402,7 @@ def pro_connect_logout(request):
     params = {
         "id_token_hint": token,
         "state": logout_state,
-        "post_logout_redirect_uri": get_absolute_url(post_logout_redirect_url),
+        "post_logout_redirect_uri": get_absolute_url(post_logout_redirect_url, host=request.get_host()),
     }
     complete_url = add_url_params(constants.PRO_CONNECT_ENDPOINT_LOGOUT, params)
     return HttpResponseRedirect(complete_url)

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -41,10 +41,11 @@ def get_safe_url(request, param_name=None, fallback_url=None, url=None):
     return fallback_url
 
 
-def get_absolute_url(path=""):
+def get_absolute_url(path="", host=None):
+    host = host or settings.ITOU_FQDN
     if path.startswith("/"):
         path = path[1:]
-    return f"{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/{path}"
+    return f"{settings.ITOU_PROTOCOL}://{host}/{path}"
 
 
 def get_external_link_markup(url, text):

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import random
 import time
+import urllib.parse
 import uuid
 
 import httpx
@@ -14,6 +15,7 @@ from cryptography.utils import int_to_bytes
 from django.conf import settings
 from django.contrib import auth, messages
 from django.core.exceptions import ValidationError
+from django.http import QueryDict
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -155,6 +157,9 @@ class TestFranceConnect:
         assert f"state={fc_state.state}" in response.url
         assert fc_state.nonce is not None
         assert f"nonce={fc_state.nonce}" in response.url
+        urlparts = urllib.parse.urlsplit(response.url)
+        query = QueryDict(urlparts.query)
+        assert query["redirect_uri"] == "http://testserver/franceconnect/callback"
 
     def test_create_django_user(self):
         """
@@ -533,7 +538,7 @@ class TestFranceConnect:
         response = client.get(url, data={"id_token": "123", "state": "some_state"})
         expected_url = (
             f"{constants.FRANCE_CONNECT_ENDPOINT_LOGOUT}?id_token_hint=123&state=some_state&"
-            "post_logout_redirect_uri=http%3A%2F%2Flocalhost:8000%2Fsearch%2Femployers"
+            "post_logout_redirect_uri=http%3A%2F%2Ftestserver%2Fsearch%2Femployers"
         )
         assertRedirects(response, expected_url, fetch_redirect_response=False)
 

--- a/tests/openid_connect/ft_connect/tests.py
+++ b/tests/openid_connect/ft_connect/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import urllib.parse
 
 import httpx
 import pytest
@@ -6,6 +7,7 @@ import respx
 from django.conf import settings
 from django.contrib import auth, messages
 from django.core.exceptions import ValidationError
+from django.http import QueryDict
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -123,6 +125,9 @@ class TestPoleEmploiConnect:
         assert f"state={pec_state.state}" in response.url
         assert pec_state.nonce is not None
         assert f"nonce={pec_state.nonce}" in response.url
+        urlparts = urllib.parse.urlsplit(response.url)
+        query = QueryDict(urlparts.query)
+        assert query["redirect_uri"] == "http://testserver/pe_connect/callback"
 
     def test_create_user(self):
         """
@@ -431,7 +436,7 @@ class TestPoleEmploiConnect:
         response = client.get(url, data={"id_token": "123"})
         expected_url = (
             f"{constants.PE_CONNECT_ENDPOINT_LOGOUT}?id_token_hint=123&"
-            "redirect_uri=http%3A%2F%2Flocalhost:8000%2Fsearch%2Femployers"
+            "redirect_uri=http%3A%2F%2Ftestserver%2Fsearch%2Femployers"
         )
         assertRedirects(response, expected_url, fetch_redirect_response=False)
 

--- a/tests/openid_connect/pro_connect/testing.py
+++ b/tests/openid_connect/pro_connect/testing.py
@@ -1,11 +1,10 @@
 from copy import deepcopy
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlsplit
 
 import httpx
 import jwt
 import respx
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import crypto, timezone
@@ -135,9 +134,10 @@ def assert_and_mock_forced_logout(client, response, id_token, expected_redirect_
     query_params = parse_qs(urlparse(response.url).query)
     post_logout_redirect_uri = query_params["post_logout_redirect_uri"][0]
     state = query_params["state"][0]
-    local_url = post_logout_redirect_uri.split(settings.ITOU_FQDN)[1]
-    assert local_url == reverse("pro_connect:logout_callback")
-    response = client.get(add_url_params(local_url, {"state": state}))
+    urlparts = urlsplit(post_logout_redirect_uri)
+    assert urlparts.path == reverse("pro_connect:logout_callback")
+    assert urlparts.netloc == "testserver"
+    response = client.get(add_url_params(urlparts.path, {"state": state}))
     assertRedirects(response, expected_redirect_url)
     return response
 

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -688,7 +688,7 @@ class TestProConnectLogout:
         pro_connect.mock_oauth_dance(client)
         logout_response = client.post(reverse("account_logout"))
         response = client.get(logout_response.url)
-        post_logout_redirect_uri = get_absolute_url(reverse("pro_connect:logout_callback"))
+        post_logout_redirect_uri = get_absolute_url(reverse("pro_connect:logout_callback"), host="testserver")
         state = ProConnectState.objects.get(used_at=None).state
         signed_state = signing.Signer().sign(state)
 
@@ -713,7 +713,7 @@ class TestProConnectLogout:
         logout_response = client.post(reverse("account_logout"), {"redirect_url": expected_redirection})
 
         response = client.get(logout_response.url)
-        post_logout_redirect_uri = get_absolute_url(reverse("pro_connect:logout_callback"))
+        post_logout_redirect_uri = get_absolute_url(reverse("pro_connect:logout_callback"), host="testserver")
         state = ProConnectState.objects.get(used_at=None).state
         signed_state = signing.Signer().sign(state)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter le test du nouveau domaine plateforme.inclusion.gouv.fr. Sans ce changement, les utilisateurs sont toujours ramenés sur `https://emplois.inclusion.beta.gouv.fr` (`ITOU_FQDN`).
