### PR TITLE
FranceConnect : Retirer les URLs de déconnexion du sector_identifier

### DIFF
--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -271,14 +271,11 @@ def sector_identifier(request):
     # https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes:
     # > When a sector_identifier_uri is provided, the host component of that URL
     # > is used as the Sector Identifier for the pairwise identifier calculation.
+    path = reverse("france_connect:callback")
     urls = [
         # > The value of the sector_identifier_uri MUST be a URL using the
         # > https scheme […]
         urlunsplit(("https", domain, path, "", ""))
         for domain in settings.ALLOWED_HOSTS
-        for path in [
-            reverse("france_connect:callback"),
-            reverse("france_connect:logout_callback"),
-        ]
     ]
     return JsonResponse(urls, safe=False)

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -640,8 +640,6 @@ def test_sector_identifier(client, settings):
     assert response.content == (
         b"["
         b'"https://emplois.inclusion.beta.gouv.fr/franceconnect/callback", '
-        b'"https://emplois.inclusion.beta.gouv.fr/franceconnect/logout_callback", '
-        b'"https://plateforme.inclusion.gouv.fr/franceconnect/callback", '
-        b'"https://plateforme.inclusion.gouv.fr/franceconnect/logout_callback"'
+        b'"https://plateforme.inclusion.gouv.fr/franceconnect/callback"'
         b"]"
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

L’équipe FranceConnect le demande. La spécification ne me semble pas très claire sur ce point, mais les exemples ne semblent lister que des _callbacks_ d’URLs de connexion.
