### PR TITLE
Tech : mise à jour de Huey avec la version 3.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -759,9 +759,9 @@ httpx==0.28.1 \
     # via
     #   -r base.in
     #   itoutils
-huey==3.1.1 \
-    --hash=sha256:156f30e90f0fae81ae2e004f2062e1b18ec9dcbc684564df63159ef546b13502 \
-    --hash=sha256:8773231c7bc7a40b9b9191d72cf1c6580bbf6742a4118c70dde6b5c2e7ccb7ce
+huey==3.3.0 \
+    --hash=sha256:a7b1581aaae5f70540faafcf3306d74fa138ec7bad520f81150bb70b224eaddf \
+    --hash=sha256:e0c2a1542e6c3acb894821cde895cf9dbf72e42deb25f55b2d44096aa30f8f24
     # via -r base.in
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -920,9 +920,9 @@ httpx==0.28.1 \
     #   -r test.txt
     #   itoutils
     #   respx
-huey==3.1.1 \
-    --hash=sha256:156f30e90f0fae81ae2e004f2062e1b18ec9dcbc684564df63159ef546b13502 \
-    --hash=sha256:8773231c7bc7a40b9b9191d72cf1c6580bbf6742a4118c70dde6b5c2e7ccb7ce
+huey==3.3.0 \
+    --hash=sha256:a7b1581aaae5f70540faafcf3306d74fa138ec7bad520f81150bb70b224eaddf \
+    --hash=sha256:e0c2a1542e6c3acb894821cde895cf9dbf72e42deb25f55b2d44096aa30f8f24
     # via -r test.txt
 identify==2.6.19 \
     --hash=sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -878,9 +878,9 @@ httpx==0.28.1 \
     #   -r base.txt
     #   itoutils
     #   respx
-huey==3.1.1 \
-    --hash=sha256:156f30e90f0fae81ae2e004f2062e1b18ec9dcbc684564df63159ef546b13502 \
-    --hash=sha256:8773231c7bc7a40b9b9191d72cf1c6580bbf6742a4118c70dde6b5c2e7ccb7ce
+huey==3.3.0 \
+    --hash=sha256:a7b1581aaae5f70540faafcf3306d74fa138ec7bad520f81150bb70b224eaddf \
+    --hash=sha256:e0c2a1542e6c3acb894821cde895cf9dbf72e42deb25f55b2d44096aa30f8f24
     # via -r base.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \


### PR DESCRIPTION
## :thinking: Pourquoi ?

Voir aussi [cet échange Slack](https://gip-inclusion.slack.com/archives/CRW3TSFRV/p1785247869948639). Le bump `huey` 3.1.1 ➜  3.3.0 avait été revert (`343a05980`) à cause de `TypeError` en prod. En réalité, la version 3.3.0 n'est pas en cause : elle ajoute un 15e champ (`retry_backoff`) au `Message`, et un consumer en 3.1.1 ne sait pas lire un message produit en 3.3.0.

L'incompatibilité ne va que dans un sens : un consumer 3.3.0 lit sans problème les messages 3.1.1. Tout mettre à jour règle donc le problème.

## :cake: Comment ?

Revert du revert.

⚠️ **Des `TypeError` réapparaîtront pendant le déploiement.** L'app web et le consumer `huey` sont 2 déploiements séparés : tant que les _producers_ seront en 3.3.0 et le _consumer_ sera encore en 3.1.1, chaque tâche créée lèvera l'erreur... Mais ça ne devrait pas durer.