### PR TITLE
Candidature: ajout d'un bloc d'information concernant les dates de contrat

### DIFF
--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -31,6 +31,33 @@
         {% bootstrap_field form_accept.hiring_start_at wrapper_class="form-group form-group-input-w-lg-33" %}
         {% bootstrap_field form_accept.hiring_end_at wrapper_class="form-group form-group-input-w-lg-33" %}
 
+        {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id="contract_date_infos" extra_classes="mt-n1 mb-3" %}
+            {% fragment as c_info__summary %}
+                À propos de ces dates de contrat
+            {% endfragment %}
+            {% fragment as c_info__detail %}
+                <span>Concernant la date de début de contrat :</span>
+                <ul class="mb-3">
+                    {% if company.kind != CompanyKind.GEIQ %}
+                        <li>La date ne peut pas être antérieure à aujourd’hui et reste modifiable jusqu’à la veille de la date saisie.</li>
+                    {% else %}
+                        <li>La date est modifiable jusqu’à la veille de la date saisie.</li>
+                    {% endif %}
+                    {% if company.is_subject_to_iae_rules %}
+                        <li>En cas de premier PASS IAE pour la personne, cette date déclenche le début de son parcours.</li>
+                    {% endif %}
+                </ul>
+                <span>Concernant la date prévisionnelle de fin de contrat :</span>
+                <ul>
+                    {% if company.can_use_employee_record %}
+                        <li>Cette date est indicative : elle n’a aucun impact sur les déclarations à faire dans l’extranet 2.0 de l'ASP.</li>
+                    {% else %}
+                        <li>Cette date n'est qu'indicative.</li>
+                    {% endif %}
+                </ul>
+            {% endfragment %}
+        {% endcomponent_info %}
+
         {# reloadable training and qualification for GEIQ #}
         {% if company.kind == CompanyKind.GEIQ %}
             {% include "apply/includes/geiq/geiq_qualification_fields.html" %}

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -43,6 +43,7 @@
                     {% else %}
                         <li>La date est modifiable jusqu’à la veille de la date saisie.</li>
                     {% endif %}
+                    <li>Cette date doit être comprise dans les 6 prochains mois (avant le {{ form_accept.get_far_future_date|date:"d/m/Y" }}).</li>
                     {% if company.is_subject_to_iae_rules %}
                         <li>En cas de premier PASS IAE pour la personne, cette date déclenche le début de son parcours.</li>
                     {% endif %}

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -31,7 +31,7 @@
         {% bootstrap_field form_accept.hiring_start_at wrapper_class="form-group form-group-input-w-lg-33" %}
         {% bootstrap_field form_accept.hiring_end_at wrapper_class="form-group form-group-input-w-lg-33" %}
 
-        {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id="contract_date_infos" extra_classes="mt-n1 mb-3" %}
+        {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id="contract_date_infos" opened=form_accept.has_error_on_date extra_classes="mt-n1 mb-3" %}
             {% fragment as c_info__summary %}
                 À propos de ces dates de contrat
             {% endfragment %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -494,6 +494,9 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         else:
             return hiring_start_at
 
+    def has_error_on_date(self):
+        return self.has_error("hiring_start_at") or self.has_error("hiring_end_at")
+
     def clean(self):
         super().clean()
         hiring_start_at = self.cleaned_data.get("hiring_start_at")

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -342,10 +342,10 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         self.job_seeker = job_seeker
         attrs_min = {}
         attrs_max = {}
+        self._today = timezone.localdate()  # Make sure the form stays consistent around midnight
         if not self.is_geiq:
-            today = timezone.localdate()
-            attrs_min["min"] = today.isoformat()
-            attrs_max["max"] = (today + relativedelta(months=6)).isoformat()
+            attrs_min["min"] = self._today.isoformat()
+            attrs_max["max"] = (self._today + relativedelta(months=6)).isoformat()
         self.fields["hiring_start_at"].required = True
         self.fields["hiring_start_at"].widget = DuetDatePickerWidget(attrs=attrs_min | attrs_max)
         self.fields["hiring_end_at"].widget = DuetDatePickerWidget(attrs=attrs_min)
@@ -378,7 +378,7 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
             if initial is None or "planned_training_hours" not in initial:
                 self.initial["planned_training_hours"] = 0
             self.fields["hiring_start_at"].help_text = "Au format JJ/MM/AAAA, par exemple {}.".format(
-                timezone.localdate().strftime("%d/%m/%Y"),
+                self._today.strftime("%d/%m/%Y"),
             )
             # Dynamic selection of qualification level
             self.fields["qualification_type"].widget.attrs.update(
@@ -492,9 +492,9 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
 
         # Hiring in the past is *temporarily* possible for GEIQ
-        if hiring_start_at < timezone.localdate() and not self.is_geiq:
+        if hiring_start_at < self._today and not self.is_geiq:
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_PAST))
-        elif hiring_start_at > timezone.localdate() + relativedelta(months=6):
+        elif hiring_start_at > self._today + relativedelta(months=6):
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_FAR_FUTURE))
         elif (
             # Keep in sync with the JobApplication.accept() transition logic.

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -341,11 +341,10 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         self.is_geiq = company.kind == CompanyKind.GEIQ
         self.job_seeker = job_seeker
         attrs_min = {}
-        attrs_max = {}
         self._today = timezone.localdate()  # Make sure the form stays consistent around midnight
         if not self.is_geiq:
             attrs_min["min"] = self._today.isoformat()
-            attrs_max["max"] = (self._today + relativedelta(months=6)).isoformat()
+        attrs_max = {"max": self.get_far_future_date().isoformat()}
         self.fields["hiring_start_at"].required = True
         self.fields["hiring_start_at"].widget = DuetDatePickerWidget(attrs=attrs_min | attrs_max)
         self.fields["hiring_end_at"].widget = DuetDatePickerWidget(attrs=attrs_min)
@@ -488,13 +487,16 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         )
         self.fields["advisor"] = get_advisor_choice_field(current_user, job_seeker.get_inverted_full_name(), qs)
 
+    def get_far_future_date(self):
+        return self._today + relativedelta(months=6)
+
     def clean_hiring_start_at(self):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
 
         # Hiring in the past is *temporarily* possible for GEIQ
         if hiring_start_at < self._today and not self.is_geiq:
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_PAST))
-        elif hiring_start_at > self._today + relativedelta(months=6):
+        elif hiring_start_at > self.get_far_future_date():
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_FAR_FUTURE))
         elif (
             # Keep in sync with the JobApplication.accept() transition logic.

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -320,12 +320,8 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
             "inverted_vae_contract",
         ]
         help_texts = {
-            # Make it clear to employers that `hiring_start_at` has an impact on the start of the
-            # "parcours IAE" and the payment of the "aide au poste".
             "hiring_start_at": (
-                "Au format JJ/MM/AAAA, par exemple {}. Il n'est pas possible d'antidater un contrat.".format(
-                    timezone.localdate().strftime("%d/%m/%Y")
-                )
+                "Au format JJ/MM/AAAA, par exemple {}.".format(timezone.localdate().strftime("%d/%m/%Y"))
             ),
             "hiring_end_at": "Au format JJ/MM/AAAA, par exemple {}.".format(
                 (timezone.localdate() + datetime.timedelta(days=Approval.DEFAULT_APPROVAL_DAYS)).strftime("%d/%m/%Y")
@@ -376,9 +372,6 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
             self.fields["contract_type_details"].widget.attrs.update({"rows": 2})
             if initial is None or "planned_training_hours" not in initial:
                 self.initial["planned_training_hours"] = 0
-            self.fields["hiring_start_at"].help_text = "Au format JJ/MM/AAAA, par exemple {}.".format(
-                self._today.strftime("%d/%m/%Y"),
-            )
             # Dynamic selection of qualification level
             self.fields["qualification_type"].widget.attrs.update(
                 {
@@ -425,17 +418,10 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
                     "hx-target": "#geiq_contract_type_and_options_block",
                 },
             )
-        elif company.kind in CompanyKind.siae_kinds():
-            # Add specific details to help texts for IAE
-            self.fields["hiring_start_at"].help_text += (
-                " La date est modifiable jusqu'à la veille de la date saisie. En cas de premier PASS IAE pour "
-                "la personne, cette date déclenche le début de son parcours."
-            )
-            self.fields["hiring_end_at"].help_text += (
-                " Elle sert uniquement à des fins d'informations et est sans conséquence sur les déclarations "
-                "à faire dans l'extranet 2.0 de l'ASP. "
-                "<b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
-            )
+        elif company.is_subject_to_iae_rules:
+            self.fields[
+                "hiring_end_at"
+            ].help_text += " <b>Ne pas renseigner cette date dans le cadre d’un CDI Inclusion.</b>"
 
         # `hired_job` can't be used from model directly because of constrained choices
         # we must use a "simple" ChoiceField and update the value on cleaning

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -492,9 +492,9 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
 
         # Hiring in the past is *temporarily* possible for GEIQ
-        if hiring_start_at and hiring_start_at < timezone.localdate() and not self.is_geiq:
+        if hiring_start_at < timezone.localdate() and not self.is_geiq:
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_PAST))
-        elif hiring_start_at and hiring_start_at > timezone.localdate() + relativedelta(months=6):
+        elif hiring_start_at > timezone.localdate() + relativedelta(months=6):
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_FAR_FUTURE))
         elif (
             # Keep in sync with the JobApplication.accept() transition logic.

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -319,7 +319,7 @@ class TestJobApplicationAcceptFormInWizardWithGEIQFields:
         assert job_application.inverted_vae_contract
 
     def test_apply_with_past_hiring_date(self, client, faker):
-        CANNOT_BACKDATE_TEXT = "Il n'est pas possible d'antidater un contrat."
+        CANNOT_BACKDATE_TEXT = "La date ne peut pas être antérieure à aujourd’hui"
         # GEIQ can temporarily accept job applications with a past hiring date
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
 
@@ -394,17 +394,22 @@ class TestJobApplicationAcceptFormInWizardWithGEIQFields:
         job_application.refresh_from_db()
         assert job_application.state == JobApplicationState.ACCEPTED
 
-    HELP_START_AT = (
-        "La date est modifiable jusqu'à la veille de la date saisie. "
-        "En cas de premier PASS IAE pour la personne, cette date déclenche le début de son parcours."
-    )
-    HELP_END_AT = (
-        "Elle sert uniquement à des fins d'informations et est sans conséquence sur les déclarations "
-        "à faire dans l'extranet 2.0 de l'ASP. "
-        "<b>Ne pas compléter cette date dans le cadre d’un CDI Inclusion</b>"
-    )
-
     def test_specific_iae_mentions_in_accept_form(self, client):
+        MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_GEIQ = "La date est modifiable jusqu’à la veille de la date saisie."
+        MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_NON_GEIQ = (
+            "La date ne peut pas être antérieure à aujourd’hui "
+            "et reste modifiable jusqu’à la veille de la date saisie."
+        )
+        FIRST_APPROVAL_START_HELP = (
+            "En cas de premier PASS IAE pour la personne, cette date déclenche le début de son parcours."
+        )
+        CDI_INCLUSION_WARNING = "Ne pas renseigner cette date dans le cadre d’un CDI Inclusion."
+        ONLY_INFORMATION_HELP = "Cette date n'est qu'indicative."
+        ONLY_INFORMATION_HELP_WITH_ASP = (
+            "Cette date est indicative : "
+            "elle n’a aucun impact sur les déclarations à faire dans l’extranet 2.0 de l'ASP."
+        )
+
         def _response(kind):
             job_application = JobApplicationFactory(
                 sent_by_prescriber_alone=True,
@@ -430,13 +435,27 @@ class TestJobApplicationAcceptFormInWizardWithGEIQFields:
             return client.get(reverse("apply:accept_contract_infos", kwargs={"session_uuid": accept_session.name}))
 
         for kind in CompanyKind.siae_kinds():
-            assertContains(_response(kind), self.HELP_START_AT)
-            assertContains(_response(kind), self.HELP_END_AT)
+            response = _response(kind)
+            assertContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_NON_GEIQ)
+            assertNotContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_GEIQ)
+            assertContains(response, FIRST_APPROVAL_START_HELP)
+            assertNotContains(response, ONLY_INFORMATION_HELP)
+            assertContains(response, ONLY_INFORMATION_HELP_WITH_ASP)
+            assertContains(response, CDI_INCLUSION_WARNING)
 
         # EA and EATT employers can no longer log in, so they're not covered here
         for kind in (CompanyKind.GEIQ, CompanyKind.OPCS):
-            assertNotContains(_response(kind), self.HELP_START_AT)
-            assertNotContains(_response(kind), self.HELP_END_AT)
+            response = _response(kind)
+            if kind == CompanyKind.GEIQ:
+                assertContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_GEIQ)
+                assertNotContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_NON_GEIQ)
+            else:
+                assertNotContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_GEIQ)
+                assertContains(response, MODIFIABLE_UNTIL_THE_DAY_BEFORE_HELP_NON_GEIQ)
+            assertNotContains(response, FIRST_APPROVAL_START_HELP)
+            assertContains(response, ONLY_INFORMATION_HELP)
+            assertNotContains(response, ONLY_INFORMATION_HELP_WITH_ASP)
+            assertNotContains(response, CDI_INCLUSION_WARNING)
 
 
 class TestJobApplicationRefusalReasonForm:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les `help_text` des champs sont déjà bien fournis et on compte rajouter de nouvelles règles (validité du PASS ou du diagnostic d'éligibilité).

## :cake: Comment ? <!-- optionnel -->

Avec un composant.
