### PR TITLE
Insertion : Meilleur affichage des listes avec markdown

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -670,7 +670,15 @@ MARKDOWNIFY = {
             "CALLBACKS": [markdown_url_set_target_blank, markdown_url_set_protocol],
             "PARSE_EMAIL": True,
         },
-    }
+    },
+    "inline": {
+        "WHITELIST_TAGS": ["a", "em", "strong", "br"],
+        "LINKIFY_TEXT": {
+            "PARSE_URLS": True,
+            "CALLBACKS": [markdown_url_set_target_blank, markdown_url_set_protocol],
+            "PARSE_EMAIL": True,
+        },
+    },
 }
 # ASP SFTP connection
 # ------------------------------------------------------------------------------

--- a/itou/templates/insertion/includes/orientation_credentials_list.html
+++ b/itou/templates/insertion/includes/orientation_credentials_list.html
@@ -12,6 +12,6 @@
         <p>(A récupérer auprès de l'usager)</p>
     {% endif %}
     <ul class="{% if show_section_heading|default:False or show_recovery_note|default:False %}mb-3 mb-md-4{% endif %}">
-        {% for prerequisite in service.prerequisites %}<li>{{ prerequisite|markdownify }}</li>{% endfor %}
+        {% for prerequisite in service.prerequisites %}<li>{{ prerequisite|markdownify:"inline" }}</li>{% endfor %}
     </ul>
 {% endif %}

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -345,7 +345,7 @@
                             <h2 class="h3">Pré-requis et justificatifs</h2>
                             <ul class="mb-0">
                                 {% for prerequisite in service.prerequisites %}
-                                    <li>{{ prerequisite|markdownify }}</li>
+                                    <li>{{ prerequisite|markdownify:"inline" }}</li>
                                 {% endfor %}
                             </ul>
                         </div>

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -1,0 +1,30 @@
+from markdownify.templatetags.markdownify import markdownify
+
+
+def test_markdown_render_default():
+    markdown = "*Lorem ipsum*, **bold** and [link](https://beta.gouv.fr).\n\n- item 1\n- item 2"
+    attrs = 'target="_blank" rel="noopener" aria-label="Ouverture dans un nouvel onglet"'
+    assert (
+        markdownify(markdown)
+        == f'<p><em>Lorem ipsum</em>, <strong>bold</strong> and <a href="https://beta.gouv.fr" {attrs}>link</a>.</p>'
+        "\n<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul>"
+    )
+
+
+def test_markdown_render_default_forbidden_tags():
+    markdown = '# Gros titre\n<script></script>\n<span class="font-size:200px;">Gros texte</span>'
+    assert markdownify(markdown) == "Gros titre\n\n<p>Gros texte</p>"
+
+
+def test_markdown_render_inline():
+    markdown = "*Lorem ipsum*, **bold** and [link](https://beta.gouv.fr)."
+    attrs = 'target="_blank" rel="noopener" aria-label="Ouverture dans un nouvel onglet"'
+    assert (
+        markdownify(markdown, "inline")
+        == f'<em>Lorem ipsum</em>, <strong>bold</strong> and <a href="https://beta.gouv.fr" {attrs}>link</a>.'
+    )
+
+
+def test_markdown_render_inline_forbidden_tags():
+    markdown = '# Gros titre\n<script></script>\n<span class="font-size:200px;">Gros texte</span>\n- item 1\n- item 2'
+    assert markdownify(markdown, "inline") == "Gros titre\n\n\nGros texte\n- item 1\n- item 2"

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -126,19 +126,13 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  <p>
-                                      Avoir plus de 18 ans
-                                  </p>
+                                  Avoir plus de 18 ans
                               </li>
                               <li>
-                                  <p>
-                                      Résider en France
-                                  </p>
+                                  Résider en France
                               </li>
                               <li>
-                                  <p>
-                                      Pièce d'identité en cours de validité
-                                  </p>
+                                  Pièce d'identité en cours de validité
                               </li>
                           </ul>
                       </div>
@@ -277,14 +271,10 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  <p>
-                                      Être orienté par un prescripteur
-                                  </p>
+                                  Être orienté par un prescripteur
                               </li>
                               <li>
-                                  <p>
-                                      Avoir 18 ans
-                                  </p>
+                                  Avoir 18 ans
                               </li>
                           </ul>
                       </div>
@@ -606,9 +596,7 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  <p>
-                                      Être orienté par un prescripteur.
-                                  </p>
+                                  Être orienté par un prescripteur.
                               </li>
                           </ul>
                       </div>

--- a/tests/www/insertion_views/__snapshots__/test_wizard.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_wizard.ambr
@@ -329,19 +329,13 @@
                           </p>
                           <ul class="mb-3 mb-md-4">
                               <li>
-                                  <p>
-                                      Résident QPV / ZFRR
-                                  </p>
+                                  Résident QPV / ZFRR
                               </li>
                               <li>
-                                  <p>
-                                      Pièce d'identité
-                                  </p>
+                                  Pièce d'identité
                               </li>
                               <li>
-                                  <p>
-                                      Justificatif de domicile
-                                  </p>
+                                  Justificatif de domicile
                               </li>
                           </ul>
                           <div class="form-group form-group-required-check form-group-required">
@@ -459,19 +453,13 @@
                           </p>
                           <ul class="mb-3 mb-md-4">
                               <li>
-                                  <p>
-                                      Résident QPV / ZFRR
-                                  </p>
+                                  Résident QPV / ZFRR
                               </li>
                               <li>
-                                  <p>
-                                      Pièce d'identité
-                                  </p>
+                                  Pièce d'identité
                               </li>
                               <li>
-                                  <p>
-                                      Justificatif de domicile
-                                  </p>
+                                  Justificatif de domicile
                               </li>
                           </ul>
                           <div class="form-group">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les fiches services contiennent des listes dont les éléments passent par `markdownify`.
Par défaut, `markdownify` crée des paragraphes, et cela crée marges non voulues, en plus d’être déroutant sémantiquement.

## :cake: Comment ? <!-- optionnel -->

On ajoute un nouveau paramètre `inline` à la configuration de `markdownify`.

Et on ajoute des tests.


Cela ne concerne pour le moment que la fiche service, mais sera aussi utilisé dans #8467 a minima.

## Rendu

Avant :  
<img width="741" height="289" alt="image" src="https://github.com/user-attachments/assets/b69f1aa7-32f1-442f-ab86-00b3136cdadf" />

Après : 
<img width="709" height="213" alt="image" src="https://github.com/user-attachments/assets/f75b13d8-2c9b-4462-8026-a7e0f14cfe58" />

