### PR TITLE
Insertion : Ne pas proposer le formulaire d’orientation pour les services venant de certaines sources

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -784,6 +784,8 @@ DORA_WWW_BASE_URL = os.getenv("DORA_WWW_BASE_URL", "https://dora.inclusion.gouv.
 DORA_API_BASE_URL = os.getenv("DORA_API_BASE_URL", "https://api.dora.inclusion.gouv.fr")
 DORA_API_TOKEN = os.getenv("DORA_API_TOKEN")
 
+NON_ORIENTABLE_DI_SOURCES = os.getenv("NON_ORIENTABLE_DI_SOURCES", [])
+
 # GPS
 # ------------------------------------------------------------------------------
 GPS_GROUPS_CREATED_BY_EMAIL = os.getenv("GPS_GROUPS_CREATED_BY_EMAIL", None)

--- a/itou/insertion/models.py
+++ b/itou/insertion/models.py
@@ -457,8 +457,14 @@ class Service(GeolocatedAddressMixin, models.Model):
         return bool(self.prerequisites)
 
     @property
+    def from_non_orientable_di_source(self) -> bool:
+        return self.source.value in settings.NON_ORIENTABLE_DI_SOURCES
+
+    @property
     def has_orientation_action(self):
-        return self.is_orientable_with_form or bool(self.mobilization_modes_professionals_external_form_link)
+        return (self.is_orientable_with_form and not self.from_non_orientable_di_source) or bool(
+            self.mobilization_modes_professionals_external_form_link
+        )
 
     def has_mobilization_modes(self):
         return (not self.is_dora and bool(self.mobilizations.all())) or (

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -41,7 +41,7 @@
                             {% if request.GET.job_seeker_public_id %}
                                 {% url_add_query start_orientation_url job_seeker_public_id=request.GET.job_seeker_public_id as start_orientation_url %}
                             {% endif %}
-                            {% if service.is_orientable_with_form %}
+                            {% if service.is_orientable_with_form and not service.from_non_orientable_di_source %}
                                 {% if can_orient_towards_insertion_service %}
                                     <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
                                        data-emplois-mobilization-kind="{{ MobilizationEventKind.SERVICE_ORIENTATION }}"

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -222,7 +222,11 @@ class OrientationStep(enum.StrEnum):
 
 
 def start_orientation(request, service_uid):
-    service = get_object_or_404(insertion_models.Service, uid=service_uid, is_orientable_with_form=True)
+    service = get_object_or_404(
+        insertion_models.Service.objects.exclude(source__value__in=settings.NON_ORIENTABLE_DI_SOURCES),
+        uid=service_uid,
+        is_orientable_with_form=True,
+    )
     if not (job_seeker_public_id := request.GET.get("job_seeker_public_id")):
         logger.info(
             "orientation wizard start_without_job_seeker user=%s service_uid=%s",

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -523,6 +523,40 @@ class TestServices:
         assertNotContains(response, self.ORIENT_BTN_LABEL)
         assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
 
+    def test_detail_non_orientable_di_sources(self, client, settings):
+        user = PrescriberFactory(membership=True)
+        blacklisted_source = "blacklisted-source"
+        settings.NON_ORIENTABLE_DI_SOURCES = [blacklisted_source]
+        service = ServiceFactory(
+            uid="test-orientable-uid",
+            name="Service non orientable",
+            updated_on="2025-01-15",
+            is_orientable_with_form=True,
+            source__value=blacklisted_source,
+        )
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertNotContains(response, self.ORIENT_BTN_LABEL)
+
+    def test_detail_non_orientable_di_sources_with_external_link(self, client, settings):
+        user = PrescriberFactory(membership=True)
+        blacklisted_source = "blacklisted-source"
+        settings.NON_ORIENTABLE_DI_SOURCES = [blacklisted_source]
+        external_link = "https://test.example.com"
+        service = ServiceFactory(
+            uid="test-orientable-uid",
+            name="Service non orientable",
+            updated_on="2025-01-15",
+            is_orientable_with_form=True,
+            mobilization_modes_professionals_external_form_link=external_link,
+            mobilization_modes_professionals_external_form_link_text="",
+            source__value=blacklisted_source,
+        )
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertContains(response, self.ORIENT_BTN_LABEL)
+        assertContains(response, f'href="{external_link}"')
+
     def test_detail_contact_section_hidden_without_contact_info(self, client):
         user = PrescriberFactory(membership=True)
         service = ServiceFactory(

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -268,6 +268,20 @@ def test_start_requires_login(client):
     assert "/accounts/login" in response.headers["Location"]
 
 
+@pytest.mark.parametrize("is_blacklisted, status_code", [(True, 404), (False, 302)])
+def test_start_with_non_orientable_di_sources(client, settings, is_blacklisted, status_code):
+    prescriber = PrescriberFactory(membership=True)
+    source_value = "source-name"
+    if is_blacklisted:
+        settings.NON_ORIENTABLE_DI_SOURCES = [source_value]
+    service = ServiceFactory(is_orientable_with_form=True, source__value=source_value)
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+    client.force_login(prescriber)
+
+    response = client.get(start_url)
+    assert response.status_code == status_code
+
+
 def test_session_isolation_between_users(client):
     prescriber = PrescriberFactory(membership=True)
     job_seeker = JobSeekerFactory(phone="0606060606")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Nous savons que certains services ou structures ne répondent pas aux demandes d'orientation. Afin d'éviter de susciter de faux espoirs, on ne arrête de proposer le formulaire d'orientation interne pour ces derniers.

[Carte Notion](https://app.notion.com/p/gip-inclusion/Retirer-le-formulaire-d-orientation-sur-les-sources-d-i-qui-ne-r-pondent-pas-3ac5f321b60480aa8fa5fdd85c87bd27?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link)

À approuver aussi : https://github.com/gip-inclusion/les-emplois-secrets/pull/78

## :cake: Comment ? <!-- optionnel -->

Une liste de sources en variables d’environnement, vu que ça peut changer de temps en temps.

