### PR TITLE
Tech: utiliser l'API Bootstrap native pour initialiser les toasts

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -161,8 +161,8 @@
         <script nonce="{{ csp_nonce }}">
             // Show any toasts present in the loaded DOM
             htmx.onLoad((target) => {
-                $(".toast-container .toast", target).each(function() {
-                    $(this).toast("show");
+                target.querySelectorAll(".toast-container .toast").forEach((toastEl) => {
+                    new bootstrap.Toast(toastEl).show();
                 });
             });
         </script>

--- a/itou/templates/nexus/layout/base.html
+++ b/itou/templates/nexus/layout/base.html
@@ -72,8 +72,8 @@
         <script nonce="{{ csp_nonce }}">
             // Show any toasts present in the loaded DOM
             htmx.onLoad((target) => {
-                $(".toast-container .toast", target).each(function() {
-                    $(this).toast("show");
+                target.querySelectorAll(".toast-container .toast").forEach((toastEl) => {
+                    new bootstrap.Toast(toastEl).show();
                 });
             });
         </script>


### PR DESCRIPTION
## :thinking: Pourquoi ?

[faite par Claude. Je doute doucement ~mais je crois qu'il a réellement raison sur ce point~]

Le mécanisme d'affichage des toasts (messages flash `extra_tags="toast"`) ~était silencieusement cassé depuis le passage à Bootstrap 5.~ utilise une vieille manière d'initialiser les toasts : en passant par jQurery. C'est relativement déprécié (Bootstrap 5 ne s'appuie plus sur jQuery)([mais fournit un pont de compatibilité](https://getbootstrap.com/docs/5.0/getting-started/javascript/#still-want-to-use-jquery-its-possible))(pour l'instant?)

Le code existant utilisait l'ancien plugin jQuery de Bootstrap 4 :

```js
$(this).toast("show");
```

~Bootstrap 5 a supprimé le pont jQuery (`$.fn.toast` n'existe plus). L'appel levait donc une `TypeError` dans la console du navigateur, le toast recevait jamais la classe `.show`, et restait caché par le CSS (`.toast:not(.show) { display: none }`). Tous les toasts de l'appli étaient concernés.~

## :cake: Comment ?

Remplacement par l'API vanilla Bootstrap 5, cohérent avec le reste du projet (ex. `new bootstrap.Modal(…).show()` déjà utilisé partout ailleurs) :

```js
target.querySelectorAll("...").forEach((toastEl) => {
    new bootstrap.Toast(toastEl).show();
});
```

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Déclencher n'importe quelle action qui produit un toast (ex. archiver une candidature depuis la vue batch), et vérifier que le toast s'affiche bien en haut de la page suivante.

<!-- changelog: Interface -->