### PR TITLE
Connexion : Afficher une bannière aux pros avertissant de la prochaine activation du 2FA

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -66,6 +66,14 @@
         <div class="global-messages-container">
             {% block global_messages %}
                 {% include "includes/demo_accounts.html" %}
+                {% if request.user and request.user.show_upcoming_mfa_activation_banner %}
+                    {% component_alert_global content=content variant="danger" %}
+                        {% fragment as content %}
+                            Sécurité du compte : anticipez dès maintenant, la double authentification sera bientôt obligatoire.
+                            <a href="{% url "otp_views:enrollment_step_0_intro" %}">Configurer</a>.
+                        {% endfragment %}
+                    {% endcomponent_alert_global %}
+                {% endif %}
                 {% if request.from_employer and request.current_organization and request.current_organization.has_job_descriptions_not_updated_recently %}
                     {% component_alert_global content=content variant="info" extra_id="deactivation-job-banner" %}
                         {% fragment as content %}

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -36,6 +36,7 @@ from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.address.format import compute_hexa_address
 from itou.common_apps.address.models import AddressMixin
 from itou.companies.models import Company
+from itou.otp.models import ItouTOTPDevice
 from itou.prescribers.enums import PrescriberAuthorizationStatus
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import (
@@ -487,6 +488,18 @@ class User(AbstractUser, AddressMixin, AbstractFieldsHistoryModel):
     @property
     def is_professional(self):
         return self.kind == UserKind.PROFESSIONAL
+
+    @property
+    def show_upcoming_mfa_activation_banner(self):
+        if not (settings.REQUIRE_MFA_FOR_PROS and self.is_professional):
+            return False
+        # Do not show if user already authenticaed with internal or external MFA.
+        if self.is_verified():
+            return False
+        # Do not show if user has already enrolled a device: we may be
+        # displaying the "Verify OTP" form, no need to show the
+        # banner there.
+        return not ItouTOTPDevice.objects.filter(user=self, disabled_at=None).exists()
 
     @property
     def is_itou_staff(self):


### PR DESCRIPTION
[Carte Notion](https://app.notion.com/p/gip-inclusion/2FA-TOTP-ETQ-utilisateur-pro-connect-on-m-incite-activer-le-2FA-Suggestion-avant-obligation-3565f321b60480dc8f59e1f2809bd855). Ne pas tenir compte du wording dans la carte Notion et Figma. Le wording de cette PR est le bon.

Les utilisateurs concernés par l'activation (c'est-à-dire qui sont dans le lot pour lesquels on force la 2FA maison si l'utilisateur n'a pas utilisé de 2FA sur ProConnect ou son fournisseur d'identité) ne verront pas le message, car on les redirige vers le flux d'enrôlement, qui n'affiche **pas** le bloc `global_messages`.

Pour les autres, ça donne ça : 

<img width="2398" height="1151" alt="image" src="https://github.com/user-attachments/assets/c78cc3cd-7eed-4f4d-8cd0-07d5408acb7a" />

