### PR TITLE
Prescripteur habilité : Ajout d'un filtre "Fin de parcours IAE à venir" dans la page "Mes accompagnements"

### DIFF
--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
@@ -1,0 +1,34 @@
+{% load django_bootstrap5 %}
+
+{% if btn_dropdown_filter|default:False %}
+    <div class="dropdown">
+        <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+            Fin de parcours IAE à venir
+        </button>
+        <ul class="dropdown-menu">
+            <li>{% bootstrap_field filters_form.pass_iae_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
+        </ul>
+    </div>
+{% else %}
+    <fieldset>
+        <legend>
+            <button class="btn btn-outline-transparent has-collapse-caret collapsed"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#collapseEndOfJourney"
+                    type="button"
+                    aria-expanded="false"
+                    aria-controls="collapseEndOfJourney">Fin de parcours IAE à venir</button>
+        </legend>
+        <div class="my-3 collapse" id="collapseEndOfJourney">
+            <ul>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.pass_iae_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.contract_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
@@ -1,5 +1,9 @@
 <div class="offcanvas-body" id="offcanvasApplyFiltersContent"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form only %}
+    {% if request.from_authorized_prescriber %}
+        <hr>
+        {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form only %}
+    {% endif %}
     {% if list_organization %}
         <hr>
         {% include "job_seekers_views/includes/job_seekers_filters/organization_members.html" with filters_form=filters_form only %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/single_checkbox.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/single_checkbox.html
@@ -13,5 +13,6 @@ Arguments:
                {% if field.value %}checked{% endif %}
                {% if id_suffix|default:"" %}data-emplois-sync-with="{{ field.id_for_label }}"{% endif %}>
         <label class="form-check-label" for="{{ field.id_for_label }}{{ id_suffix|default:'' }}">{{ field.label }}</label>
+        {% if field.help_text %}<span class="form-text text-muted d-block">{{ field.help_text }}</span>{% endif %}
     </div>
 </div>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -19,6 +19,9 @@
                     </li>
                 </ul>
             </div>
+            {% if request.from_authorized_prescriber %}
+                {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form btn_dropdown_filter=True only %}
+            {% endif %}
             {% if list_organization %}
                 <button type="button" class="btn btn-ico btn-dropdown-filter" data-bs-toggle="offcanvas" data-bs-target="#offcanvasApplyFilters" aria-controls="offcanvasApplyFilters">
                     <i class="ri-sound-module-fill fw-medium" aria-hidden="true"></i>

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.db.models import OuterRef, Q, Subquery
 from django.forms import ValidationError
@@ -9,6 +11,7 @@ from itou.approvals.models import Approval
 from itou.asp import models as asp_models
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
+from itou.companies.models import Contract
 from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.forms import JobSeekerProfileFieldsMixin, JobSeekerProfileModelForm
 from itou.users.models import JobSeekerProfile, JobSeekerProfileQuerySet, NirModificationRequest, User
@@ -18,6 +21,10 @@ from itou.utils.perms.utils import can_view_personal_information
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.validators import validate_nir
 from itou.utils.widgets import DuetDatePickerWidget
+
+
+PASS_IAE_ENDING_SOON_DAYS = 90
+IAE_CONTRACT_ENDING_SOON_DAYS = 30
 
 
 class FilterForm(forms.Form):
@@ -38,6 +45,17 @@ class FilterForm(forms.Form):
     pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
     no_pass_iae = forms.BooleanField(label="Aucun", required=False)
 
+    pass_iae_ending_soon = forms.BooleanField(
+        label="PASS IAE bientôt expiré",
+        required=False,
+        help_text="Dans les 90 prochains jours",
+    )
+    contract_ending_soon = forms.BooleanField(
+        label="Contrat IAE bientôt terminé",
+        required=False,
+        help_text="Dans les 30 prochains jours",
+    )
+
     is_stalled = forms.BooleanField(label="N’afficher que les usagers sans solution", required=False)
 
     organization_members = forms.MultipleChoiceField(
@@ -46,6 +64,7 @@ class FilterForm(forms.Form):
 
     def __init__(self, job_seeker_qs, data, *args, request, **kwargs):
         super().__init__(data, *args, **kwargs)
+        self.request = request
         self.fields["job_seeker"].choices = self._get_choices_for_job_seeker(job_seeker_qs, request)
         if request.current_organization:
             self.fields["organization_members"].choices = self._get_choices_for_organization_members(
@@ -92,24 +111,54 @@ class FilterForm(forms.Form):
         elif self.cleaned_data.get("eligibility_pending") and not self.cleaned_data.get("eligibility_validated"):
             queryset = queryset.eligibility_pending()
 
-        # Approval (PASS IAE) status (all checkboxes checked = all cases, so do not filter out results)
-        pass_iae_filters = [
+        today = timezone.localdate()
+
+        # PASS IAE status (all checkboxes checked = all cases, so do not filter out results).
+        # last_approval_end_at is shared by this status filter and the "PASS IAE ending soon" filter.
+        pass_iae_status_filters = [
             self.cleaned_data.get(key) for key in ("pass_iae_active", "pass_iae_expired", "no_pass_iae")
         ]
-        if any(pass_iae_filters) and not all(pass_iae_filters):
-            last_approval_end_at = Subquery(
-                Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
+        use_pass_iae_status = any(pass_iae_status_filters) and not all(pass_iae_status_filters)
+        # The "end of IAE journey" filters are reserved for authorized prescribers.
+        from_authorized_prescriber = self.request.from_authorized_prescriber
+        pass_iae_ending_soon = from_authorized_prescriber and self.cleaned_data.get("pass_iae_ending_soon")
+        if use_pass_iae_status or pass_iae_ending_soon:
+            queryset = queryset.annotate(
+                last_approval_end_at=Subquery(
+                    Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
+                )
             )
-            queryset = queryset.annotate(last_approval_end_at=last_approval_end_at)
 
+        if use_pass_iae_status:
             pass_status_filter = Q()
             if self.cleaned_data.get("pass_iae_active"):
-                pass_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
+                pass_status_filter |= Q(last_approval_end_at__gte=today)
             if self.cleaned_data.get("pass_iae_expired"):
-                pass_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
+                pass_status_filter |= Q(last_approval_end_at__lt=today)
             if self.cleaned_data.get("no_pass_iae"):
                 pass_status_filter |= Q(last_approval_end_at__isnull=True)
             filters.append(pass_status_filter)
+
+        # Upcoming end of IAE journey (authorized prescribers only): the two conditions are combined
+        # with AND when both are checked. PASS IAE ending soon is reliable; IAE contract end dates come
+        # from ASP data that is partial and delayed by a few days.
+        contract_ending_soon = from_authorized_prescriber and self.cleaned_data.get("contract_ending_soon")
+        if pass_iae_ending_soon or contract_ending_soon:
+            end_of_journey_filter = Q()
+            if pass_iae_ending_soon:
+                pass_window = (today, today + datetime.timedelta(days=PASS_IAE_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_approval_end_at__range=pass_window)
+            if contract_ending_soon:
+                queryset = queryset.annotate(
+                    last_contract_end_date=Subquery(
+                        Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
+                        .order_by("-end_date")
+                        .values("end_date")[:1]
+                    )
+                )
+                contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_contract_end_date__range=contract_window)
+            filters.append(end_of_journey_filter)
 
         if self.cleaned_data.get("is_stalled"):
             queryset = queryset.filter(

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -19,7 +19,12 @@ from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
 from itou.utils.templatetags.str_filters import mask_unless
 from tests.approvals.factories import ApprovalFactory, SuspensionFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, CompanyWith2MembershipsFactory
+from tests.companies.factories import (
+    CompanyFactory,
+    CompanyMembershipFactory,
+    CompanyWith2MembershipsFactory,
+    ContractFactory,
+)
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import (
@@ -973,6 +978,165 @@ def test_filtered_by_approval_state(client, factory, url):
         job_seeker_expired_eligibility_expired_approval,
         job_seeker_expired_eligibility_valid_approval,
     ]
+
+
+@freeze_time("2026-01-15")
+@pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
+def test_filtered_by_end_of_iae_journey(client, url):
+    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
+    user = organization.members.first()
+    client.force_login(user)
+
+    today = datetime.date(2026, 1, 15)
+
+    def assigned_job_seeker(first_name):
+        return IAEEligibilityDiagnosisFactory(
+            from_prescriber=True,
+            author=user,
+            author_prescriber_organization=organization,
+            job_seeker__first_name=first_name,
+            job_seeker__last_name="Zorro",
+            with_job_seeker_assignment=True,
+        ).job_seeker
+
+    def add_soon_pass(job_seeker):
+        ApprovalFactory(
+            user=job_seeker,
+            start_at=today - datetime.timedelta(days=600),
+            end_at=today + datetime.timedelta(days=30),
+        )
+
+    def add_soon_contract(job_seeker):
+        ContractFactory(
+            job_seeker=job_seeker,
+            start_date=today - datetime.timedelta(days=200),
+            end_date=today + datetime.timedelta(days=20),
+        )
+
+    # Only a PASS IAE ending soon.
+    job_seeker_pass_only = assigned_job_seeker("pass only")
+    add_soon_pass(job_seeker_pass_only)
+
+    # Only an IAE contract ending soon.
+    job_seeker_contract_only = assigned_job_seeker("contract only")
+    add_soon_contract(job_seeker_contract_only)
+
+    # Both a PASS IAE and an IAE contract ending soon.
+    job_seeker_both = assigned_job_seeker("both ending soon")
+    add_soon_pass(job_seeker_both)
+    add_soon_contract(job_seeker_both)
+
+    # Neither ends soon.
+    job_seeker_neither = assigned_job_seeker("neither")
+    ApprovalFactory(
+        user=job_seeker_neither,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=200),
+    )
+
+    response = client.get(url, {"pass_iae_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_pass_only, job_seeker_both}
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_contract_only, job_seeker_both}
+
+    # Both checked => AND: only the job seeker with both a soon PASS and a soon contract.
+    response = client.get(url, {"pass_iae_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_both]
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_edge_cases(client):
+    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
+    user = organization.members.first()
+    client.force_login(user)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+
+    def assigned_job_seeker(first_name):
+        return IAEEligibilityDiagnosisFactory(
+            from_prescriber=True,
+            author=user,
+            author_prescriber_organization=organization,
+            job_seeker__first_name=first_name,
+            job_seeker__last_name="Zorro",
+            with_job_seeker_assignment=True,
+        ).job_seeker
+
+    # PASS ending exactly on the 90-day boundary is included (range is inclusive).
+    job_seeker_pass_boundary = assigned_job_seeker("pass boundary")
+    ApprovalFactory(
+        user=job_seeker_pass_boundary,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=90),
+    )
+
+    # Contract ending exactly on the 30-day boundary is included.
+    job_seeker_contract_boundary = assigned_job_seeker("contract boundary")
+    ContractFactory(
+        job_seeker=job_seeker_contract_boundary,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=30),
+    )
+
+    # A contract without an end date (ongoing) is ignored.
+    job_seeker_contract_no_end = assigned_job_seeker("contract no end")
+    ContractFactory(
+        job_seeker=job_seeker_contract_no_end,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=None,
+    )
+
+    # Several contracts: only the latest end date counts (an older one already ended).
+    job_seeker_multiple_contracts = assigned_job_seeker("multiple contracts")
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=400),
+        end_date=today - datetime.timedelta(days=200),
+    )
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=today + datetime.timedelta(days=15),
+    )
+
+    response = client.get(url, {"pass_iae_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_pass_boundary]
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {
+        job_seeker_contract_boundary,
+        job_seeker_multiple_contracts,
+    }
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
+    # A non-authorized prescriber neither sees the filter nor is affected by its query params.
+    organization = PrescriberOrganizationWith2MembershipFactory()
+    user = organization.members.first()
+    client.force_login(user)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=user,
+        author_prescriber_organization=organization,
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    # PASS ending far in the future: it would be filtered out if the filter applied.
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=200),
+    )
+
+    assertNotContains(client.get(url), "Fin de parcours IAE à venir")
+
+    response = client.get(url, {"pass_iae_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker]
 
 
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les prescripteurs habilités suivent des candidats dans « Mes accompagnements » mais n'ont pas de vue simple pour repérer ceux qui approchent d'une fin de parcours IAE, un moment clé pour préparer la suite avec France Travail ou le RPE. Ce filtre les rend visibles en un clic.

## :cake: Comment ?

Ajout d'un filtre dédié « Fin de parcours IAE à venir », distinct du filtre « Situation IAE », placé en troisième position et réservé aux prescripteurs habilités. Il propose deux cases indépendantes, combinées en ET lorsque les deux sont cochées.

La case « PASS IAE bientôt expiré » retient les usagers dont le dernier PASS se termine dans les 90 prochains jours (`Approval.end_at`, donnée fiable). La case « Contrat IAE bientôt terminé » retient ceux dont un contrat IAE se termine dans les 30 prochains jours (`Contract.end_date`, issue des données ASP, partielles et différées de quelques jours).

L'implémentation réutilise `FilterForm.filter()`. Il n'y a aucune migration, aucun changement de modèle ni de droits : le filtre ne fait que restreindre le queryset déjà borné par les assignations.

Décisions produit à valider : fenêtres fixes de 90 jours (PASS) et 30 jours (contrat), non paramétrables en V1 ; deux cases cochées valent ET ; fonctionnalité réservée aux prescripteurs habilités.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

1. Se connecter en prescripteur habilité, aller sur « Mes accompagnements » (`/job-seekers/list`).
2. Vérifier la présence du troisième filtre « Fin de parcours IAE à venir ».
3. Cocher « PASS IAE bientôt expiré » : la liste ne garde que les usagers dont le dernier PASS finit dans les 90 prochains jours.
4. Cocher « Contrat IAE bientôt terminé » : la liste ne garde que ceux dont un contrat IAE finit dans les 30 prochains jours.
5. Cocher les deux cases : la liste applique l'intersection des deux conditions.
6. Se connecter en employeur ou en prescripteur non habilité : le filtre n'apparaît pas.

## :computer: Captures d'écran

À compléter lors du test sur recette jetable.
