### PR TITLE
Candidature : Nettoyage d’une méthode non utilisée

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -1118,10 +1118,6 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
             queryset = queryset.filter(sender_company__id__in=sender_companies)
         return queryset
 
-    def _get_choices_for_job_seeker(self, users):
-        users = [(user.id, user_full_name) for user in users if (user_full_name := user.get_inverted_full_name())]
-        return sorted(users, key=lambda user: user[1])
-
 
 class PrescriberFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsForm):
     """


### PR DESCRIPTION

## :thinking: Pourquoi ?

Depuis 0c95a5991d, une nouvelle méthome d’autocomplete est utilisée.

