### PR TITLE
France Travail Connect : retour sur les anciennes URLs

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -64,9 +64,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     # --------------------------------------------------------------------------------------
     # France Travail Connect URLs.
-    path("ft_connect/", include("itou.openid_connect.ft_connect.urls")),
-    # Legacy, to remove in a few days
-    path("pe_connect/", include("itou.openid_connect.ft_connect.urls", namespace="pe_connect")),
+    path("pe_connect/", include("itou.openid_connect.ft_connect.urls")),
     # FranceConnect URLs.
     path("franceconnect/", include("itou.openid_connect.france_connect.urls")),
     # ProConnect URLs.

--- a/itou/openid_connect/ft_connect/views.py
+++ b/itou/openid_connect/ft_connect/views.py
@@ -44,7 +44,7 @@ def _redirect_to_job_seeker_login_on_error(error_msg, request, extra_tags=""):
 @login_not_required
 def ft_connect_authorize(request):
     # The redirect_uri should be defined in the France Travail Connect settings to be allowed
-    # NB: the integration platform allows "http://127.0.0.1:8000/ft_connect/callback"
+    # NB: the integration platform allows "http://127.0.0.1:8000/pe_connect/callback"
     redirect_uri = get_absolute_url(reverse("ft_connect:callback"), host=request.get_host())
     nonce = crypto.get_random_string(12)
     state = FranceTravailConnectState.save_state(nonce=nonce)

--- a/tests/openid_connect/ft_connect/tests.py
+++ b/tests/openid_connect/ft_connect/tests.py
@@ -127,7 +127,7 @@ class TestPoleEmploiConnect:
         assert f"nonce={pec_state.nonce}" in response.url
         urlparts = urllib.parse.urlsplit(response.url)
         query = QueryDict(urlparts.query)
-        assert query["redirect_uri"] == "http://testserver/ft_connect/callback"
+        assert query["redirect_uri"] == "http://testserver/pe_connect/callback"
 
     def test_create_user(self):
         """

--- a/tests/www/login/__snapshots__/tests.ambr
+++ b/tests/www/login/__snapshots__/tests.ambr
@@ -209,7 +209,7 @@
           </strong>
       </p>
       <div class="mt-4 text-center">
-          <form action="/ft_connect/authorize" method="post">
+          <form action="/pe_connect/authorize" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <input alt="Se connecter avec votre compte France Travail" data-matomo-action="clic" data-matomo-category="inscription-candidat" data-matomo-event="true" data-matomo-option="se-connecter-avec-pe" src="/static/img/ft_connect_btn.svg" type="image"/>
           </form>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les nouvelles URL n'ont pas encore été autorisées, ce qui bloque nos utilisateurs:
https://gip-inclusion.slack.com/archives/C01181Y04LT/p1785221017654099

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
