### PR TITLE
Tech: Ajout d'une fonction pour changer le mot de passe de l'API INSEE

### DIFF
--- a/itou/utils/apis/api_entreprise.py
+++ b/itou/utils/apis/api_entreprise.py
@@ -133,3 +133,34 @@ def etablissement_get_or_error(siret):
     )
 
     return etablissement, None
+
+
+def renew_password(new_password):
+    # Allow to renew the password through the API (it's the only way)
+    # See the API documentation
+    # https://portail-api.insee.fr/catalog/api/26d13266-689d-3fee-845d-c08e12b8f0dd/doc?page=a7e0ed84-020c-48bc-a0ed-84020c08bce2
+
+    access_token = get_access_token()
+    if not access_token:
+        return False, "Problème de connexion à la base Sirene. Essayez ultérieurement."
+
+    url = f"{settings.API_INSEE_SIRENE_URL}/renouvellement"
+    response = httpx.post(
+        url,
+        content=json.dumps(
+            {
+                "oldPassword": settings.API_INSEE_PASSWORD,
+                "newPassword": new_password,
+            }
+        ),
+        headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
+    )
+
+    if response.status_code == 200:
+        return True, None
+
+    if response.status_code == 400:
+        error = "Problème lors du renouvellement du mot de passe. \n" + response.content.decode()
+    else:
+        error = "Problème de connexion à la base Sirene. Essayez ultérieurement."
+    return False, error

--- a/itou/utils/management/commands/renew_insee_api_password.py
+++ b/itou/utils/management/commands/renew_insee_api_password.py
@@ -1,0 +1,28 @@
+from django.utils import crypto
+
+from itou.utils.apis.api_entreprise import renew_password
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
+    def handle(self, **options):
+        # Allow to renew the password through the API (it's the only way)
+        # See the API documentation
+        # https://portail-api.insee.fr/catalog/api/26d13266-689d-3fee-845d-c08e12b8f0dd/doc?page=a7e0ed84-020c-48bc-a0ed-84020c08bce2
+
+        # Only 13 special characters are allowed
+        # We will not use $ as it causes issues when used in environment variables
+        ALLOWED_SPECIAL_CHARACTERS = "@#^&*-_!+=?."
+        new_password = crypto.get_random_string(30, crypto.RANDOM_STRING_CHARS + ALLOWED_SPECIAL_CHARACTERS)
+        self.stdout.write(f"Tentative de modification du mot de passe en : {new_password}")
+        self.stdout.write("...")
+
+        success, error = renew_password(new_password)
+        if success:
+            self.stdout.write(
+                "Mot de passe modifié. Mettez-le à jour dans settings et dans le gestionnaire de mot de passe."
+            )
+        else:
+            self.stdout.write(error)

--- a/tests/utils/apis/test_entreprise_api.py
+++ b/tests/utils/apis/test_entreprise_api.py
@@ -1,12 +1,14 @@
 import copy
 import json
 import logging
+from io import StringIO
 
 import httpx
 import pytest
 import respx
 from django.conf import settings
 from django.core.cache import caches
+from django.core.management import call_command
 from freezegun import freeze_time
 
 from itou.utils.apis import api_entreprise
@@ -251,3 +253,17 @@ class TestApiEntreprise:
         assert etablissement.post_code is None
         assert etablissement.city is None
         assert etablissement.department is None
+
+    @respx.mock
+    def test_renew_password_command(self, settings):
+        settings.API_INSEE_USERNAME = "baz"
+        respx.post(f"{settings.API_INSEE_SIRENE_URL}/renouvellement").respond(200, json={})
+        out = StringIO()
+
+        call_command("renew_insee_api_password", stdout=out)
+
+        out.seek(0)
+        assert (
+            "Mot de passe modifié. Mettez-le à jour dans settings et dans le gestionnaire de mot de passe."
+            in out.read()
+        )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le mot de passe de l'API INSEE doit être changé tous les 3 mois, via API uniquement.
Autant le faire depuis le code en se connectant sur l'instance de prod.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
