### PR TITLE
insertion: Correction d'un problème de sélection de sous-filtres de recherche

### DIFF
--- a/itou/templates/search/services/results.html
+++ b/itou/templates/search/services/results.html
@@ -26,7 +26,7 @@
 {% block title_extra %}
     <div class="c-search mt-3 mt-md-4">
         <div class="c-search__bar">
-            <form hx-boost="true" hx-push-url="true" hx-indicator="#services-search-results" id="top_search_form">
+            <form hx-boost="true" hx-push-url="true" hx-include="#filters_form" hx-indicator="#services-search-results" id="top_search_form">
                 {% if job_seeker.public_id %}
                     <input type="hidden" name="job_seeker_public_id" value="{{ job_seeker.public_id }}">
                 {% endif %}
@@ -55,7 +55,8 @@
                               hx-target="#services-search-results"
                               hx-swap="outerHTML"
                               hx-push-url="true"
-                              hx-disinherit="*">
+                              hx-disinherit="hx-trigger hx-target"
+                              id="filters_form">
                             <div class="btn-dropdown-filter-group my-3 my-md-4">
                                 {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.thematics only %}
                                 {% include "includes/btn_dropdown_filter/radio.html" with field=form.reception only %}


### PR DESCRIPTION
[Ticket Notion](https://app.notion.com/p/gip-inclusion/Bug-le-filtre-Mode-d-accueil-se-r-initialise-tout-seul-3a35f321b60480069addccb24fe87f41?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link)

Je peux séparer en deux commits mais c'est sur des mêmes lignes, bon...

## :desert_island: Comment tester ?

En recette jetable après relecture

# Catégories changelog
Insertion
