### PR TITLE
Contrôle a posteriori : certification des critères de niveau 2

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -194,7 +194,7 @@ class EvaluationCampaignAdmin(ItouModelAdmin):
                 "siae__convention",
             )
             .prefetch_related(
-                "evaluated_job_applications__evaluated_administrative_criteria",
+                "evaluated_job_applications__evaluated_administrative_criteria__administrative_criteria",
                 "siae__memberships__user",
             )
             .order_by("evaluation_campaign_id", "id")

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -98,8 +98,8 @@ class EvaluatedJobApplicationsInline(ItouTabularInline):
 
 class EvaluatedAdministrativeCriteriaInline(ItouTabularInline):
     model = models.EvaluatedAdministrativeCriteria
-    fields = ("id_link", "uploaded_at", "submitted_at", "review_state")
-    readonly_fields = ("id_link", "uploaded_at", "submitted_at", "review_state")
+    fields = ("id_link", "criteria_certified", "uploaded_at", "submitted_at", "review_state")
+    readonly_fields = ("id_link", "criteria_certified", "uploaded_at", "submitted_at", "review_state")
     extra = 0
 
     @admin.display(description="lien vers les critères administratifs évalués")
@@ -366,11 +366,18 @@ class EvaluatedJobApplicationAdmin(DeleteOnlyMixin, ItouModelAdmin):
 
 @admin.register(models.EvaluatedAdministrativeCriteria)
 class EvaluatedAdministrativeCriteriaAdmin(DeleteOnlyMixin, ItouModelAdmin):
-    list_display = ("evaluated_job_application", "administrative_criteria", "submitted_at", "review_state")
+    list_display = (
+        "evaluated_job_application",
+        "administrative_criteria",
+        "criteria_certified",
+        "submitted_at",
+        "review_state",
+    )
     list_display_links = ("administrative_criteria",)
     fields = (
         "evaluated_job_application",
         "administrative_criteria",
+        "criteria_certified",
         "uploaded_at",
         "proof_link",
         "submitted_at",

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -193,10 +193,8 @@ class EvaluationCampaignAdmin(ItouModelAdmin):
                 "evaluation_campaign",
                 "siae__convention",
             )
-            .prefetch_related(
-                "evaluated_job_applications__evaluated_administrative_criteria",
-                "siae__memberships__user",
-            )
+            .prefetch_administrative_criteria()
+            .prefetch_related("siae__memberships__user")
             .order_by("evaluation_campaign_id", "id")
         )
         headers = [

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -315,7 +315,7 @@ class EvaluationCampaign(models.Model):
                     EvaluatedAdministrativeCriteria.objects.bulk_create(criteria)
 
             evaluated_siaes = EvaluatedSiae.objects.filter(pk__in=evaluated_siaes_pks).prefetch_related(
-                "evaluated_job_applications__evaluated_administrative_criteria"
+                "evaluated_job_applications__evaluated_administrative_criteria__administrative_criteria"
             )
             emails = []
             for evaluated_siae in evaluated_siaes:
@@ -349,7 +349,7 @@ class EvaluationCampaign(models.Model):
         auto_validation = []
         for evaluated_siae in self.evaluated_siaes.select_related(
             "evaluation_campaign__institution", "siae"
-        ).prefetch_related("evaluated_job_applications__evaluated_administrative_criteria"):
+        ).prefetch_related("evaluated_job_applications__evaluated_administrative_criteria__administrative_criteria"):
             state = evaluated_siae.state
             email_factory = SIAEEmailFactory(evaluated_siae)
             if evaluated_siae.reviewed_at is not None:
@@ -417,7 +417,9 @@ class EvaluationCampaign(models.Model):
             evaluated_siaes = (
                 EvaluatedSiae.objects.filter(evaluation_campaign=self)
                 .filter(notified_at=None)
-                .prefetch_related("evaluated_job_applications__evaluated_administrative_criteria")
+                .prefetch_related(
+                    "evaluated_job_applications__evaluated_administrative_criteria__administrative_criteria"
+                )
             )
             has_siae_to_notify = False
             siae_without_proofs = []
@@ -470,7 +472,7 @@ class EvaluationCampaign(models.Model):
             # add final_state to notified ones
             notified_evaluated_siaes = list(
                 EvaluatedSiae.objects.filter(evaluation_campaign=self, notified_at__isnull=False).prefetch_related(
-                    "evaluated_job_applications__evaluated_administrative_criteria"
+                    "evaluated_job_applications__evaluated_administrative_criteria__administrative_criteria"
                 )
             )
             for notified_evaluated_siae in notified_evaluated_siaes:

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -9,7 +9,7 @@ from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q
 from django.utils import timezone
 from django.utils.functional import cached_property
 
-from itou.eligibility.enums import AdministrativeCriteriaLevel
+from itou.eligibility.enums import ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND
 from itou.eligibility.models import AdministrativeCriteria, SelectedAdministrativeCriteria
 from itou.eligibility.utils import iae_has_required_criteria
 from itou.institutions.enums import InstitutionKind
@@ -298,20 +298,6 @@ class EvaluationCampaign(models.Model):
                                     criteria_certified=True,
                                 )
                             )
-                        # TODO: For the 2026 campaign on auto-prescriptions
-                        # hires in 2025, this should be updated to handle
-                        # LEVEL_2.
-                        # Generating an accepted administrative criteria with
-                        # level 2 will significantly break all views in this
-                        # module. Many parts of it rely on the criteria state
-                        # to decide what actions to offer, and the state of the
-                        # evaluated job application.
-                        assert (
-                            selected_criterion.administrative_criteria.level == AdministrativeCriteriaLevel.LEVEL_1
-                        ), (
-                            f"AdministrativeCriteria pk={selected_criterion.pk} has level "
-                            f"{selected_criterion.administrative_criteria.level}."
-                        )
                     EvaluatedAdministrativeCriteria.objects.bulk_create(criteria)
 
             evaluated_siaes = EvaluatedSiae.objects.filter(pk__in=evaluated_siaes_pks).prefetch_related(
@@ -740,7 +726,7 @@ class EvaluatedJobApplication(models.Model):
         evaluation_enums.EvaluatedJobApplicationsState.UPLOADED,
         evaluation_enums.EvaluatedJobApplicationsState.PROCESSING,
         evaluation_enums.EvaluatedJobApplicationsState.PENDING,
-        # High priority: if at least one criteria has this state, the evaluated job application will also
+        # High priority: if at least one criterion has this state, the evaluated job application will also have it
     ]
 
     job_application = models.ForeignKey(
@@ -781,11 +767,33 @@ class EvaluatedJobApplication(models.Model):
                 evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2: evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2,  # noqa: E501
             }[criteria.review_state]
 
-        return max(
-            (state_from(criteria) for criteria in self.evaluated_administrative_criteria.all()),
+        evaluated_criteria = self.evaluated_administrative_criteria.all()
+        state = max(
+            (state_from(evaluated_criterion) for evaluated_criterion in evaluated_criteria),
             key=self.STATES_PRIORITY.index,
             default=evaluation_enums.EvaluatedJobApplicationsState.PENDING,
         )
+
+        # A job application (i.e. auto-prescription) only reaches the ACCEPTED state when each criterion is accepted
+        # (remember that ACCEPTED has the lowest priority in STATES_PRIORITY). Still being accepted is not enough:
+        # the set of accepted criteria must also satisfy the IAE eligibility rule, i.e. it must contain at least one
+        # level 1 criterion or N level 2 criteria, where N (between 2 and 3) depends on the SIAE kind.
+        # We make sure a set of accepted-but-insufficient criteria (e.g. a single certified level 2 criterion
+        # pre-created at campaign start) do not lock the evaluation: we keep it PENDING so the SIAE can add/prove any
+        # missing criteria.
+        # Note that the IAE eligibility rule only applies to IAE kinds; for other kinds the original logic applies
+        # (i.e. each criterion must be accepted for the job evaluation to be accepted).
+        if (
+            state == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+            and self.evaluated_siae.siae.kind in ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND
+            and not iae_has_required_criteria(
+                [evaluated_criterion.administrative_criteria for evaluated_criterion in evaluated_criteria],
+                self.evaluated_siae.siae.kind,
+            )
+        ):
+            return evaluation_enums.EvaluatedJobApplicationsState.PENDING
+
+        return state
 
     def hide_state_from_siae(self):
         """Hide in-progress evaluation from SIAE, until results are official."""

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 from itou.companies.models import Company
-from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, SelectedAdministrativeCriteria
 from itou.eligibility.utils import iae_has_required_criteria
 from itou.institutions.enums import InstitutionKind
@@ -302,25 +301,11 @@ class EvaluationCampaign(models.Model):
                                     criteria_certified=True,
                                 )
                             )
-                        # TODO: For the 2026 campaign on auto-prescriptions
-                        # hires in 2025, this should be updated to handle
-                        # LEVEL_2.
-                        # Generating an accepted administrative criteria with
-                        # level 2 will significantly break all views in this
-                        # module. Many parts of it rely on the criteria state
-                        # to decide what actions to offer, and the state of the
-                        # evaluated job application.
-                        assert (
-                            selected_criterion.administrative_criteria.level == AdministrativeCriteriaLevel.LEVEL_1
-                        ), (
-                            f"AdministrativeCriteria pk={selected_criterion.pk} has level "
-                            f"{selected_criterion.administrative_criteria.level}."
-                        )
                     EvaluatedAdministrativeCriteria.objects.bulk_create(criteria)
 
-            evaluated_siaes = EvaluatedSiae.objects.filter(pk__in=evaluated_siaes_pks).prefetch_related(
-                "evaluated_job_applications__evaluated_administrative_criteria"
-            )
+            evaluated_siaes = EvaluatedSiae.objects.filter(
+                pk__in=evaluated_siaes_pks
+            ).prefetch_administrative_criteria()
             emails = []
             for evaluated_siae in evaluated_siaes:
                 if evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED:
@@ -353,7 +338,7 @@ class EvaluationCampaign(models.Model):
         auto_validation = []
         for evaluated_siae in self.evaluated_siaes.select_related(
             "evaluation_campaign__institution", "siae"
-        ).prefetch_related("evaluated_job_applications__evaluated_administrative_criteria"):
+        ).prefetch_administrative_criteria():
             state = evaluated_siae.state
             email_factory = SIAEEmailFactory(evaluated_siae)
             if evaluated_siae.reviewed_at is not None:
@@ -421,7 +406,7 @@ class EvaluationCampaign(models.Model):
             evaluated_siaes = (
                 EvaluatedSiae.objects.filter(evaluation_campaign=self)
                 .filter(notified_at=None)
-                .prefetch_related("evaluated_job_applications__evaluated_administrative_criteria")
+                .prefetch_administrative_criteria()
             )
             has_siae_to_notify = False
             siae_without_proofs = []
@@ -473,9 +458,9 @@ class EvaluationCampaign(models.Model):
             # previous loop iterates over not notified evaluated_siaes.
             # add final_state to notified ones
             notified_evaluated_siaes = list(
-                EvaluatedSiae.objects.filter(evaluation_campaign=self, notified_at__isnull=False).prefetch_related(
-                    "evaluated_job_applications__evaluated_administrative_criteria"
-                )
+                EvaluatedSiae.objects.filter(
+                    evaluation_campaign=self, notified_at__isnull=False
+                ).prefetch_administrative_criteria()
             )
             for notified_evaluated_siae in notified_evaluated_siaes:
                 notified_evaluated_siae.final_state = notified_evaluated_siae.state
@@ -485,6 +470,15 @@ class EvaluationCampaign(models.Model):
 class EvaluatedSiaeQuerySet(models.QuerySet):
     def for_company(self, siae):
         return self.filter(siae=siae)
+
+    def prefetch_administrative_criteria(self):
+        # The level of the administrative criteria is used to compute the state of the job application.
+        return self.prefetch_related(
+            Prefetch(
+                "evaluated_job_applications__evaluated_administrative_criteria",
+                queryset=EvaluatedAdministrativeCriteria.objects.select_related("administrative_criteria"),
+            )
+        )
 
     def in_progress(self):
         return self.exclude(evaluation_campaign__evaluations_asked_at=None).filter(
@@ -783,11 +777,28 @@ class EvaluatedJobApplication(models.Model):
                 evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2: evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2,  # noqa: E501
             }[criteria.review_state]
 
-        return max(
-            (state_from(criteria) for criteria in self.evaluated_administrative_criteria.all()),
+        evaluated_criteria = self.evaluated_administrative_criteria.all()
+        state = max(
+            (state_from(evaluated_criterion) for evaluated_criterion in evaluated_criteria),
             key=self.STATES_PRIORITY.index,
             default=evaluation_enums.EvaluatedJobApplicationsState.PENDING,
         )
+
+        # For a job application (i.e. auto-prescription) to reach the ACCEPTED state, each criterion must be accepted
+        # (remember that ACCEPTED has the lowest priority in STATES_PRIORITY). Still being accepted is not enough:
+        # the set of accepted criteria must also satisfy the IAE eligibility rule, i.e. it must contain at least one
+        # level 1 criterion or N level 2 criteria, where N depends on the SIAE kind (between 2 and 3 at the time of
+        # writing, but refer to ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND).
+        # We make sure a set of accepted-but-insufficient criteria (e.g. a single certified level 2 criterion
+        # pre-created at campaign start) do not lock the evaluation: we keep it PENDING so the SIAE can add/prove any
+        # missing criteria.
+        if state == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED and not iae_has_required_criteria(
+            [evaluated_criterion.administrative_criteria for evaluated_criterion in evaluated_criteria],
+            self.evaluated_siae.siae.kind,
+        ):
+            return evaluation_enums.EvaluatedJobApplicationsState.PENDING
+
+        return state
 
     def hide_state_from_siae(self):
         """Hide in-progress evaluation from SIAE, until results are official."""
@@ -912,6 +923,8 @@ class EvaluatedAdministrativeCriteria(models.Model):
     def can_upload(self):
         if self.evaluated_job_application.evaluated_siae.submission_freezed_at:
             return False
+        if self.criteria_certified:
+            return False  # Certified criteria do not require a proof.
         if self.submitted_at is None:
             return True
 

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -918,6 +918,8 @@ class EvaluatedAdministrativeCriteria(models.Model):
     def can_upload(self):
         if self.evaluated_job_application.evaluated_siae.submission_freezed_at:
             return False
+        if self.criteria_certified:
+            return False  # Certified criteria do not require a proof.
         if self.submitted_at is None:
             return True
 

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -736,7 +736,7 @@ class EvaluatedJobApplication(models.Model):
         evaluation_enums.EvaluatedJobApplicationsState.UPLOADED,
         evaluation_enums.EvaluatedJobApplicationsState.PROCESSING,
         evaluation_enums.EvaluatedJobApplicationsState.PENDING,
-        # High priority: if at least one criteria has this state, the evaluated job application will also
+        # High priority: if at least one criterion has this state, the evaluated job application will also have it
     ]
 
     job_application = models.ForeignKey(

--- a/itou/templates/eligibility/includes/iae/criteria_input.html
+++ b/itou/templates/eligibility/includes/iae/criteria_input.html
@@ -7,7 +7,12 @@
 
         <label for="{{ field.id_for_label }}" class="form-check-label">
 
-            {{ field.label }}
+            <span class="d-flex gap-1">
+                {{ field.label }}
+                {% if field.name in certified_criteria_keys %}
+                    {% include "eligibility/includes/badge_certified.html" only %}
+                {% endif %}
+            </span>
 
             {% if field.help_text %}<p class="small mb-0 form-text text-muted">{{ field.help_text }}</p>{% endif %}
 
@@ -17,24 +22,30 @@
 
                 {# Weird point. Should be cleanup someday. This form uses objects_dict, despite single field is already sent #}
                 {% with objects_dict|get_dict_item:field.name as criteria %}
-                    {% if criteria.written_proof %}
+                    {% if certified_criteria_keys and field.name in certified_criteria_keys %}
                         <p class="small mb-0 form-text text-muted">
-                            <strong>Pièce justificative :</strong>
-                            <i>{{ criteria.written_proof }}</i>
+                            Ce critère étant certifié, aucun justificatif n’est demandé pour le moment.
                         </p>
-                    {% endif %}
-                    {% if criteria.written_proof_validity %}
-                        <p class="small mb-0 form-text text-muted">
-                            <strong>Durée de validité du justificatif :</strong>
-                            <i>{{ criteria.written_proof_validity }}</i>
-                        </p>
-                    {% endif %}
-                    {% if criteria.written_proof_url %}
-                        <p class="small mb-0 form-text text-muted">
-                            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
-                                {{ criteria.written_proof_url }}
-                            </a>
-                        </p>
+                    {% else %}
+                        {% if criteria.written_proof %}
+                            <p class="small mb-0 form-text text-muted">
+                                <strong>Pièce justificative :</strong>
+                                <i>{{ criteria.written_proof }}</i>
+                            </p>
+                        {% endif %}
+                        {% if criteria.written_proof_validity %}
+                            <p class="small mb-0 form-text text-muted">
+                                <strong>Durée de validité du justificatif :</strong>
+                                <i>{{ criteria.written_proof_validity }}</i>
+                            </p>
+                        {% endif %}
+                        {% if criteria.written_proof_url %}
+                            <p class="small mb-0 form-text text-muted">
+                                <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                                    {{ criteria.written_proof_url }}
+                                </a>
+                            </p>
+                        {% endif %}
                     {% endif %}
                 {% endwith %}
             {% endif %}

--- a/itou/templates/eligibility/includes/iae/criteria_input.html
+++ b/itou/templates/eligibility/includes/iae/criteria_input.html
@@ -7,7 +7,12 @@
 
         <label for="{{ field.id_for_label }}" class="form-check-label">
 
-            {{ field.label }}
+            <span class="d-flex gap-1">
+                {{ field.label }}
+                {% if certified_criteria_keys and field.name in certified_criteria_keys %}
+                    {% include "eligibility/includes/badge_certified.html" only %}
+                {% endif %}
+            </span>
 
             {% if field.help_text %}<p class="small mb-0 form-text text-muted">{{ field.help_text }}</p>{% endif %}
 
@@ -17,24 +22,30 @@
 
                 {# Weird point. Should be cleanup someday. This form uses objects_dict, despite single field is already sent #}
                 {% with objects_dict|get_dict_item:field.name as criteria %}
-                    {% if criteria.written_proof %}
+                    {% if certified_criteria_keys and field.name in certified_criteria_keys %}
                         <p class="small mb-0 form-text text-muted">
-                            <strong>Pièce justificative :</strong>
-                            <i>{{ criteria.written_proof }}</i>
+                            Ce critère étant certifié, aucun justificatif n’est demandé pour le moment.
                         </p>
-                    {% endif %}
-                    {% if criteria.written_proof_validity %}
-                        <p class="small mb-0 form-text text-muted">
-                            <strong>Durée de validité du justificatif :</strong>
-                            <i>{{ criteria.written_proof_validity }}</i>
-                        </p>
-                    {% endif %}
-                    {% if criteria.written_proof_url %}
-                        <p class="small mb-0 form-text text-muted">
-                            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
-                                {{ criteria.written_proof_url }}
-                            </a>
-                        </p>
+                    {% else %}
+                        {% if criteria.written_proof %}
+                            <p class="small mb-0 form-text text-muted">
+                                <strong>Pièce justificative :</strong>
+                                <i>{{ criteria.written_proof }}</i>
+                            </p>
+                        {% endif %}
+                        {% if criteria.written_proof_validity %}
+                            <p class="small mb-0 form-text text-muted">
+                                <strong>Durée de validité du justificatif :</strong>
+                                <i>{{ criteria.written_proof_validity }}</i>
+                            </p>
+                        {% endif %}
+                        {% if criteria.written_proof_url %}
+                            <p class="small mb-0 form-text text-muted">
+                                <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                                    {{ criteria.written_proof_url }}
+                                </a>
+                            </p>
+                        {% endif %}
                     {% endif %}
                 {% endwith %}
             {% endif %}

--- a/itou/templates/eligibility/includes/iae/form.html
+++ b/itou/templates/eligibility/includes/iae/form.html
@@ -22,7 +22,7 @@
 
     {% for field in form %}
         {% if form.LEVEL_1_PREFIX in field.name %}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form.OBJECTS certified_criteria_keys=None %}
         {% endif %}
     {% endfor %}
 
@@ -30,7 +30,7 @@
 
     {% for field in form %}
         {% if form.LEVEL_2_PREFIX in field.name %}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form.OBJECTS certified_criteria_keys=None %}
         {% endif %}
     {% endfor %}
 

--- a/itou/templates/siae_evaluations/evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_detail.html
@@ -105,7 +105,7 @@
                                                 {% with collapse_id="collapseCertifiedApplication-"|add:collapse_id_suffix %}
                                                     {% component_info borderless=True c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id=collapse_id %}
                                                         {% fragment as c_info__summary %}
-                                                            Cette auto-prescription répond à un critère de niveau 1 certifié. Aucun justificatif n’est demandé pour le moment.
+                                                            Les critères certifiés pour cette auto-prescription suffisent à justifier l’éligibilité du salarié. Aucun justificatif complémentaire n’est demandé pour le moment.
                                                         {% endfragment %}
                                                         {% fragment as c_info__detail %}
                                                             <p>

--- a/itou/templates/siae_evaluations/evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_detail.html
@@ -105,7 +105,7 @@
                                                 {% with collapse_id="collapseCertifiedApplication-"|add:collapse_id_suffix %}
                                                     {% component_info borderless=True c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id=collapse_id %}
                                                         {% fragment as c_info__summary %}
-                                                            Cette auto-prescription répond à un critère de niveau 1 certifié. Aucun justificatif n’est demandé pour le moment.
+                                                            Cette auto-prescription répond à un ou plusieurs critères certifiés, qui suffisent à justifier l’éligibilité du salarié. Aucun justificatif complémentaire n’est demandé pour le moment.
                                                         {% endfragment %}
                                                         {% fragment as c_info__detail %}
                                                             <p>

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -15,7 +15,7 @@
         <h3 class="h4">Niveau 1</h3>
 
         {% for field in level_1_fields %}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS certified_criteria_keys=form_administrative_criteria.certified_criteria_keys %}
         {% endfor %}
     {% endif %}
 
@@ -25,7 +25,7 @@
         {% for field in level_2_fields %}
             {# notice that eligibility/includes/iae/criteria_input.html requires form_administrative_criteria.OBJECTS #}
             {# altough field is already sent ~ vincentporte's note - april 2022#}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS certified_criteria_keys=form_administrative_criteria.certified_criteria_keys %}
         {% endfor %}
     {% endif %}
 

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -15,7 +15,7 @@
         <h3 class="h4">Niveau 1</h3>
 
         {% for field in level_1_fields %}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS certified_criteria_keys=certified_criteria_keys %}
         {% endfor %}
     {% endif %}
 
@@ -25,7 +25,7 @@
         {% for field in level_2_fields %}
             {# notice that eligibility/includes/iae/criteria_input.html requires form_administrative_criteria.OBJECTS #}
             {# altough field is already sent ~ vincentporte's note - april 2022#}
-            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS %}
+            {% include "eligibility/includes/iae/criteria_input.html" with field=field objects_dict=form_administrative_criteria.OBJECTS certified_criteria_keys=certified_criteria_keys %}
         {% endfor %}
     {% endif %}
 

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -21,7 +21,7 @@
                     {% endif %}
                 {% endif %}
             </div>
-            {% if item.evaluated_administrative_criteria.all %}
+            {% if item.evaluated_administrative_criteria.all and evaluated_job_application_state != 'PENDING' %}
                 {% with collapse_id_suffix=item.pk|stringformat:"s" %}
                     {% with collapse_id="collapseItemsEvaluated"|add:collapse_id_suffix %}
                         {% component_info borderless=True c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id=collapse_id opened=True extra_classes="mt-3" %}

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -75,13 +75,13 @@
             {% endif %}
         </div>
     {% endif %}
-    {% if item.should_select_criteria == "PENDING" %}
+    {% if should_select_criteria == "PENDING" %}
         <div class="c-box--results__footer">
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
                 <a href="{% url 'siae_evaluations_views:siae_select_criteria' item.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">Sélectionner les critères</a>
             </div>
         </div>
-    {% elif item.should_select_criteria == "EDITABLE" %}
+    {% elif should_select_criteria == "EDITABLE" %}
         <div class="c-box--results__footer">
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
                 <a href="{% url 'siae_evaluations_views:siae_select_criteria' item.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">Modifier les critères</a>

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -21,7 +21,8 @@
                     {% endif %}
                 {% endif %}
             </div>
-            {% if item.evaluated_administrative_criteria.all %}
+            {# Note that a state different from `PENDING` implies there is at least one evaluated criterion associated with the job application. #}
+            {% if evaluated_job_application_state != 'PENDING' %}
                 {% with collapse_id_suffix=item.pk|stringformat:"s" %}
                     {% with collapse_id="collapseItemsEvaluated"|add:collapse_id_suffix %}
                         {% component_info borderless=True c_info__summary=c_info__summary c_info__detail=c_info__detail collapse_id=collapse_id opened=True extra_classes="mt-3" %}

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -48,7 +48,9 @@
                     </div>
 
                     {% for evaluated_job_application in evaluated_job_applications %}
-                        {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application %}
+                        {% with should_select_criteria=evaluated_job_application.should_select_criteria %}
+                            {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application should_select_criteria=should_select_criteria %}
+                        {% endwith %}
                     {% endfor %}
 
                     {% if is_submittable %}

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -49,7 +49,7 @@
 
                     {% for evaluated_job_application in evaluated_job_applications %}
                         {% with should_select_criteria=evaluated_job_application.should_select_criteria %}
-                            {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application should_select_criteria=should_select_criteria %}
+                            {% include "siae_evaluations/includes/list_item.html" with item=evaluated_job_application evaluated_job_application_state=evaluated_job_application.compute_state should_select_criteria=should_select_criteria %}
                         {% endwith %}
                     {% endfor %}
 

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -38,7 +38,7 @@ class SetChosenPercentForm(forms.ModelForm):
 
 
 class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
-    def __init__(self, siae, job_app_selected_administrative_criteria, **kwargs):
+    def __init__(self, siae, job_app_selected_administrative_criteria, certified_criteria_keys=None, **kwargs):
         administrative_criteria = [e.administrative_criteria for e in job_app_selected_administrative_criteria]
         super().__init__(
             is_authorized_prescriber=False,
@@ -46,6 +46,13 @@ class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
             administrative_criteria=administrative_criteria,
             **kwargs,
         )
+        # Checkboxes corresponding to certified criteria are disabled: user/SIAE can neither uncheck nor remove them.
+        # A disabled field keeps its initial value and is excluded from `changed_data`, so
+        # `EvaluatedJobApplication.save_selected_criteria` will not delete a certified criterion.
+        self.certified_criteria_keys = set(certified_criteria_keys or ())
+        for key in self.certified_criteria_keys:
+            self.fields[key].disabled = True
+            self.fields[key].initial = True
         self.num_level2_admin_criteria = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[siae.kind]
 
 

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -38,7 +38,7 @@ class SetChosenPercentForm(forms.ModelForm):
 
 
 class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
-    def __init__(self, siae, job_app_selected_administrative_criteria, **kwargs):
+    def __init__(self, siae, job_app_selected_administrative_criteria, certified_criteria_keys=None, **kwargs):
         administrative_criteria = [e.administrative_criteria for e in job_app_selected_administrative_criteria]
         super().__init__(
             is_authorized_prescriber=False,
@@ -46,6 +46,14 @@ class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
             administrative_criteria=administrative_criteria,
             **kwargs,
         )
+        # Checkboxes corresponding to certified criteria are disabled: user/SIAE can neither uncheck nor remove them.
+        # A disabled field keeps its initial value and is excluded from `changed_data`, so
+        # `EvaluatedJobApplication.save_selected_criteria` will not delete a certified criterion.
+        self.certified_criteria_keys = set(certified_criteria_keys or ())
+        for key in self.certified_criteria_keys:
+            if key in self.fields:
+                self.fields[key].disabled = True
+                self.fields[key].initial = True
         self.num_level2_admin_criteria = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[siae.kind]
 
 

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -676,15 +676,23 @@ def siae_select_criteria(
     ):
         return HttpResponseForbidden()
     eligibility_diagnosis = evaluated_job_application.job_application.eligibility_diagnosis
+    # As a reminder, form checkboxes map to the set of administrative criteria declared at hiring, i.e. the only ones
+    # that can be justified. Evaluated criteria objects only carry the control state and the `criteria_certified` flag
+    # used to pre-check and lock the certified criteria.
     job_application_administrative_criteria = eligibility_diagnosis.selected_administrative_criteria.all()
+    certified_criteria_keys = {
+        eval_criterion.administrative_criteria.key
+        for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
+        if eval_criterion.criteria_certified
+    }
     initial_data = {
         eval_criterion.administrative_criteria.key: True
         for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
     }
-
     form_administrative_criteria = AdministrativeCriteriaEvaluationForm(
         siae=siae,
         job_app_selected_administrative_criteria=job_application_administrative_criteria,
+        certified_criteria_keys=certified_criteria_keys,
         data=request.POST or None,
         initial=initial_data,
     )
@@ -726,6 +734,7 @@ def siae_select_criteria(
         "form_administrative_criteria": form_administrative_criteria,
         "level_1_fields": level_1_fields,
         "level_2_fields": level_2_fields,
+        "certified_criteria_keys": certified_criteria_keys,
         "kind": siae.kind,
         "back_url": back_url,
         "matomo_custom_title": "Contrôle a posteriori : sélection des critères",

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -676,15 +676,23 @@ def siae_select_criteria(
     ):
         return HttpResponseForbidden()
     eligibility_diagnosis = evaluated_job_application.job_application.eligibility_diagnosis
+    # As a reminder, form checkboxes map to the set of administrative criteria declared at hiring, i.e. the only ones
+    # that can be justified. Evaluated criteria objects only carry the control state and the `criteria_certified` flag
+    # used to pre-check and lock the certified criteria.
     job_application_administrative_criteria = eligibility_diagnosis.selected_administrative_criteria.all()
+    certified_criteria_keys = {
+        eval_criterion.administrative_criteria.key
+        for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
+        if eval_criterion.criteria_certified
+    }
     initial_data = {
         eval_criterion.administrative_criteria.key: True
         for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
     }
-
     form_administrative_criteria = AdministrativeCriteriaEvaluationForm(
         siae=siae,
         job_app_selected_administrative_criteria=job_application_administrative_criteria,
+        certified_criteria_keys=certified_criteria_keys,
         data=request.POST or None,
         initial=initial_data,
     )

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEvaluatedSiaeModel.test_state_on_closed_campaign_criteria_accepted
   dict({
-    'num_queries': 2,
+    'num_queries': 3,
     'queries': list([
       dict({
         'origin': list([
@@ -41,6 +41,30 @@
           ORDER BY "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" ASC,
                    "eligibility_administrativecriteria"."level" ASC,
                    "eligibility_administrativecriteria"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EvaluatedJobApplication.compute_state[siae_evaluations/models.py]',
+          'state_from[siae_evaluations/models.py]',
+          '<genexpr>[siae_evaluations/models.py]',
+          'EvaluatedSiae.state_from_applications[siae_evaluations/models.py]',
+          'EvaluatedSiae.state[siae_evaluations/models.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
+          FROM "eligibility_administrativecriteria"
+          WHERE "eligibility_administrativecriteria"."id" = %s
+          LIMIT 21
         ''',
       }),
     ]),

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEvaluatedSiaeModel.test_state_on_closed_campaign_criteria_accepted
   dict({
-    'num_queries': 2,
+    'num_queries': 3,
     'queries': list([
       dict({
         'origin': list([
@@ -41,6 +41,30 @@
           ORDER BY "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" ASC,
                    "eligibility_administrativecriteria"."level" ASC,
                    "eligibility_administrativecriteria"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EvaluatedJobApplication.compute_state[siae_evaluations/models.py]',
+          'state_from[siae_evaluations/models.py]',
+          '<genexpr>[siae_evaluations/models.py]',
+          'EvaluatedSiae.state_from_applications[siae_evaluations/models.py]',
+          'EvaluatedSiae.state[siae_evaluations/models.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
+          FROM "eligibility_administrativecriteria"
+          WHERE "eligibility_administrativecriteria"."id" = %s
+          LIMIT 21
         ''',
       }),
     ]),
@@ -672,7 +696,17 @@
                  "siae_evaluations_evaluatedadministrativecriteria"."uploaded_at",
                  "siae_evaluations_evaluatedadministrativecriteria"."submitted_at",
                  "siae_evaluations_evaluatedadministrativecriteria"."review_state",
-                 "siae_evaluations_evaluatedadministrativecriteria"."criteria_certified"
+                 "siae_evaluations_evaluatedadministrativecriteria"."criteria_certified",
+                 "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
           FROM "siae_evaluations_evaluatedadministrativecriteria"
           INNER JOIN "eligibility_administrativecriteria" ON ("siae_evaluations_evaluatedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" IN (%s,

--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -90,6 +90,9 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
             criteria=factory.RelatedFactory(
                 "tests.siae_evaluations.factories.EvaluatedAdministrativeCriteriaFactory",
                 factory_related_name="evaluated_job_application",
+                # A single level 1 criterion is enough to satisfy the IAE eligibility rule, so the complete job
+                # application (i.e. auto-prescription) is accepted once its criterion is accepted.
+                administrative_criteria=factory.LazyFunction(lambda: AdministrativeCriteria.objects.level1().first()),
                 uploaded_at=factory.LazyAttribute(
                     lambda siae: (
                         siae.factory_parent.evaluated_siae.evaluation_campaign.evaluations_asked_at

--- a/tests/siae_evaluations/factories.py
+++ b/tests/siae_evaluations/factories.py
@@ -90,6 +90,9 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
             criteria=factory.RelatedFactory(
                 "tests.siae_evaluations.factories.EvaluatedAdministrativeCriteriaFactory",
                 factory_related_name="evaluated_job_application",
+                # A single level 1 criterion is enough to satisfy the IAE eligibility rule, so the complete job
+                # application (i.e. auto-prescription) is accepted once its criterion is accepted.
+                level1=True,
                 uploaded_at=factory.LazyAttribute(
                     lambda siae: (
                         siae.factory_parent.evaluated_siae.evaluation_campaign.evaluations_asked_at
@@ -117,6 +120,13 @@ class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
 class EvaluatedAdministrativeCriteriaFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EvaluatedAdministrativeCriteria
+
+    class Params:
+        level1 = factory.Trait(
+            administrative_criteria=factory.LazyFunction(
+                lambda: AdministrativeCriteria.objects.level1().order_by("?").first()
+            )
+        )
 
     evaluated_job_application = factory.SubFactory(EvaluatedJobApplicationFactory)
     administrative_criteria = factory.Iterator(AdministrativeCriteria.objects.all())

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -110,7 +110,8 @@ class TestEvaluationCampaignAdmin:
             + 1  # Count the full results
             + 1  # Fetch evaluated siae and related evaludation_campaign, siae, convention
             + 1  # Prefetch evaludated job applications
-            + 1  # Prefetch corresponding administrative criteria
+            + 1  # Prefetch corresponding evaluated administrative criteria
+            + 1  # Prefetch administrative criteria (level is used to compute the job application state)
             + 1  # Prefetch siae memberships
             + 1  # Prefetch users of siae memberships
         ):

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -89,6 +89,7 @@ class TestEvaluationCampaignAdmin:
         )
         campaign4_jobapp = EvaluatedJobApplicationFactory(evaluated_siae=campaign4_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=campaign4_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=1),
             submitted_at=timezone.now() - relativedelta(days=1),

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertNumQueries
 
 from itou.companies.enums import CompanyKind
+from itou.eligibility.models import AdministrativeCriteria
 from itou.siae_evaluations import enums as evaluation_enums
 from tests.companies.factories import CompanyMembershipFactory
 from tests.institutions.factories import InstitutionFactory
@@ -92,6 +93,7 @@ class TestEvaluationCampaignAdmin:
             evaluated_job_application=campaign4_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=1),
             submitted_at=timezone.now() - relativedelta(days=1),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         # Not selected.

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -111,7 +111,7 @@ class TestEvaluationCampaignAdmin:
             + 1  # Count the full results
             + 1  # Fetch evaluated siae and related evaludation_campaign, siae, convention
             + 1  # Prefetch evaludated job applications
-            + 1  # Prefetch corresponding administrative criteria
+            + 1  # Prefetch corresponding evaluated administrative criteria and their administrative criteria
             + 1  # Prefetch siae memberships
             + 1  # Prefetch users of siae memberships
         ):

--- a/tests/siae_evaluations/test_emails.py
+++ b/tests/siae_evaluations/test_emails.py
@@ -131,6 +131,7 @@ class TestInstitutionEmailFactory:
         )
         evaluated_jobapp = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=evaluated_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=51, minutes=1),
             submitted_at=timezone.now() - relativedelta(days=51),
@@ -159,6 +160,7 @@ class TestInstitutionEmailFactory:
         )
         evaluated_jobapp = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=evaluated_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=51, minutes=1),
             submitted_at=timezone.now() - relativedelta(days=51),

--- a/tests/siae_evaluations/test_emails.py
+++ b/tests/siae_evaluations/test_emails.py
@@ -7,6 +7,7 @@ from django.utils import dateformat, timezone
 from freezegun import freeze_time
 
 from itou.companies.enums import CompanyKind
+from itou.eligibility.models import AdministrativeCriteria
 from itou.siae_evaluations.emails import CampaignEmailFactory, InstitutionEmailFactory, SIAEEmailFactory
 from itou.siae_evaluations.enums import EvaluatedAdministrativeCriteriaState
 from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory
@@ -134,6 +135,7 @@ class TestInstitutionEmailFactory:
             evaluated_job_application=evaluated_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=51, minutes=1),
             submitted_at=timezone.now() - relativedelta(days=51),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 
@@ -162,6 +164,7 @@ class TestInstitutionEmailFactory:
             evaluated_job_application=evaluated_jobapp,
             uploaded_at=timezone.now() - relativedelta(days=51, minutes=1),
             submitted_at=timezone.now() - relativedelta(days=51),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -671,6 +671,7 @@ class TestEvaluationCampaignManager:
         )
         evaluated_jobapp_accepted = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae_accepted)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             submitted_at=timezone.now() - relativedelta(days=2),
             evaluated_job_application=evaluated_jobapp_accepted,
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
@@ -839,6 +840,7 @@ class TestEvaluationCampaignManager:
         assert evaluated_siae_submitted.reviewed_at is None
         # The DDETS IAE set the review_state to ACCEPTED but forgot to validate its review (hence the None reviewed_at)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             submitted_at=timezone.now() - relativedelta(days=6),
             evaluated_job_application=evaluated_jobapp_submitted,
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
@@ -980,6 +982,7 @@ class TestEvaluationCampaignManager:
         )
         evaluated_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             submitted_at=timezone.now() - relativedelta(days=1),
             evaluated_job_application=evaluated_job_application,
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
@@ -1268,7 +1271,9 @@ class TestEvaluatedSiaeModel:
         # one evaluated_administrative_criterion
         # empty : proof and submitted_at empty)
         evaluated_administrative_criteria0 = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof=None
+            level1=True,
+            evaluated_job_application=evaluated_job_application,
+            proof=None,
         )
         assert evaluation_enums.EvaluatedSiaeState.PENDING == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1614,6 +1619,7 @@ class TestEvaluatedSiaeModel:
             evaluated_siae__reviewed_at=timezone.now() - relativedelta(days=5),
         )
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
@@ -1670,7 +1676,9 @@ class TestEvaluatedJobApplicationModel:
         assert evaluation_enums.EvaluatedJobApplicationsState.PENDING == evaluated_job_application.compute_state()
 
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof=None
+            level1=True,
+            evaluated_job_application=evaluated_job_application,
+            proof=None,
         )
         assert evaluation_enums.EvaluatedJobApplicationsState.PROCESSING == evaluated_job_application.compute_state()
 

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -524,6 +524,45 @@ class TestEvaluationCampaignManager:
         assert evaluated_siae.reviewed_at is None
         assert evaluated_siae.final_reviewed_at is None
 
+    def test_populate_job_application_with_insufficient_certified_level_2_criterion(self):
+        # A single certified level 2 criterion is not enough for the job application to be accepted: the SIAE still
+        # has to prove a total of 2 or 3 level 2 criteria (depending on the SIAE kind) so the job application must stay
+        # editable and the SIAE must not be auto-accepted.
+        evaluation_campaign = EvaluationCampaignFactory()
+        company = CompanyFactory(
+            department=evaluation_campaign.institution.department, with_membership=True, kind=CompanyKind.EI
+        )
+        create_batch_of_job_applications(company)
+        certified_job_app = JobApplication.objects.first()
+        # `Travailleur handicapé` is a certifiable level 2 criterion.
+        level_2 = AdministrativeCriteria.objects.get(kind=AdministrativeCriteriaKind.TH)
+        IAESelectedAdministrativeCriteriaFactory(
+            eligibility_diagnosis_id=certified_job_app.eligibility_diagnosis_id,
+            administrative_criteria=level_2,
+            criteria_certified=True,
+            certification_period=InclusiveDateRange(certified_job_app.hiring_start_at),
+        )
+        now = timezone.now()
+        evaluation_campaign.populate(now)
+
+        criterion = EvaluatedAdministrativeCriteria.objects.get()
+        assert criterion.criteria_certified is True
+        assert criterion.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
+        assert criterion.evaluated_job_application.job_application_id == certified_job_app.pk
+
+        evaluated_job_app = EvaluatedJobApplication.objects.get(job_application=certified_job_app)
+        # EI requires 3 accepted level 2 criteria, i.e. a single one is not enough.
+        assert evaluated_job_app.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+        assert (
+            evaluated_job_app.should_select_criteria
+            == evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.PENDING
+        )
+
+        evaluated_siae = evaluated_job_app.evaluated_siae
+        assert evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.PENDING
+        assert evaluated_siae.reviewed_at is None
+        assert evaluated_siae.final_reviewed_at is None
+
     def test_populate_all_job_applications_certified(self, django_capture_on_commit_callbacks, mailoutbox):
         institution_membership = InstitutionMembershipFactory()
         evaluation_campaign = EvaluationCampaignFactory(institution=institution_membership.institution)
@@ -1686,6 +1725,49 @@ class TestEvaluatedJobApplicationModel:
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
         assert evaluated_job_application.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2
+
+    def test_state_cumulated_accepted_level_2_criteria(self):
+        # Between 2 and 3 accepted level 2 criteria are required (2 for AI or ETTI, 3 otherwise) in order to validate
+        # the job application, i.e. the auto-prescription.
+        level_2a, level_2b, level_2c = AdministrativeCriteria.objects.level2()[:3]
+        level_1 = AdministrativeCriteria.objects.level1().first()
+        campaign = EvaluationCampaignFactory()
+
+        def certified_job_app(kind, criteria):
+            evaluated_job_application = EvaluatedJobApplicationFactory(
+                evaluated_siae__evaluation_campaign=campaign, evaluated_siae__siae__kind=kind
+            )
+            for criterion in criteria:
+                EvaluatedAdministrativeCriteriaFactory(
+                    evaluated_job_application=evaluated_job_application,
+                    administrative_criteria=criterion,
+                    submitted_at=timezone.now(),
+                    review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
+                    criteria_certified=True,
+                )
+            return evaluated_job_application
+
+        # CASE 1: A single certified level 2 criterion is not enough to validate the auto-prescription.
+        case_1 = certified_job_app(CompanyKind.EI, [level_2a])
+        assert case_1.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+        # It stays editable so the SIAE can make modifications.
+        assert case_1.should_select_criteria == evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.PENDING
+
+        # CASE 2: Two certified level 2 criteria are still not enough for an EI (which requires 3).
+        case_2 = certified_job_app(CompanyKind.EI, [level_2a, level_2b])
+        assert case_2.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+
+        # CASE 3: Two certified level 2 criteria are enough for an AI (which requires 2).
+        case_3 = certified_job_app(CompanyKind.AI, [level_2a, level_2b])
+        assert case_3.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+        # Three certified level 2 criteria are enough for an EI.
+        case_3_ei = certified_job_app(CompanyKind.EI, [level_2a, level_2b, level_2c])
+        assert case_3_ei.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+
+        # CASE 4: A certified level 1 criterion validates the auto-prescription on its own, even alongside
+        # (unnecessary) level 2 criteria.
+        case_4 = certified_job_app(CompanyKind.EI, [level_1, level_2a])
+        assert case_4.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
 
     def test_should_select_criteria_with_mock(self, subtests):
         evaluated_job_application = EvaluatedJobApplicationFactory()

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -12,7 +12,11 @@ from pytest_django.asserts import assertNumQueries, assertQuerySetEqual
 
 from itou.approvals.enums import Origin
 from itou.companies.enums import CompanyKind, CompanySource
-from itou.eligibility.enums import AdministrativeCriteriaKind, AuthorKind
+from itou.eligibility.enums import (
+    ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND,
+    AdministrativeCriteriaKind,
+    AuthorKind,
+)
 from itou.eligibility.models import AdministrativeCriteria
 from itou.institutions.enums import InstitutionKind
 from itou.job_applications.enums import JobApplicationState
@@ -558,6 +562,51 @@ class TestEvaluationCampaignManager:
 
         evaluated_siae = evaluated_job_app.evaluated_siae
         evaluated_siae.refresh_from_db()
+        assert evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.PENDING
+        assert evaluated_siae.reviewed_at is None
+        assert evaluated_siae.final_reviewed_at is None
+
+    def test_populate_job_application_with_insufficient_certified_level_2_criterion(self):
+        # The SIAE has to prove a total of N level 2 criteria for the job application to be accepted. N depends
+        # on the SIAE kind (refer to ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND; between 2 and 3 at the
+        # time of writing), so the job application must stay editable and the SIAE must not be auto-accepted.
+        evaluation_campaign = EvaluationCampaignFactory()
+        company = CompanyFactory(
+            department=evaluation_campaign.institution.department, with_membership=True, evaluable_kind=True
+        )
+        create_batch_of_job_applications(company)
+        certified_job_app = JobApplication.objects.first()
+        # `Travailleur handicapé` and `Parent isolé` are certifiable level 2 criteria.
+        level_2_criteria = AdministrativeCriteria.objects.filter(
+            kind__in=[AdministrativeCriteriaKind.TH, AdministrativeCriteriaKind.PI]
+        )
+        # Certify one criterion less than the SIAE kind requires (as of now, AI/ETTI require 2 but ACI/ EI require 3).
+        required = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[company.kind]
+        for administrative_criteria in level_2_criteria[: required - 1]:
+            IAESelectedAdministrativeCriteriaFactory(
+                eligibility_diagnosis_id=certified_job_app.eligibility_diagnosis_id,
+                administrative_criteria=administrative_criteria,
+                criteria_certified=True,
+                certification_period=InclusiveDateRange(certified_job_app.hiring_start_at),
+            )
+        now = timezone.now()
+        evaluation_campaign.populate(now)
+
+        assert EvaluatedAdministrativeCriteria.objects.count() == required - 1
+        for criterion in EvaluatedAdministrativeCriteria.objects.all():
+            assert criterion.criteria_certified is True
+            assert criterion.review_state == evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
+            assert criterion.evaluated_job_application.job_application_id == certified_job_app.pk
+
+        evaluated_job_app = EvaluatedJobApplication.objects.get(job_application=certified_job_app)
+        # One level 2 criterion is missing for the auto-prescription to be accepted.
+        assert evaluated_job_app.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+        assert (
+            evaluated_job_app.should_select_criteria
+            == evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.PENDING
+        )
+
+        evaluated_siae = evaluated_job_app.evaluated_siae
         assert evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.PENDING
         assert evaluated_siae.reviewed_at is None
         assert evaluated_siae.final_reviewed_at is None
@@ -1725,6 +1774,49 @@ class TestEvaluatedJobApplicationModel:
         )
         assert evaluated_job_application.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.REFUSED_2
 
+    def test_state_cumulated_accepted_level_2_criteria(self):
+        # Between 2 and 3 accepted level 2 criteria are required (2 for AI or ETTI, 3 otherwise) in order to validate
+        # the job application, i.e. the auto-prescription.
+        level_2a, level_2b, level_2c = AdministrativeCriteria.objects.level2()[:3]
+        level_1 = AdministrativeCriteria.objects.level1().first()
+        campaign = EvaluationCampaignFactory()
+
+        def certified_job_app(kind, criteria):
+            evaluated_job_application = EvaluatedJobApplicationFactory(
+                evaluated_siae__evaluation_campaign=campaign, evaluated_siae__siae__kind=kind
+            )
+            for criterion in criteria:
+                EvaluatedAdministrativeCriteriaFactory(
+                    evaluated_job_application=evaluated_job_application,
+                    administrative_criteria=criterion,
+                    submitted_at=timezone.now(),
+                    review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
+                    criteria_certified=True,
+                )
+            return evaluated_job_application
+
+        # CASE 1: A single certified level 2 criterion is not enough to validate the auto-prescription.
+        case_1 = certified_job_app(CompanyKind.EI, [level_2a])
+        assert case_1.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+        # It stays editable so the SIAE can make modifications.
+        assert case_1.should_select_criteria == evaluation_enums.EvaluatedJobApplicationsSelectCriteriaState.PENDING
+
+        # CASE 2: Two certified level 2 criteria are still not enough for an EI (which requires 3).
+        case_2 = certified_job_app(CompanyKind.EI, [level_2a, level_2b])
+        assert case_2.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.PENDING
+
+        # CASE 3: Two certified level 2 criteria are enough for an AI (which requires 2).
+        case_3 = certified_job_app(CompanyKind.AI, [level_2a, level_2b])
+        assert case_3.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+        # Three certified level 2 criteria are enough for an EI.
+        case_3_ei = certified_job_app(CompanyKind.EI, [level_2a, level_2b, level_2c])
+        assert case_3_ei.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+
+        # CASE 4: A certified level 1 criterion validates the auto-prescription on its own, even alongside
+        # (unnecessary) level 2 criteria.
+        case_4 = certified_job_app(CompanyKind.EI, [level_1, level_2a])
+        assert case_4.compute_state() == evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED
+
     def test_should_select_criteria_with_mock(self, subtests):
         evaluated_job_application = EvaluatedJobApplicationFactory()
         assert (
@@ -1846,11 +1938,25 @@ class TestEvaluatedAdministrativeCriteriaModel:
         evaluated_administrative_criteria.save(update_fields=["submitted_at", "review_state"])
         assert evaluated_administrative_criteria.can_upload()
 
-        for state in [
-            state
-            for state in evaluation_enums.EvaluatedAdministrativeCriteriaState
-            if state != evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
-        ]:
+    def test_can_upload_returns_false_with_certified_criteria(self, subtests):
+        # A certified criterion is accepted when the campaign starts: the SIAE has no proof to transmit.
+        fake_now = timezone.now()
+
+        evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
+            evaluated_job_application=EvaluatedJobApplicationFactory(),
+            proof=None,
+            criteria_certified=True,
+        )
+        assert not evaluated_administrative_criteria.can_upload()
+
+        # Not even during the adversarial stage, where a refused criterion could be uploaded again.
+        evaluated_siae = evaluated_administrative_criteria.evaluated_job_application.evaluated_siae
+        evaluated_siae.reviewed_at = fake_now
+        evaluated_siae.save(update_fields=["reviewed_at"])
+
+        evaluated_administrative_criteria.submitted_at = fake_now
+        evaluated_administrative_criteria.save(update_fields=["submitted_at"])
+        for state in evaluation_enums.EvaluatedAdministrativeCriteriaState:
             with subtests.test(state=state.name):
                 evaluated_administrative_criteria.review_state = state
                 evaluated_administrative_criteria.save(update_fields=["review_state"])

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -635,6 +635,7 @@ class TestEvaluationCampaignManager:
         EvaluatedAdministrativeCriteriaFactory(
             submitted_at=timezone.now() - relativedelta(days=2),
             evaluated_job_application=evaluated_jobapp_accepted,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         refused_ts = timezone.now() - relativedelta(days=3)
@@ -803,6 +804,7 @@ class TestEvaluationCampaignManager:
         EvaluatedAdministrativeCriteriaFactory(
             submitted_at=timezone.now() - relativedelta(days=6),
             evaluated_job_application=evaluated_jobapp_submitted,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 
@@ -944,6 +946,7 @@ class TestEvaluationCampaignManager:
         EvaluatedAdministrativeCriteriaFactory(
             submitted_at=timezone.now() - relativedelta(days=1),
             evaluated_job_application=evaluated_job_application,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         # DDETS accepted the document but forgot to validate
@@ -1230,7 +1233,9 @@ class TestEvaluatedSiaeModel:
         # one evaluated_administrative_criterion
         # empty : proof and submitted_at empty)
         evaluated_administrative_criteria0 = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof=None
+            evaluated_job_application=evaluated_job_application,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
+            proof=None,
         )
         assert evaluation_enums.EvaluatedSiaeState.PENDING == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1579,6 +1584,7 @@ class TestEvaluatedSiaeModel:
             evaluated_job_application=evaluated_job_app,
             uploaded_at=timezone.now() - relativedelta(days=2),
             submitted_at=timezone.now() - relativedelta(days=1),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         with assertSnapshotQueries(snapshot):
@@ -1632,7 +1638,9 @@ class TestEvaluatedJobApplicationModel:
         assert evaluation_enums.EvaluatedJobApplicationsState.PENDING == evaluated_job_application.compute_state()
 
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteriaFactory(
-            evaluated_job_application=evaluated_job_application, proof=None
+            evaluated_job_application=evaluated_job_application,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
+            proof=None,
         )
         assert evaluation_enums.EvaluatedJobApplicationsState.PROCESSING == evaluated_job_application.compute_state()
 

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -1919,7 +1919,7 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
 
     @freeze_time("2023-01-24 11:11:00")
     def test_data_card_statistics(self, client):
-        company = CompanyFactory()
+        company = CompanyFactory(evaluable_kind=True)
         previous_campaign = EvaluationCampaignFactory(
             institution=self.institution,
             ended_at=timezone.now() - relativedelta(years=1),
@@ -1937,7 +1937,8 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
         campaign = EvaluationCampaignFactory(
             institution=self.institution, ended_at=timezone.now() - relativedelta(hours=1)
         )
-        other_evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign=campaign)
+        other_company = CompanyFactory(evaluable_kind=True)
+        other_evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign=campaign, siae=other_company)
         EvaluatedJobApplicationFactory(evaluated_siae=other_evaluated_siae)
 
         evaluated_siae = EvaluatedSiaeFactory(evaluation_campaign=campaign, siae=company)

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -717,8 +717,8 @@ class TestInstitutionEvaluatedSiaeDetailView:
         "<b>le résultat du contrôle est négatif</b>."
     )
     certified_text = (
-        "Cette auto-prescription répond à un critère de niveau 1 certifié. "
-        "Aucun justificatif n’est demandé pour le moment."
+        "Les critères certifiés pour cette auto-prescription suffisent à justifier l’éligibilité du salarié. "
+        "Aucun justificatif complémentaire n’est demandé pour le moment."
     )
 
     @pytest.fixture(autouse=True)

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -717,8 +717,8 @@ class TestInstitutionEvaluatedSiaeDetailView:
         "<b>le résultat du contrôle est négatif</b>."
     )
     certified_text = (
-        "Cette auto-prescription répond à un critère de niveau 1 certifié. "
-        "Aucun justificatif n’est demandé pour le moment."
+        "Cette auto-prescription répond à un ou plusieurs critères certifiés, qui suffisent à justifier l’éligibilité "
+        "du salarié. Aucun justificatif complémentaire n’est demandé pour le moment."
     )
 
     @pytest.fixture(autouse=True)

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -542,7 +542,10 @@ class TestInstitutionEvaluatedSiaeListView:
             for_snapshot=True,
         )
         evaluated_job_app = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
-        EvaluatedAdministrativeCriteriaFactory.create(evaluated_job_application=evaluated_job_app)
+        EvaluatedAdministrativeCriteriaFactory.create(
+            evaluated_job_application=evaluated_job_app,
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
+        )
         url = reverse(
             "siae_evaluations_views:institution_evaluated_siae_list",
             kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
@@ -1561,6 +1564,7 @@ class TestInstitutionEvaluatedSiaeDetailView:
         EvaluatedAdministrativeCriteriaFactory(
             evaluated_job_application=evaluated_job_app,
             submitted_at=timezone.now() - relativedelta(days=1),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
         client.force_login(self.user)
@@ -3079,6 +3083,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             evaluated_job_application=accepted_job_application,
             proof=FileFactory(),
             submitted_at=timezone.now(),
+            administrative_criteria=AdministrativeCriteria.objects.level1().first(),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -542,7 +542,10 @@ class TestInstitutionEvaluatedSiaeListView:
             for_snapshot=True,
         )
         evaluated_job_app = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
-        EvaluatedAdministrativeCriteriaFactory.create(evaluated_job_application=evaluated_job_app)
+        EvaluatedAdministrativeCriteriaFactory.create(
+            level1=True,
+            evaluated_job_application=evaluated_job_app,
+        )
         url = reverse(
             "siae_evaluations_views:institution_evaluated_siae_list",
             kwargs={"evaluation_campaign_pk": evaluation_campaign.pk},
@@ -1559,6 +1562,7 @@ class TestInstitutionEvaluatedSiaeDetailView:
         )
         evaluated_job_app = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=evaluated_job_app,
             submitted_at=timezone.now() - relativedelta(days=1),
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
@@ -3076,6 +3080,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
         # Should not be displayed (not sanctionnable)
         accepted_job_application = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(
+            level1=True,
             evaluated_job_application=accepted_job_application,
             proof=FileFactory(),
             submitted_at=timezone.now(),

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -10,8 +10,9 @@ from django.urls import reverse
 from django.utils import dateformat, html, timezone
 from freezegun import freeze_time
 from itoutils.django.testing import assertSnapshotQueries
-from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertRedirects
+from pytest_django.asserts import assertContains, assertHTMLEqual, assertMessages, assertNotContains, assertRedirects
 
+from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import (
     ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND,
     AdministrativeCriteriaKind,
@@ -967,6 +968,76 @@ class TestSiaeSelectCriteriaView:
         response = client.post(url)
         assert response.status_code == 403
 
+    def test_with_insufficient_certified_level_2_criteria(self, client):
+        # A single certified level 2 criterion is not enough to validate the auto-prescription so the form must remain
+        # reachable: the SIAE still has to provide proofs for some criteria. The certified criterion is shown with a
+        # `Certifié` badge, pre-checked, disabled and cannot be removed.
+        self.siae.kind = CompanyKind.AI  # AI requires 2 level 2 criteria.
+        self.siae.save(update_fields=["kind", "updated_at"])
+        evaluated_job_application = create_evaluated_siae_with_consistent_datas(
+            self.siae, self.user, level_1=False, level_2=True
+        )
+        eligibility_diagnosis = evaluated_job_application.job_application.eligibility_diagnosis
+        certified_criterion = AdministrativeCriteria.objects.get(kind=AdministrativeCriteriaKind.TH)
+        EvaluatedAdministrativeCriteria.objects.create(
+            evaluated_job_application=evaluated_job_application,
+            administrative_criteria=certified_criterion,
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
+            uploaded_at=timezone.now(),
+            submitted_at=timezone.now(),
+            criteria_certified=True,
+        )
+        url = reverse(
+            "siae_evaluations_views:siae_select_criteria",
+            kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
+        )
+        client.force_login(self.user)
+
+        # The form is reachable (i.e. not 403) at that stage.
+        response = client.get(url)
+        assert certified_criterion.key in response.context["certified_criteria_keys"]
+        # We also make sure the certified level 2 criterion is displayed (with its checkbox disabled and checked).
+        soup = parse_response_to_soup(response, "#main")
+        [checkbox] = soup.select(f"#id_{certified_criterion.key}")
+        assertHTMLEqual(
+            f"""<input type="checkbox" name="{certified_criterion.key}" """
+            f"""class="form-check-input" disabled="" id="id_{certified_criterion.key}" checked="">""",
+            str(checkbox),
+        )
+        label = checkbox.find_next()
+        assertHTMLEqual(
+            f"""<label for="id_{certified_criterion.key}" class="form-check-label">
+                <span class="d-flex gap-1">
+                    {certified_criterion.get_kind_display()}
+                    <span class="badge badge-xs rounded-pill bg-info-lighter text-info">
+                        <i class="ri-verified-badge-fill" aria-hidden="true"></i> Certifié
+                    </span>
+                </span>
+                <p class="small mb-0 form-text text-muted">
+                  Ce critère étant certifié, aucun justificatif n’est demandé pour le moment.
+                </p>
+            </label>""",
+            str(label),
+        )
+        certified_field = next(f for f in response.context["level_2_fields"] if f.name == certified_criterion.key)
+        assert certified_field.field.disabled is True
+        assert "checked" in certified_field.subwidgets[0].data["attrs"]
+
+        # A valid POST that does not re-check the certified criterion must not remove it as a disabled field keeps its
+        # initial value and is excluded from the form changed data.
+        other = (
+            eligibility_diagnosis.selected_administrative_criteria.exclude(administrative_criteria=certified_criterion)
+            .first()
+            .administrative_criteria
+        )
+        response = client.post(url, data={other.key: True})
+        assert response.status_code == 302
+        remaining = {
+            eval_criterion.administrative_criteria_id
+            for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
+        }
+        assert set(remaining) == {certified_criterion.pk, other.pk}
+
 
 class TestSiaeUploadDocsView:
     def setup_method(self):
@@ -1475,8 +1546,8 @@ class TestSiaeEvaluatedSiaeDetailView:
         assertContains(
             response,
             (
-                "Cette auto-prescription répond à un critère de niveau 1 certifié. "
-                "Aucun justificatif n’est demandé pour le moment."
+                "Les critères certifiés pour cette auto-prescription suffisent à justifier l’éligibilité du salarié. "
+                "Aucun justificatif complémentaire n’est demandé pour le moment."
             ),
             html=True,
             count=1,

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertRedirects
 
+from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import (
     ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND,
     AdministrativeCriteriaKind,
@@ -967,6 +968,57 @@ class TestSiaeSelectCriteriaView:
         response = client.post(url)
         assert response.status_code == 403
 
+    def test_with_insufficient_certified_level_2_criteria(self, client):
+        # A single certified level 2 criterion is not enough to validate the auto-prescription so the form must remain
+        # reachable: the SIAE still has to provide proofs for some criteria. The certified criterion is shown with a
+        # `Certifié` badge, pre-checked, disabled and cannot be removed.
+        self.siae.kind = CompanyKind.AI  # AI requires 2 level 2 criteria.
+        self.siae.save(update_fields=["kind", "updated_at"])
+        evaluated_job_application = create_evaluated_siae_with_consistent_datas(
+            self.siae, self.user, level_1=False, level_2=True
+        )
+        eligibility_diagnosis = evaluated_job_application.job_application.eligibility_diagnosis
+        certified = AdministrativeCriteria.objects.get(kind=AdministrativeCriteriaKind.TH)
+        EvaluatedAdministrativeCriteria.objects.create(
+            evaluated_job_application=evaluated_job_application,
+            administrative_criteria=certified,
+            review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
+            uploaded_at=timezone.now(),
+            submitted_at=timezone.now(),
+            criteria_certified=True,
+        )
+        url = reverse(
+            "siae_evaluations_views:siae_select_criteria",
+            kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
+        )
+        client.force_login(self.user)
+
+        # The form is reachable (i.e. not 403) at that stage.
+        response = client.get(url)
+        assert response.status_code == 200
+        assert certified.key in response.context["certified_criteria_keys"]
+        assertContains(response, "Certifié")
+
+        certified_field = next(f for f in response.context["level_2_fields"] if f.name == certified.key)
+        assert certified_field.field.disabled is True
+        assert "checked" in certified_field.subwidgets[0].data["attrs"]
+
+        # A valid POST that does not re-check the certified criterion must not remove it as a disabled field keeps its
+        # initial value and is excluded from the form changed data.
+        other = (
+            eligibility_diagnosis.selected_administrative_criteria.exclude(administrative_criteria=certified)
+            .first()
+            .administrative_criteria
+        )
+        response = client.post(url, data={other.key: True})
+        assert response.status_code == 302
+        remaining = {
+            eval_criterion.administrative_criteria_id
+            for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
+        }
+        assert certified.pk in remaining
+        assert other.pk in remaining
+
 
 class TestSiaeUploadDocsView:
     def setup_method(self):
@@ -1475,8 +1527,8 @@ class TestSiaeEvaluatedSiaeDetailView:
         assertContains(
             response,
             (
-                "Cette auto-prescription répond à un critère de niveau 1 certifié. "
-                "Aucun justificatif n’est demandé pour le moment."
+                "Cette auto-prescription répond à un ou plusieurs critères certifiés, qui suffisent à justifier "
+                "l’éligibilité du salarié. Aucun justificatif complémentaire n’est demandé pour le moment."
             ),
             html=True,
             count=1,


### PR DESCRIPTION
## :thinking: Pourquoi ?

[[Carte Notion](https://app.notion.com/p/gip-inclusion/Tenir-compte-de-la-certification-des-crit-res-de-niveau-2-dans-le-cadre-du-contr-le-a-posteriori-3965f321b60480f2a03bcb71aba046f8)]

En prévision de la prochaine campagne de **contrôle à posteriori**, la logique de l'application devait évoluer afin de prendre en compte la certification des **critères de niveau 2** – comme l'indiquait d'ailleurs ce [commentaire](https://github.com/gip-inclusion/les-emplois/pull/8536/changes/7be1bff79964992a5bae5a362674b34bfdd8826f#diff-7c47a4dac6db2de559ad6359b70ee9ec336e5498532632c3b995968a32b656adL301) laissé par [?] dans la méthode `EvaluationCampaign.populate()` :
```
TODO: For the 2026 campaign on auto-prescriptions
hires in 2025, this should be updated to handle
LEVEL_2.
Generating an accepted administrative criteria with
level 2 will significantly break all views in this
module. Many parts of it rely on the criteria state
to decide what actions to offer, and the state of the
evaluated job application.
```

Donc dans l'idée de faire gagner du temps à nos utilisateurs, et afin de sécuriser la procédure, cette PR nous rapproche d'un monde meilleur où les auto-prescriptions seront vérifiées automatiquement, y compris les critères de niveau 2.

## :cake: Comment ?

- Modification de la [méthode `EvaluatedJobApplication.compute_state()`](https://github.com/gip-inclusion/les-emplois/pull/8536/changes/7be1bff79964992a5bae5a362674b34bfdd8826f#diff-7c47a4dac6db2de559ad6359b70ee9ec336e5498532632c3b995968a32b656adR786) pour lui faire prendre en compte la règle des 2/3 critères administratifs de niveau 2 nécessaires à la validation dans le cas d'une auto-prescription.
- Suppression d'un `assert` qui vérifiait que seuls des critères de niveau 1 étaient certifiés.
- Récupération, dans un souci de performance, de `administrative_criteria` via le prefetch puisqu'on utilise maintenant le niveau du critère administratif afin de calculer l'état d'avancement du contrôle de l'auto-prescription.
- On indique désormais ici et là dans l'admin de Django lorsqu'un critère administratif est certifié.
- Demande de modification afin de coller à la [maquette](https://www.figma.com/board/qeX0CIKOdKaHWkd4yJo98H/Certification-des-crit%C3%A8res-de-niveau-2?node-id=0-1&p=f&t=CSdUBWWMwumQtg8v-0) : on ne liste plus les critères certifiés depuis la page de justification lorsque ceux-ci ne permettent pas d'emblée une validation automatique.
- Modification de la méthode `can_upload()` afin d'empêcher une SIAE de téléverser un justificatif pour un critère certifié.
- Petites optimisations dans les templates.

À faire aussi ?
- ~~Dans les tests, tirer au hasard un critère parmi ceux de niveau 1 -- plutôt que toujours le même ?~~ Fait ✅
- Un peu partout, remplacer _criterion_  par _criteria_ là où l'erreur singulier/pluriel est commise ? (e.g. `EvaluatedAdministrativeCriteria.administrative_criteria`)

## :desert_island: Comment tester ?

Sélectionner des critères à justifier puis téléverser les documents justificatifs attendus.
Les soumettre puis s'identifier en tant qu'utilisateur DDETS afin de les contrôler.

Pour certifier un critère administratif alors que la campagne est déjà créée / en cours, exécuter cette commande dans le shell de Django afin de créer l'évaluation d'un critère administratif :
```python
EvaluatedAdministrativeCriteria.objects.create(evaluated_job_application_id=<PK de l'auto-prescription consultée>, administrative_criteria_id=<PK du critère administratif>, uploaded_at=timezone.now(), submitted_at=timezone.now(), review_state="ACCEPTED", criteria_certified=True)
```

La liste des critères administratifs (avec leurs clés primaires) est disponible ici : http://localhost:8000/admin/eligibility/administrativecriteria/

## :computer: Captures d'écran

- Côté SIAE : deux critères de niveau 1 certifiés provoquent la validation automatique de l'auto-prescription.

- Modification du message indiquant qu'un critère a été certifié :
<img width="1890" height="560" alt="image" src="https://github.com/user-attachments/assets/b7ecbafe-2f65-4416-a89b-6b447aae047c" />

- Et au passage, côté SIAE, suppression de l'affichage des critères administratifs lorsque l'auto-prescription a le statut _À traiter_ (`PENDING`) afin de ne pas induire l'utilisateur en erreur, i.e. afin de mettre en évidence le bouton `Sélectionner les critères` :

Avant             |  Après
:-------------------------:|:-------------------------:
<img width="1824" height="896" alt="image" src="https://github.com/user-attachments/assets/d97bd26e-c3d0-4eed-9449-951daf5cd6da" /> | .

[...]