### PR TITLE
Tech: Masquer par défaut les accompagnateur dont le compte est désactivés

### DIFF
--- a/itou/archive/anonymize.py
+++ b/itou/archive/anonymize.py
@@ -78,7 +78,7 @@ def anonymize_professionals_without_deletion(users):
     # No need to keep assignments from professionals without organization or company.
     # If a professional was anonymized without deletion just because of an assignment
     # like these, he will be deleted on the next command run.
-    JobSeekerAssignment.objects.filter(
+    JobSeekerAssignment.include_inactive.filter(
         professional_id__in=user_ids,
         prescriber_organization_id__isnull=True,
         company_id__isnull=True,

--- a/itou/prescribers/management/commands/merge_organizations.py
+++ b/itou/prescribers/management/commands/merge_organizations.py
@@ -51,10 +51,10 @@ def _model_sanity_check():
 
 
 def _get_job_seeker_assignments(from_id, to_id):
-    from_org_assignments = users_models.JobSeekerAssignment.objects.filter(prescriber_organization_id=from_id)
+    from_org_assignments = users_models.JobSeekerAssignment.include_inactive.filter(prescriber_organization_id=from_id)
     to_org_assignments = {
         (assignment.job_seeker, assignment.professional): assignment
-        for assignment in users_models.JobSeekerAssignment.objects.filter(prescriber_organization_id=to_id)
+        for assignment in users_models.JobSeekerAssignment.include_inactive.filter(prescriber_organization_id=to_id)
     }
 
     assignments_to_update = []
@@ -156,8 +156,12 @@ def organization_merge_into(from_id, to_id):
     invitations.update(organization_id=to_id)
     prolongations.update(prescriber_organization_id=to_id)
     prolongation_requests.update(prescriber_organization_id=to_id)
-    _, deleted_assignments = users_models.JobSeekerAssignment.objects.filter(pk__in=assignments_ids_to_delete).delete()
-    users_models.JobSeekerAssignment.objects.bulk_update(assignments_to_update, fields=["prescriber_organization_id"])
+    _, deleted_assignments = users_models.JobSeekerAssignment.include_inactive.filter(
+        pk__in=assignments_ids_to_delete
+    ).delete()
+    users_models.JobSeekerAssignment.include_inactive.bulk_update(
+        assignments_to_update, fields=["prescriber_organization_id"]
+    )
     _, deleted_objs = from_organization.delete()
     logger.info("Deleted organization ID %s, deleted objects: %s", from_id, deleted_objs | deleted_assignments)
 

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -60,6 +60,7 @@ from itou.utils.admin import (
 from itou.utils.templatetags.str_filters import pluralizefr
 from itou.utils.validators import is_france_travail_id_format
 from itou.utils.views import with_triggers_context
+from itou.www.apply.views.common import JobSeekerAndContractInfosNeededMixin
 
 
 logger = logging.getLogger(__name__)
@@ -482,7 +483,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
             key = "job_seeker"
         elif obj.is_professional:
             key = "professional"
-        if key and (count := models.JobSeekerAssignment.objects.filter(**{key: obj}).count()):
+        if key and (count := models.JobSeekerAssignment.include_inactive.filter(**{key: obj}).count()):
             url = reverse("admin:users_jobseekerassignment_changelist", query={key: obj.pk})
             return format_html('<a href="{}">Liste des affectations candidat ({})</a>', url, count)
         return self.get_empty_value_display()
@@ -867,7 +868,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
                             item.sender = to_user
                         if field.name == "job_seeker_assignments":
                             # Check and merge if to_user has an assignment with same professional and organization
-                            to_user_assignment = models.JobSeekerAssignment.objects.filter(
+                            to_user_assignment = models.JobSeekerAssignment.include_inactive.filter(
                                 job_seeker=to_user,
                                 professional=item.professional,
                                 prescriber_organization=item.prescriber_organization,
@@ -878,7 +879,9 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
                                     assignment_to_delete=item, assignment_to_keep=to_user_assignment
                                 )
                             else:
-                                models.JobSeekerAssignment.objects.filter(pk=item.pk).update(job_seeker=to_user)
+                                models.JobSeekerAssignment.include_inactive.filter(pk=item.pk).update(
+                                    job_seeker=to_user
+                                )
                         else:
                             # Don't change assignment's updated_at field
                             item.save()
@@ -1285,6 +1288,13 @@ class JobSeekerAssignmentAdmin(ItouModelAdmin):
         "company",
     )
     ordering = ("-updated_at",)
+
+    def get_queryset(self, request):
+        queryset = self.model.include_inactive.all()
+        ordering = self.get_ordering(request)
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        return queryset
 
     @admin.display(description="candidat")
     def job_seeker_display(self, obj):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1603,12 +1603,17 @@ class IdentityCertification(models.Model):
         ]
 
 
-class JobSeekerAssignmentManager(models.Manager):
+class JobSeekerAssignmentQueryset(models.QuerySet):
+    def active(self):
+        return self.filter(professional__is_active=True)
+
+
+class ActiveJobSeekerAssignmentManager(models.Manager.from_queryset(JobSeekerAssignmentQueryset)):
     def upsert_assignment(
         self, job_seeker, professional, organization, last_action_kind, assigned_to_unknown_advisor=False
     ):
         assert job_seeker.is_job_seeker
-        if not professional.is_professional:
+        if not professional.is_professional or not professional.is_active:
             # This should not happen but we don't want to block everything
             logger.error("We should not try to add a JobSeekerAssignment on user=%s", professional.pk)
             return
@@ -1644,7 +1649,10 @@ class JobSeekerAssignmentManager(models.Manager):
                     Q(professional=professional, prescriber_organization=prescriber_organization, company=company)
                 )
 
-        return JobSeekerAssignment.objects.filter(or_queries(filters))
+        return JobSeekerAssignment.objects.filter(or_queries(filters)).filter(ended_at=None)
+
+    def get_queryset(self):
+        return super().get_queryset().active()
 
 
 class JobSeekerAssignment(models.Model):
@@ -1693,7 +1701,8 @@ class JobSeekerAssignment(models.Model):
         default=False,
     )
 
-    objects = JobSeekerAssignmentManager()
+    objects = ActiveJobSeekerAssignmentManager()
+    include_inactive = JobSeekerAssignmentQueryset.as_manager()
 
     class Meta:
         verbose_name = "affectation candidat"

--- a/itou/users/utils.py
+++ b/itou/users/utils.py
@@ -22,7 +22,7 @@ NIR_RE = re.compile(
 
 def merge_job_seeker_assignments(*, assignment_to_delete, assignment_to_keep):
     last_assignment = max([assignment_to_delete, assignment_to_keep], key=lambda a: a.updated_at)
-    JobSeekerAssignment.objects.filter(pk=assignment_to_keep.pk).update(
+    JobSeekerAssignment.include_inactive.filter(pk=assignment_to_keep.pk).update(
         created_at=min(assignment_to_delete.created_at, assignment_to_keep.created_at),
         updated_at=last_assignment.updated_at,
         last_action_kind=last_assignment.last_action_kind,

--- a/itou/www/itou_staff_views/merge_utils.py
+++ b/itou/www/itou_staff_views/merge_utils.py
@@ -145,7 +145,7 @@ def handle_job_seeker_assignment(model, from_user, to_user):
             moved_pks.append(from_user_assignment.pk)
             from_user_assignment.professional = to_user
 
-    JobSeekerAssignment.objects.filter(pk__in=moved_pks).update(professional=to_user)
+    JobSeekerAssignment.include_inactive.filter(pk__in=moved_pks).update(professional=to_user)
     base_log = get_log_prefix(to_user, from_user) + f"{model.__module__}.{model.__name__}.professional"
     if updated_pks:
         logger.info(f"{base_log} updated : {updated_pks}")

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1027,6 +1027,21 @@ class TestLastAssignment:
         assert last_advisor == job_seeker_assignment_2.professional
         assert last_advisor_org == org_2
 
+    def test_inactive_advisor(self):
+        JobSeekerAssignmentFactory(professional__is_active=False)
+
+        assert JobSeekerAssignment.objects.count() == 0
+        assert JobSeekerAssignment.include_inactive.count() == 1
+
+    def test_dont_upsert_inactive_professional(self, caplog):
+        professional = PrescriberFactory(is_active=False)
+        job_seeker = JobSeekerFactory()
+
+        JobSeekerAssignment.objects.upsert_assignment(job_seeker, professional, None, random.choice(ActionKind.values))
+        assert JobSeekerAssignment.include_inactive.count() == 0
+
+        assert caplog.messages == [f"We should not try to add a JobSeekerAssignment on user={professional.pk}"]
+
 
 @pytest.mark.parametrize("initial_asp_uid", ("000000000000000000000000000000", ""))
 @override_settings(SECRET_KEY="test")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Même logique que dans GPS : l'utilisateur n'est plus actif, il ne faut pas qu'on puisse le contacter via la plateforme.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
