### PR TITLE
Insertion : réaméliorer le formatage des pré-requis (pour les services D·I)

### DIFF
--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -345,7 +345,12 @@
                             <h2 class="h3">Pré-requis et justificatifs</h2>
                             <ul class="mb-0">
                                 {% for prerequisite in service.prerequisites %}
-                                    <li>{{ prerequisite|markdownify:"inline" }}</li>
+                                    {% if service.is_dora %}
+                                        <li>{{ prerequisite|markdownify:"inline" }}</li>
+                                    {% else %}
+                                        {# D·I service may have blocks tags such as lists #}
+                                        <li>{{ prerequisite|markdownify }}</li>
+                                    {% endif %}
                                 {% endfor %}
                             </ul>
                         </div>

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -271,10 +271,14 @@
                           </h2>
                           <ul class="mb-0">
                               <li>
-                                  Être orienté par un prescripteur
+                                  <p>
+                                      Être orienté par un prescripteur
+                                  </p>
                               </li>
                               <li>
-                                  Avoir 18 ans
+                                  <p>
+                                      Avoir 18 ans
+                                  </p>
                               </li>
                           </ul>
                       </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?
Le format de `access_conditions_di` est… hétérogène, comme discuté dans #8382

Suite au commit 881ec5f71ae1bcc58f5035548af55d883d9afd6d, l’affichage pour certains services DI est meilleur, mais pour d’autres il est cassé, ex :

<img width="685" height="129" alt="image" src="https://github.com/user-attachments/assets/909dd9ad-c7df-4759-ba10-b782ddaa167c" />

La solution facile est de "*revert*" 881ec5f pour les services DI. 
On peut probablement mieux faire, mais ça n’est pas urgent, surtout pour les services DI.


## Comparaisons

### `main` (avec le commit 881ec5f)
<img width="988" height="172" alt="image" src="https://github.com/user-attachments/assets/0d7d5974-f016-4a49-b8b4-a7656e03858d" />

<img width="871" height="257" alt="image" src="https://github.com/user-attachments/assets/bd2b9a8c-e5f9-4b3c-97b5-3a5bced969f5" />

<img width="810" height="231" alt="image" src="https://github.com/user-attachments/assets/bafa67e9-5f57-4734-904f-94537ef4871b" />


### "comme avant" (markdown avec balises bloc autorisées pour DI)

<img width="743" height="182" alt="image" src="https://github.com/user-attachments/assets/89d4ffb3-8652-43c6-a328-4e97e9b8adfe" />

<img width="670" height="387" alt="image" src="https://github.com/user-attachments/assets/83e1f268-a3da-4293-b6b7-0de47021c41d" />

<img width="814" height="291" alt="image" src="https://github.com/user-attachments/assets/0dced911-f07f-43ab-b022-42de83e25d87" />

