### PR TITLE
FranceConnect : Ajouter un URL pour le sector_identifier

### DIFF
--- a/itou/openid_connect/france_connect/urls.py
+++ b/itou/openid_connect/france_connect/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("callback", views.france_connect_callback, name="callback"),
     path("logout", views.france_connect_logout, name="logout"),
     path("logout_callback", views.france_connect_logout_callback, name="logout_callback"),
+    path("sector_identifier", views.sector_identifier, name="sector_identifier"),
 ]

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlunsplit
 
 import httpx
 import jwt
@@ -258,3 +259,26 @@ def france_connect_logout_callback(request):
             f"Merci de vérifier que vous êtes bien déconnecté de {IdentityProvider.FRANCE_CONNECT.label}.",
         )
     return HttpResponseRedirect(reverse("search:employers_home"))
+
+
+@login_not_required
+def sector_identifier(request):
+    # Always serve this view under the emplois.inclusion.beta.gouv.fr domain.
+    #
+    # The original redirect_uri had domain emplois.inclusion.beta.gouv.fr, it
+    # is thus the Sector Identifier.
+    #
+    # https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes:
+    # > When a sector_identifier_uri is provided, the host component of that URL
+    # > is used as the Sector Identifier for the pairwise identifier calculation.
+    urls = [
+        # > The value of the sector_identifier_uri MUST be a URL using the
+        # > https scheme […]
+        urlunsplit(("https", domain, path, "", ""))
+        for domain in settings.ALLOWED_HOSTS
+        for path in [
+            reverse("france_connect:callback"),
+            reverse("france_connect:logout_callback"),
+        ]
+    ]
+    return JsonResponse(urls, safe=False)

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -628,3 +628,20 @@ def test_create_fc_user_with_already_existing_fc_email_fails():
     )
     with pytest.raises(MultipleSubSameEmailException):
         fc_user_data.create_or_update_user()
+
+
+def test_sector_identifier(client, settings):
+    settings.ALLOWED_HOSTS = ["emplois.inclusion.beta.gouv.fr", "plateforme.inclusion.gouv.fr"]
+    response = client.get(
+        reverse("france_connect:sector_identifier"),
+        headers={"Host": "plateforme.inclusion.gouv.fr"},
+        secure=True,
+    )
+    assert response.content == (
+        b"["
+        b'"https://emplois.inclusion.beta.gouv.fr/franceconnect/callback", '
+        b'"https://emplois.inclusion.beta.gouv.fr/franceconnect/logout_callback", '
+        b'"https://plateforme.inclusion.gouv.fr/franceconnect/callback", '
+        b'"https://plateforme.inclusion.gouv.fr/franceconnect/logout_callback"'
+        b"]"
+    )


### PR DESCRIPTION
## :thinking: Pourquoi ?

FranceConnect utilise les _pairwise identifier_, qui permettent de générer des `subs` différent selon le client [1] [2].

## :cake: Comment ? <!-- optionnel -->

Pour identifier `emplois.inclusion.beta.gouv.fr` comme appartenant à la même organisation que `plateforme.inclusion.gouv.fr`, nous devons définir un `sector_identifier` [3].

L’URI du `sector_identifier` doit être sur le domaine emplois.inclusion.beta.gouv.fr, afin que FranceConnect continue de générer les `subs` pour ce domaine.

[1] https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/
[2] https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
[3] https://openid.net/specs/openid-connect-registration-1_0.html#SectorIdentifierValidation
