### PR TITLE
Contrôle a posteriori : correction de l'alignement sur la page de sélection de l'échantillon

### DIFF
--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -93,7 +93,11 @@
                                         <p class="fw-bold">
                                             Ratio sélectionné : <span id="showChosenPercentValue"></span> %
                                         </p>
-                                        <p>{{ min }}% {{ form.chosen_percent }} {{ max }}%</p>
+                                        <div class="d-flex align-items-center gap-2">
+                                            <span class="text-nowrap">{{ min }}%</span>
+                                            {{ form.chosen_percent }}
+                                            <span class="text-nowrap">{{ max }}%</span>
+                                        </div>
                                     </div>
 
                                     {% itou_buttons_form primary_label="Valider" secondary_url=back_url %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le champ `chosen_percent` et les pourcentages min/max s'affichaient sur plusieurs lignes, cassant l'alignement et tout la mise en page de la zone.

## :cake: Comment ?

Passage à un conteneur flex (`d-flex align-items-center gap-2`) pour garder les éléments alignés sur une seule ligne.

## :computer: Captures d'écran

**AVANT**

<img width="2256" height="1370" alt="github-issue" src="https://github.com/user-attachments/assets/0bfcd617-f1ce-4ff5-9775-2e00579dafe6" />

<br/>

**APRÈS**

<img width="1917" height="1600" alt="image" src="https://github.com/user-attachments/assets/0af35f86-728a-480c-baa9-e95594f1079d" />
