### PR TITLE
Insertion : Petit correctif temporel à `sync_orientation_statuses`

### DIFF
--- a/itou/insertion/management/commands/sync_orientation_statuses.py
+++ b/itou/insertion/management/commands/sync_orientation_statuses.py
@@ -10,6 +10,11 @@ from itou.utils.apis.dora import DoraAPIClient, DoraApiItemsIterator
 from itou.utils.command import BaseCommand
 
 
+# We are comparing datetimes from DORA and from les Emplois.
+# We’ll consider equal two datetimes that are less than 3 seconds away.
+MIN_EMPLOIS_DORA_TIMEDELTA = datetime.timedelta(seconds=3)
+
+
 class DoraStatus(NamedTuple):
     status: str
     processing_date: datetime.datetime | None  # the date on which the orientation was processed by DORA
@@ -73,7 +78,7 @@ class Command(BaseCommand):
             emplois_status = DoraStatus.from_orientation(orientation)
             if dora_status == emplois_status:
                 continue
-            elif emplois_status.updated_at > dora_status.updated_at:
+            elif (emplois_status.updated_at - dora_status.updated_at) > MIN_EMPLOIS_DORA_TIMEDELTA:
                 # This situation should not happen, we want to have only one source of truth.
                 # For now it is DORA from which we update the status, processing_date and updated_at.
                 # Later on, the orientations will be managed on Les Emplois and we don’t want to

--- a/tests/insertion/test_sync_orientation_statuses.py
+++ b/tests/insertion/test_sync_orientation_statuses.py
@@ -112,6 +112,38 @@ def test_doesnt_update_more_recent_emplois(dora_settings, respx_mock, caplog):
     assert f"Trying to update orientation={orientation.pk} with older DORA data" in caplog.messages
 
 
+def test_updates_even_if_small_time_delta(dora_settings, respx_mock):
+    """
+    Real case when the time on les Emplois is slightly in the future in comparison to DORA.
+    In such case: update anyway.
+    """
+    dora_datetime = datetime.datetime(2026, 7, 20, 0, 0, 0, 0, tzinfo=datetime.UTC)
+    emplois_datetime = datetime.datetime(2026, 7, 20, 0, 0, 1, 123, tzinfo=datetime.UTC)
+    with freeze_time(emplois_datetime):
+        orientation = OrientationFactory(status=OrientationStatus.PENDING)
+    respx_mock.get(DORA_STATUS_URL).respond(
+        200,
+        json=paginated(
+            [
+                status_item(
+                    orientation.id,
+                    OrientationStatus.PENDING,
+                    processing_date=None,
+                    updated_at=dora_datetime.isoformat(),
+                )
+            ]
+        ),
+    )
+
+    call_command("sync_orientation_statuses", wet_run=True)
+
+    orientation.refresh_from_db()
+    assert orientation.status == OrientationStatus.PENDING
+    assert orientation.processing_date is None
+    assert orientation.dora_status_updated_at == dora_datetime
+    assert orientation.updated_at == dora_datetime
+
+
 def test_first_run_has_no_updated_after(dora_settings, respx_mock):
     route = respx_mock.get(DORA_STATUS_URL).respond(200, json=paginated([]))
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans la commande, on compare des timestamps provenant de différents SI (DORA et Les Emplois). 
Il vaut mieux considérer que les timestamps (updated_at) ne diffèrent que si l’écart est significatif.


(et là je me dis que le script devient alambiqué, mais c’est peut-être qu’une synchro entre 2 SI est forcément un peu complexe ?) 


