### PR TITLE
Connexion : Ouvrir l'accès au parcours d'enrôlement au 2FA interne

### DIFF
--- a/itou/otp/utils.py
+++ b/itou/otp/utils.py
@@ -93,8 +93,10 @@ def user_uses_external_mfa(user):
 def user_can_enroll_otp_device(user):
     """Whether our own 2FA applies to this user and the identity provider does not already
     handle it: enrolling a device is useful."""
-    return not user_uses_external_mfa(user) and (
-        user.show_upcoming_mfa_activation_banner or user_is_concerned_by_otp(user)
+    if user_uses_external_mfa(user):
+        return False
+    return (user.is_itou_staff and settings.REQUIRE_OTP_FOR_STAFF) or (
+        user.is_professional and settings.REQUIRE_MFA_FOR_PROS
     )
 
 


### PR DESCRIPTION
On a désactivé la bannière "anticipez dès maintenant, la double authentification sera bientôt obligatoire", parce que le parcours d'enrôlement au 2FA interne doit être amélioré. En conséquence, seuls les utilisateurs du 1er lot cible (environ 355 utilisateurs sur 5 entreprises et 5 organisations) peuvent accéder au parcours d'enrôlement.

C'est bloquant pour les entretiens utilisateur réalisés par les UX. Les utilisateurs contactés pour ces entretiens ne sont pas nécessairement dans le 1er lot d'utilisateurs cibles. Quand on leur donne l'URL du parcours, ils reçoivent une 404 si on ne réactive pas temporairement la bannière.

Cette PR élargit un peu les conditions d'accès au parcours : les utilisateurs ayant l'URL (donc les utilisateurs des entretiens UX) pourront enrôler leur appareil.

