### PR TITLE
Insertion : Mettre à jour Orientation.updated_at lors de la synchro des statuts des orientations

### DIFF
--- a/itou/insertion/management/commands/sync_orientation_statuses.py
+++ b/itou/insertion/management/commands/sync_orientation_statuses.py
@@ -12,8 +12,8 @@ from itou.utils.command import BaseCommand
 
 class DoraStatus(NamedTuple):
     status: str
-    processing_date: datetime.datetime | None  # date à laquelle l'orientation a été traitée côté Dora
-    dora_status_updated_at: datetime.datetime  # date de dernière modification côté DORA, borne de la synchro
+    processing_date: datetime.datetime | None  # the date on which the orientation was processed by DORA
+    dora_status_updated_at: datetime.datetime  # the date of the last modification on DORA side, synchronization point
 
     @classmethod
     def from_api_item(cls, item):
@@ -58,7 +58,7 @@ class Command(BaseCommand):
         self.logger.info("Retrieved count=%d orientation statuses from DORA", len(statuses))
 
         orientations = list(Orientation.objects.filter(id__in=statuses).only("id", *DoraStatus._fields))
-        # Dora only knows the orientations we sent it: an unknown uid means both databases
+        # DORA only knows the orientations we sent it: an unknown uid means both databases
         # diverged, which has to be dealt with before syncing anything.
         if unknown := statuses.keys() - {str(orientation.id) for orientation in orientations}:
             raise RuntimeError(f"Unknown orientations from DORA: {', '.join(sorted(unknown))}")

--- a/itou/insertion/management/commands/sync_orientation_statuses.py
+++ b/itou/insertion/management/commands/sync_orientation_statuses.py
@@ -14,14 +14,17 @@ class DoraStatus(NamedTuple):
     status: str
     processing_date: datetime.datetime | None  # the date on which the orientation was processed by DORA
     dora_status_updated_at: datetime.datetime  # the date of the last modification on DORA side, synchronization point
+    updated_at: datetime.datetime  # the date actually displayed in the interfaces
 
     @classmethod
     def from_api_item(cls, item):
         processing_date = item["processing_date"]
+        dora_status_updated_at = datetime.datetime.fromisoformat(item["updated_at"])
         return cls(
             status=item["status"],
             processing_date=datetime.datetime.fromisoformat(processing_date) if processing_date else None,
-            dora_status_updated_at=datetime.datetime.fromisoformat(item["updated_at"]),
+            dora_status_updated_at=dora_status_updated_at,
+            updated_at=dora_status_updated_at,
         )
 
     @classmethod
@@ -30,6 +33,7 @@ class DoraStatus(NamedTuple):
             status=orientation.status,
             processing_date=orientation.processing_date,
             dora_status_updated_at=orientation.dora_status_updated_at,
+            updated_at=orientation.updated_at,
         )
 
 
@@ -66,11 +70,20 @@ class Command(BaseCommand):
         to_update = []
         for orientation in orientations:
             dora_status = statuses[str(orientation.id)]
-            if dora_status == DoraStatus.from_orientation(orientation):
+            emplois_status = DoraStatus.from_orientation(orientation)
+            if dora_status == emplois_status:
+                continue
+            elif emplois_status.updated_at > dora_status.updated_at:
+                # This situation should not happen, we want to have only one source of truth.
+                # For now it is DORA from which we update the status, processing_date and updated_at.
+                # Later on, the orientations will be managed on Les Emplois and we don’t want to
+                # overwrite the data -- we’ll have to figure out data reconciliation.
+                self.logger.error("Trying to update orientation=%s with older DORA data", orientation.pk)
                 continue
             orientation.status = dora_status.status
             orientation.processing_date = dora_status.processing_date
             orientation.dora_status_updated_at = dora_status.dora_status_updated_at
+            orientation.updated_at = dora_status.updated_at
             to_update.append(orientation)
 
         Orientation.objects.bulk_update(to_update, DoraStatus._fields)

--- a/tests/insertion/test_sync_orientation_statuses.py
+++ b/tests/insertion/test_sync_orientation_statuses.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from django.core.management import call_command
+from freezegun import freeze_time
 
 from itou.insertion.enums import OrientationStatus
 from tests.insertion.factories import OrientationFactory
@@ -30,7 +31,8 @@ def dora_settings_fixture(settings):
 
 
 def test_updates_existing_orientation_status(dora_settings, respx_mock):
-    orientation = OrientationFactory(status=OrientationStatus.PENDING)
+    with freeze_time("2026-07-01"):
+        orientation = OrientationFactory(status=OrientationStatus.PENDING)
     respx_mock.get(DORA_STATUS_URL).respond(
         200,
         json=paginated(
@@ -51,13 +53,15 @@ def test_updates_existing_orientation_status(dora_settings, respx_mock):
     assert orientation.status == OrientationStatus.ACCEPTED
     assert orientation.processing_date == datetime.datetime(2026, 7, 20, 9, 30, tzinfo=datetime.UTC)
     assert orientation.dora_status_updated_at == datetime.datetime(2026, 7, 20, 9, 30, tzinfo=datetime.UTC)
+    assert orientation.updated_at == datetime.datetime(2026, 7, 20, 9, 30, tzinfo=datetime.UTC)
 
 
 def test_null_processing_date_is_synced(dora_settings, respx_mock):
-    orientation = OrientationFactory(
-        status=OrientationStatus.PENDING,
-        processing_date=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
-    )
+    with freeze_time("2026-01-01"):
+        orientation = OrientationFactory(
+            status=OrientationStatus.PENDING,
+            processing_date=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+        )
     respx_mock.get(DORA_STATUS_URL).respond(
         200,
         json=paginated(
@@ -77,6 +81,35 @@ def test_null_processing_date_is_synced(dora_settings, respx_mock):
     orientation.refresh_from_db()
     assert orientation.status == OrientationStatus.EXPIRED
     assert orientation.processing_date is None
+    assert orientation.updated_at == datetime.datetime(2026, 7, 20, 10, 0, tzinfo=datetime.UTC)
+
+
+def test_doesnt_update_more_recent_emplois(dora_settings, respx_mock, caplog):
+    more_recent_datetime = datetime.datetime(2026, 8, 1, tzinfo=datetime.UTC)
+    with freeze_time(more_recent_datetime):
+        orientation = OrientationFactory(status=OrientationStatus.PENDING)
+    respx_mock.get(DORA_STATUS_URL).respond(
+        200,
+        json=paginated(
+            [
+                status_item(
+                    orientation.id,
+                    OrientationStatus.ACCEPTED,
+                    processing_date="2026-07-20T09:30:00+00:00",
+                    updated_at="2026-07-20T09:30:00+00:00",
+                )
+            ]
+        ),
+    )
+
+    call_command("sync_orientation_statuses", wet_run=True)
+
+    orientation.refresh_from_db()
+    # Nothing changed
+    assert orientation.status == OrientationStatus.PENDING
+    assert orientation.dora_status_updated_at is None
+    assert orientation.updated_at == more_recent_datetime
+    assert f"Trying to update orientation={orientation.pk} with older DORA data" in caplog.messages
 
 
 def test_first_run_has_no_updated_after(dora_settings, respx_mock):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans #8496, on doit afficher et trier les orientations par date de dernière mise à jour.

Pour le moment, les orientations ne peuvent être mises à jour qu'à l'aide de la commande `sync_orientation_statuses`, c'est-à-dire depuis DORA.
On pourrait alors utiliser `orientation.dora_status_updated_at or orientation.created_at` par exemple, mais il est prévu de gérer les orientations du côté Emplois également.
Autant avoir et utiliser proprement un champ `updated_at` dès maintenant.
