### PR TITLE
FTConnect : Importer la civilité de l’utilisateur

### DIFF
--- a/itou/openid_connect/ft_connect/models.py
+++ b/itou/openid_connect/ft_connect/models.py
@@ -1,8 +1,12 @@
+import contextlib
 import dataclasses
 from typing import ClassVar
 
 from itou.openid_connect.models import OIDConnectState, OIDConnectUserData
-from itou.users.enums import IdentityProvider, UserKind
+from itou.users.enums import IdentityProvider, Title, UserKind
+
+
+TITLE_MAP = {"male": Title.M, "female": Title.MME}
 
 
 class PoleEmploiConnectState(OIDConnectState):
@@ -17,3 +21,13 @@ class PoleEmploiConnectUserData(OIDConnectUserData):
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.PE_CONNECT
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
+    title: str | None = None
+
+    @staticmethod
+    def user_info_mapping_dict(user_info: dict):
+        # Python 3's zero-argument super() only works in class or instance methods.
+        attrs = super(PoleEmploiConnectUserData, PoleEmploiConnectUserData).user_info_mapping_dict(user_info=user_info)
+        with contextlib.suppress(KeyError):
+            gender = user_info["gender"]
+            attrs["title"] = TITLE_MAP[gender]
+        return attrs

--- a/tests/openid_connect/ft_connect/tests.py
+++ b/tests/openid_connect/ft_connect/tests.py
@@ -19,7 +19,7 @@ from itou.openid_connect.constants import OIDC_STATE_CLEANUP
 from itou.openid_connect.ft_connect import constants
 from itou.openid_connect.ft_connect.models import PoleEmploiConnectState, PoleEmploiConnectUserData
 from itou.openid_connect.models import EmailInUseException, InvalidKindException, MultipleSubSameEmailException
-from itou.users.enums import IdentityProvider, UserKind
+from itou.users.enums import IdentityProvider, Title, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants, triggers
 from tests.eligibility.factories import IAESelectedAdministrativeCriteriaFactory
@@ -144,6 +144,7 @@ class TestPoleEmploiConnect:
         assert user.external_data_source_history[0]["source"] == "PEC"
         assert user.identity_provider == IdentityProvider.PE_CONNECT
         assert user.kind == UserKind.JOB_SEEKER
+        assert user.title == Title.MME
 
         # Update user
         peamu_user_data.last_name = "DUPUIS"
@@ -163,6 +164,7 @@ class TestPoleEmploiConnect:
             username=peamu_user_data.username,
             last_name="will_be_forgotten",
             identity_provider=IdentityProvider.PE_CONNECT,
+            title=Title.M,
         )
         with triggers.fake_context():
             user, created = peamu_user_data.create_or_update_user()
@@ -171,6 +173,7 @@ class TestPoleEmploiConnect:
         assert user.first_name == PEAMU_USERINFO["given_name"]
         assert user.external_data_source_history[0]["source"] == "PEC"
         assert user.identity_provider == IdentityProvider.PE_CONNECT
+        assert user.title == Title.MME
 
     def test_create_user_with_already_existing_peamu_id_but_from_other_sso(self):
         """
@@ -202,6 +205,7 @@ class TestPoleEmploiConnect:
             username=PEAMU_USERINFO["sub"],
             identity_provider=IdentityProvider.PE_CONNECT,
             born_in_france=True,
+            title=Title.M,
         )
         IAESelectedAdministrativeCriteriaFactory(
             eligibility_diagnosis__job_seeker=job_seeker,
@@ -218,8 +222,9 @@ class TestPoleEmploiConnect:
         assert user.external_data_source_history[0]["source"] == "PEC"
         assert user.identity_provider == IdentityProvider.PE_CONNECT
         assert user.kind == UserKind.JOB_SEEKER
+        assert user.title == Title.M
         assert (
-            f"Not updating fields first_name, last_name on job seeker pk={job_seeker.pk} "
+            f"Not updating fields first_name, last_name, title on job seeker pk={job_seeker.pk} "
             "because their identity has been certified." in caplog.messages
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le champ genre a été créé après le connecteur PoleEmploiConnect, et personne n’a mis à jour le connecteur pour remplir ce "nouveau" champ.

https://github.com/gip-inclusion/les-emplois/commit/7e3455d77dc14bf355ed0e5dbb8e569e298ffdba
https://github.com/gip-inclusion/les-emplois/commit/345435b05ce5243c9958132550fecca1f2547ce4

Merci Xavier pour la leçon d’histoire :)
