### PR TITLE
Employeur: Rendre obligatoire la saisie du commentaire de mise en attente de candidature

### DIFF
--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -38,7 +38,7 @@
             {% bootstrap_form form alert_error_type="all" %}
 
             {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
-            {% itou_buttons_form primary_label="Mettre en liste d'attente" reset_url=reset_url show_mandatory_fields_mention=False matomo_category="candidature" matomo_action="submit" matomo_name="postpone_application_confirmation" %}
+            {% itou_buttons_form primary_label="Mettre en liste d'attente" reset_url=reset_url show_mandatory_fields_mention=True matomo_category="candidature" matomo_action="submit" matomo_name="postpone_application_confirmation" %}
 
         </form>
     </div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -268,7 +268,6 @@ class AnswerForm(forms.Form):
         label="Réponse",
         widget=forms.Textarea(),
         help_text="Votre réponse sera visible par le candidat et le prescripteur",
-        required=False,
         strip=True,
     )
 

--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -152,7 +152,11 @@ def postpone(request):
 
     if not form.is_valid():
         # This is unlikely since the form is quite simple and the answer field is required
-        messages.error(request, "Les candidatures n’ont pas pu être mises en attente.")
+        messages.error(
+            request,
+            "Les candidatures n’ont pas pu être mises en attente : le commentaire est obligatoire.",
+            extra_tags="toast",
+        )
         logger.error(
             "user=%s tried to batch postponed %s applications but the form wasn't valid",
             request.user.pk,

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -8243,11 +8243,11 @@
               </div>
               <form action="/apply/company/batch/postpone?next_url=/apply/siae/list%3Fdisplay%3Dtable%26start_date%3D2015-01-01" method="post">
                   <div class="modal-body">
-                      <div class="form-group">
+                      <div class="form-group form-group-required">
                           <label class="form-label" for="id_answer">
                               Commentaire à envoyer au candidat
                           </label>
-                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" rows="10"></textarea>
+                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" required="" rows="10"></textarea>
                           <div class="form-text" id="id_answer_helptext">
                               Votre réponse sera visible par le candidat et le prescripteur
                           </div>
@@ -8284,11 +8284,11 @@
               </div>
               <form action="/apply/company/batch/postpone?next_url=/apply/siae/list%3Fdisplay%3Dtable%26start_date%3D2015-01-01" method="post">
                   <div class="modal-body">
-                      <div class="form-group">
+                      <div class="form-group form-group-required">
                           <label class="form-label" for="id_answer">
                               Commentaire à envoyer aux 2 candidats
                           </label>
-                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" rows="10"></textarea>
+                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" required="" rows="10"></textarea>
                           <div class="form-text" id="id_answer_helptext">
                               Votre réponse sera visible par le candidat et le prescripteur
                           </div>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -8136,11 +8136,11 @@
               </div>
               <form action="/apply/company/batch/postpone?next_url=/apply/siae/list%3Fstart_date%3D2015-01-01" method="post">
                   <div class="modal-body">
-                      <div class="form-group">
+                      <div class="form-group form-group-required">
                           <label class="form-label" for="id_answer">
                               Commentaire à envoyer au candidat
                           </label>
-                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" rows="10"></textarea>
+                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" required="" rows="10"></textarea>
                           <div class="form-text" id="id_answer_helptext">
                               Votre réponse sera visible par le candidat et le prescripteur
                           </div>
@@ -8177,11 +8177,11 @@
               </div>
               <form action="/apply/company/batch/postpone?next_url=/apply/siae/list%3Fstart_date%3D2015-01-01" method="post">
                   <div class="modal-body">
-                      <div class="form-group">
+                      <div class="form-group form-group-required">
                           <label class="form-label" for="id_answer">
                               Commentaire à envoyer aux 2 candidats
                           </label>
-                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" rows="10"></textarea>
+                          <textarea aria-describedby="id_answer_helptext" class="form-control" cols="40" id="id_answer" name="answer" placeholder="Votre réponse sera visible par les candidats et les prescripteurs/orienteurs" required="" rows="10"></textarea>
                           <div class="form-text" id="id_answer_helptext">
                               Votre réponse sera visible par le candidat et le prescripteur
                           </div>

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -5714,6 +5714,10 @@
   
   Suite à votre candidature au sein de la structure EI ACME Inc., l’employeur a mis votre candidature en attente.
   
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
   Les emplois de l'inclusion
@@ -5728,6 +5732,10 @@
   Bonjour,
   
   La candidature de D… J… au sein de la structure EI ACME Inc. a été mise en attente par l’employeur.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
   
   -----
   
@@ -5748,6 +5756,10 @@
   
   Suite à votre candidature au sein de la structure EI ACME Inc., l’employeur a mis votre candidature en attente.
   
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
   Les emplois de l'inclusion
@@ -5762,6 +5774,10 @@
   Bonjour,
   
   La candidature de DOE Jane au sein de la structure EI ACME Inc. a été mise en attente par l’employeur.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
   
   -----
   

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -5997,6 +5997,10 @@
   
   Suite à votre candidature au sein de la structure EI ACME Inc., l’employeur a mis votre candidature en attente.
   
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
   Les emplois de l'inclusion
@@ -6011,6 +6015,10 @@
   Bonjour,
   
   La candidature de D… J… au sein de la structure EI ACME Inc. a été mise en attente par l’employeur.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
   
   -----
   
@@ -6031,6 +6039,10 @@
   
   Suite à votre candidature au sein de la structure EI ACME Inc., l’employeur a mis votre candidature en attente.
   
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
   ---
   [TEST] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [TEST]
   Les emplois de l'inclusion
@@ -6045,6 +6057,10 @@
   Bonjour,
   
   La candidature de DOE Jane au sein de la structure EI ACME Inc. a été mise en attente par l’employeur.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
   
   -----
   

--- a/tests/www/apply/test_batch_views.py
+++ b/tests/www/apply/test_batch_views.py
@@ -705,11 +705,15 @@ class TestBatchPostpone:
         )
         assertRedirects(response, next_url)
         postponable_app.refresh_from_db()
-        assert postponable_app.state == JobApplicationState.POSTPONED
+        assert postponable_app.state == JobApplicationState.PROCESSING
         assert postponable_app.answer == ""
         assertMessages(
             response,
-            [messages.Message(messages.SUCCESS, "La candidature a bien été mise en attente.", extra_tags="toast")],
+            [
+                messages.Message(
+                    messages.ERROR, "Les candidatures n’ont pas pu être mises en attente.", extra_tags="toast"
+                )
+            ],
         )
 
     def test_unpostponable(self, client):

--- a/tests/www/apply/test_batch_views.py
+++ b/tests/www/apply/test_batch_views.py
@@ -705,11 +705,17 @@ class TestBatchPostpone:
         )
         assertRedirects(response, next_url)
         postponable_app.refresh_from_db()
-        assert postponable_app.state == JobApplicationState.POSTPONED
+        assert postponable_app.state == JobApplicationState.PROCESSING
         assert postponable_app.answer == ""
         assertMessages(
             response,
-            [messages.Message(messages.SUCCESS, "La candidature a bien été mise en attente.", extra_tags="toast")],
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "Les candidatures n’ont pas pu être mises en attente : le commentaire est obligatoire.",
+                    extra_tags="toast",
+                )
+            ],
         )
 
     def test_unpostponable(self, client):

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1608,7 +1608,7 @@ class TestProcessViews:
         response = client.get(url)
         assert response.status_code == 200
 
-        post_data = {"answer": ""}
+        post_data = {"answer": "On vous rappellera."}
         response = client.post(url, data=post_data)
         next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
         assertRedirects(response, next_url)

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1608,7 +1608,7 @@ class TestProcessViews:
         response = client.get(url)
         assert response.status_code == 200
 
-        post_data = {"answer": ""}
+        post_data = {"answer": "On vous rappellera."}
         response = client.post(url, data=post_data)
         next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
         assertRedirects(response, next_url)
@@ -1691,6 +1691,25 @@ class TestProcessViews:
         assert mail_to_other_employer.to == [job_application.sender.email]
         assert mail_to_other_employer.subject == snapshot(name="postpone_email_to_proxy_subject")
         assert mail_to_other_employer.body == snapshot(name="postpone_email_to_proxy_body")
+
+    def test_postpone_missing_answer(self, client):
+        company = CompanyFactory(with_membership=True)
+        job_application = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            to_company=company,
+            state=JobApplicationState.PROCESSING,
+            answer="",
+        )
+        client.force_login(company.members.first())
+
+        url = reverse("apply:postpone", kwargs={"job_application_id": job_application.pk})
+        response = client.post(url, data={"answer": ""})
+
+        assert response.status_code == 200
+        assert response.context["form"].has_error("answer")
+        job_application.refresh_from_db()
+        assert job_application.state == JobApplicationState.PROCESSING
+        assert job_application.answer == ""
 
     @pytest.mark.parametrize(
         "eligibility_trait,expected_msg",


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Rendre obligatoire la saisie du commentaire de mise en attente de candidature](https://app.notion.com/p/gip-inclusion/Rendre-obligatoire-la-saisie-du-commentaire-de-mise-en-attente-de-candidature-3a45f321b6048074a209c98ed0dd8221)
TLDR: juste rendre le champ de réponse pour la mise en attente d'une candidature obligatoire.

Vu avec Zora: les batch form sont également concernés.

## :cake: Comment ? <!-- optionnel -->

Juste en retirant `required=False` du champ commentaire, et passant `show_mandatory_fields_mention` du composant à `True`.

David, je t'ai mis en copie pour info parce que le front est concerné, mais c'est un changement de UI mineur.

## :desert_island: Comment tester ?

Il y a ce qu'il faut pour tester (une candidature en attente) en tant qu'IA. Aller pour la mettre en attente, tenter de soumettre avec un champ vide : erreur.

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
<img width="1216" height="455" alt="Capture d’écran 2026-07-22 à 12 11 16" src="https://github.com/user-attachments/assets/83ef8b95-e6a1-4f01-b649-00b0eb53ea2e" />
