### PR TITLE
Tech : fixe `prune-cache: true` pour `setup-uv`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
+        prune-cache: true
         cache-dependency-glob: "requirements/test.txt"
     - name: 📥 Install dependencies
       run: |

--- a/.github/workflows/clean-clevercloud-buckets.yml
+++ b/.github/workflows/clean-clevercloud-buckets.yml
@@ -21,5 +21,6 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          prune-cache: true
       - name: Remove leftover buckets from interrupted test suites
         run: uv run --script scripts/delete-buckets --use-case=ci_buckets

--- a/.github/workflows/review-app-removal.yml
+++ b/.github/workflows/review-app-removal.yml
@@ -47,6 +47,7 @@ jobs:
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: true
+        prune-cache: true
 
     - name: 🗑 Delete S3 bucket
       run: uv run --script scripts/delete-buckets --use-case=review_app


### PR DESCRIPTION
## :thinking: Pourquoi ?

`setup-uv` v9.0.0 inverse la valeur par défaut de `prune-cache` (`true` → `false`) : tout le cache uv est désormais uploadé. Aucun de nos trois appels ne déterminant explicitement l'option `prune-cache`, sans cette PR ils basculeraient donc au merge des PR Dependabot #8484 et #8485 (et puis _explicit is better than implicit_).

## :cake: Comment ?

`prune-cache: true` est ajouté explicitement aux trois appels. **C'est un no-op aujourd'hui** (`prune-cache: true` est déjà le défaut en v8) : le but est de rendre #8484 et #8485 neutres.

À noter : Astral a inversé ce défaut pour soulager l'infrastructure PyPI. On assume de conserver l'ancien comportement car on veut une CI rapide (cf. les précisions dans le message du commit) et car on n'a que 10 Go de cache à dispo, déjà en bonne partie consommés.