### PR TITLE
Tech: réduction des batchs de `delete_unused_files`

### DIFF
--- a/itou/files/management/commands/delete_unused_files.py
+++ b/itou/files/management/commands/delete_unused_files.py
@@ -77,7 +77,8 @@ class Command(BaseCommand):
             self.logger.info("Found %d keys to remove from S3.", len(to_remove))
             # https://docs.aws.amazon.com/boto3/latest/reference/services/s3/client/delete_objects.html
             # > The request can contain a list of up to 1,000 keys that you want to delete.
-            for batch in batched(to_remove, 1_000):
+            # But 1_000 ended up with a ReadTimeout: batches of 100 seem to be handled in ~40 seconds
+            for batch in batched(to_remove, 100):
                 self.logger.info("Deleting %d keys from S3.", len(batch))
                 response = client.delete_objects(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec 1_000 cela a timeout, cf:
https://app.datadoghq.eu/logs?query=service%3Aitou-prod%20%40command.name%3A%2A.delete_unused_files&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1784791079420&to_ts=1784877479420&live=true
et
https://app.datadoghq.eu/logs?query=service%3Aitou-prod%20%40pid%3A303458&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&context_event=AZ-RruxuAAA9wuUNqCGDHwAJ&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1784855285751&to_ts=1784855585798&live=false

## :cake: Comment ? <!-- optionnel -->

En réduisant la taille des batchs.