### PR TITLE
delete_unused_files: Supprimer les fichiers en masse

### DIFF
--- a/itou/files/management/commands/delete_unused_files.py
+++ b/itou/files/management/commands/delete_unused_files.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         known_keys = set(File.objects.values_list("key", flat=True))
         self.logger.info("Checking existing files: %d files in database", len(known_keys))
         for page in page_iterator:
-            obj_summaries = page["Contents"]
+            obj_summaries = page.get("Contents", [])
             for obj_summary in obj_summaries:
                 key = obj_summary["Key"]
                 if not key.startswith(f"{TEMPORARY_STORAGE_PREFIX}/"):

--- a/itou/files/management/commands/delete_unused_files.py
+++ b/itou/files/management/commands/delete_unused_files.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 import operator
+from itertools import batched
 
 from django.conf import settings
 from django.db import transaction
@@ -15,8 +16,6 @@ from itou.utils.storage.s3 import TEMPORARY_STORAGE_PREFIX, s3_client
 # Wait a bit before deleting a unknown file from S3 in case the database File is still not commited
 # Also Wait a bit before deleting a orphan File since it might have ben created outside an atomic transation
 CLEANING_DELAY = datetime.timedelta(days=1)
-
-MAX_FILES_CLEANUP = 50_000
 
 
 class Command(BaseCommand):
@@ -56,9 +55,9 @@ class Command(BaseCommand):
         page_iterator = paginator.paginate(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
         temporary_files_nb = 0
         unknown_files_nb = 0
-        removed_files_nb = 0
         known_keys = set(File.objects.values_list("key", flat=True))
         self.logger.info("Checking existing files: %d files in database", len(known_keys))
+        to_remove = []
         for page in page_iterator:
             obj_summaries = page.get("Contents", [])
             for obj_summary in obj_summaries:
@@ -67,29 +66,34 @@ class Command(BaseCommand):
                     if key not in known_keys:
                         unknown_files_nb += 1
                         if obj_summary["LastModified"] < cutoff:
-                            removed_files_nb += 1
-                            client.delete_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
+                            to_remove.append(key)
                     else:
                         known_keys.remove(key)
                 else:
                     temporary_files_nb += 1
-                if removed_files_nb >= MAX_FILES_CLEANUP:
-                    self.logger.warning(
-                        (
-                            "Stopped bucket cleaning after reaching MAX_FILES_CLEANUP: "
-                            "found unknown=%d and temporary=%d files in the bucket, removed=%d files"
-                        ),
-                        unknown_files_nb,
-                        temporary_files_nb,
-                        removed_files_nb,
-                    )
-                    return
 
+        failed_deletions = 0
+        if to_remove:
+            self.logger.info("Found %d keys to remove from S3.", len(to_remove))
+            # https://docs.aws.amazon.com/boto3/latest/reference/services/s3/client/delete_objects.html
+            # > The request can contain a list of up to 1,000 keys that you want to delete.
+            for batch in batched(to_remove, 1_000):
+                self.logger.info("Deleting %d keys from S3.", len(batch))
+                response = client.delete_objects(
+                    Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+                    Delete={
+                        "Objects": [{"Key": key} for key in batch],
+                        "Quiet": True,
+                    },
+                )
+                if errors := response.get("Errors", []):
+                    failed_deletions += len(errors)
+                    self.logger.error("Failed to delete files: %s", errors)
         self.logger.info(
             "Completed bucket cleaning: found unknown=%d and temporary=%d files in the bucket, removed=%d files",
             unknown_files_nb,
             temporary_files_nb,
-            removed_files_nb,
+            len(to_remove) - failed_deletions,
         )
         if known_keys:
             # keys are present in database as File object but missing from our bucket

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -209,6 +209,8 @@ def test_delete_unused_files_from_s3(temporary_bucket, caplog, mocker):
         "Starting unused file removal",
         "Deleted 0 orphans files from database",
         "Checking existing files: 2 files in database",
+        "Found 3 keys to remove from S3.",
+        "Deleting 3 keys from S3.",
         "Completed bucket cleaning: found unknown=3 and temporary=1 files in the bucket, removed=3 files",
         f"1 database files do not exist in the bucket: [{missing_file.key!r}]",
     ]

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -105,6 +105,21 @@ def test_copy(pdf_file):
         assert old.read() == new.read()
 
 
+@pytest.mark.empty_temporary_bucket_expected
+@pytest.mark.usefixtures("temporary_bucket")
+def test_delete_unused_files_no_files(caplog):
+    call_command("delete_unused_files")
+    assert caplog.messages[:-1] == [
+        "Starting unused file removal",
+        "Deleted 0 orphans files from database",
+        "Checking existing files: 0 files in database",
+        "Completed bucket cleaning: found unknown=0 and temporary=0 files in the bucket, removed=0 files",
+    ]
+    assert caplog.messages[-1].startswith(
+        "Management command itou.files.management.commands.delete_unused_files succeeded in"
+    )
+
+
 @pytest.mark.usefixtures("temporary_bucket")
 def test_delete_unused_files_from_database(caplog):
     old_orphan = FileFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

La tâche dure trop longtemps (~ 12h).

651977491ecd78b33fbdba9e6c22e1b91fa6ba02 était une mesure temporaire pour résoudre le problème, l’amélioration des performances apportées par ce patch devrait permettre de retirer `MAX_FILES_CLEANUP`.
