### PR TITLE
Tech : Ajout de détails dans les assertions du script d'import des SIAE

### DIFF
--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -30,8 +30,12 @@ def update_existing_conventions(siret_to_siae_row, conventions_by_siae_key):
     ).select_related("convention")
     for siae in managed_siaes_with_conventions:
         convention = siae.convention
-        assert convention.kind == siae.kind
-        assert convention.siren_signature == siae.siren
+        assert convention.kind == siae.kind, (
+            f"convention {convention.id} has kind {convention.kind}, siae {siae.id} has {siae.kind}"
+        )
+        assert convention.siren_signature == siae.siren, (
+            f"convention {convention.id} has SIREN {convention.siren_signature}, siae {siae.id} has {siae.siren}"
+        )
 
         if siae.siret not in siret_to_siae_row:
             # At some point, old C1 siaes stop existing in the latest FluxIAE file.
@@ -53,7 +57,9 @@ def update_existing_conventions(siret_to_siae_row, conventions_by_siae_key):
                 f"convention.id={convention.id} has changed asp_id from "
                 f"{convention.asp_id} to {row.asp_id} (will be updated)"
             )
-            assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()
+            assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists(), (
+                f"unexpected convention exists with asp_id={row.asp_id} and kind {siae.kind}"
+            )
             convention.asp_id = row.asp_id
             convention.save(update_fields={"asp_id", "updated_at"})
             continue
@@ -124,12 +130,14 @@ def get_creatable_conventions(siret_to_siae_row, conventions_by_siae_key):
             # Some inactive siaes are absent in the latest ASP exports but
             # are still present in db because they have members and/or job applications.
             # We cannot build a convention object for those.
-            assert not siae.is_active
+            assert not siae.is_active, f"SIAE {siae.id} is unexpectedly active"
             continue
 
         row = siret_to_siae_row[siae.siret]
         # convention is to be unique for an asp_id and a SIAE kind
-        assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()
+        assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists(), (
+            f"unexpected convention exists with asp_id={row.asp_id} and kind {siae.kind}"
+        )
 
         convention_data = conventions_by_siae_key[(row.asp_id, siae.kind)]
         convention = SiaeConvention(
@@ -157,16 +165,20 @@ def check_convention_data_consistency():
         # Unfortunately some inactive conventions have lost their ASP siae.
         asp_siaes = [siae for siae in convention.siaes.all() if siae.source == CompanySource.ASP]
         if convention.is_active:
-            assert len(asp_siaes) == 1
+            assert len(asp_siaes) == 1, "unexpected length {len(asp_siaes)} for convention {convention.id}"
         else:
             assert 0 <= len(asp_siaes) <= 1
             # Check that each inactive convention has a grace period start date.
-            assert convention.deactivated_at is not None
+            assert convention.deactivated_at is not None, "convention {convention.id} is unexpectedly active"
 
         # Additional data consistency checks.
         for siae in convention.siaes.all():
-            assert siae.siren == convention.siren_signature
-            assert siae.kind == convention.kind
+            assert siae.siren == convention.siren_signature, (
+                f"siae {siae.id} has siren {siae.siren}, convention {convention.id} has {convention.siren_signature}"
+            )
+            assert siae.kind == convention.kind, (
+                f"siae {siae.id} has kind {siae.kind}, convention {convention.id} has {convention.kind}"
+            )
 
     asp_siaes_without_convention = Company.objects.filter(
         kind__in=CompanyKind.siae_kinds(), source=CompanySource.ASP, convention__isnull=True
@@ -186,12 +198,17 @@ def create_conventions(siret_to_siae_row, conventions_by_siae_key):
     print(f"will create {len(creatable_conventions)} conventions")
 
     for convention, siae in creatable_conventions:
-        assert not SiaeConvention.objects.filter(asp_id=convention.asp_id, kind=convention.kind).exists()
+        assert not SiaeConvention.objects.filter(asp_id=convention.asp_id, kind=convention.kind).exists(), (
+            f"unexpected convention exists with asp_id={convention.asp_id} and kind {convention.kind}"
+        )
         convention.save()
-        assert convention.siaes.count() == 0
+        assert convention.siaes.count() == 0, (
+            f"convention {convention.id} unexpectedly has {convention.siaes.count()} siaes"
+        )
         siae.convention = convention
         siae.save(update_fields={"convention", "updated_at"})
-        assert convention.siaes.filter(source=CompanySource.ASP).count() == 1
+        company_count = convention.siaes.filter(source=CompanySource.ASP).count()
+        assert company_count == 1, f"convention {convention.id} has {company_count} ASP companies"
 
 
 @transaction.atomic()

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -27,7 +27,9 @@ def get_creatable_and_deletable_afs(af_number_to_row):
 
         # The AF already exists in db. Let's check if some of its fields have changed.
         row = af_number_to_row[af.number]
-        assert af.convention.kind == row.kind
+        assert af.convention.kind == row.kind, (
+            f"convention of af {af.id} has kind {af.convention.kind}, CSV has kind {row.kind}"
+        )
 
         updated_fields = set()
         for field in ["start_at", "end_at"]:

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -76,7 +76,7 @@ def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
     for siae in Company.objects.select_related("convention").filter(
         source=CompanySource.ASP, convention__isnull=False
     ):
-        assert siae.should_have_convention
+        assert siae.should_have_convention, f"siae {siae.id} unexpectedly should not have convention"
 
         if siae.convention.asp_id not in asp_id_to_siae_row:
             continue
@@ -90,7 +90,7 @@ def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
             auth_email_updates += 1
 
         if siae.siret != row.siret:
-            assert siae.siren == row.siret[:9]
+            assert siae.siren == row.siret[:9], f"siae {siae.id} has SIREN {siae.siren}, file has SIRET {row.siret}"
 
             existing_siae = Company.objects.filter(siret=row.siret, kind=siae.kind).first()
             if existing_siae:
@@ -132,10 +132,14 @@ def create_new_siaes(siret_to_siae_row, conventions_by_siae_key):
         existing_siaes = Company.objects.select_related("convention").filter(convention__asp_id=asp_id, kind=kind)
         # Siaes with this asp_id already exist, no need to create one more.
         for existing_siae in existing_siaes:
-            assert existing_siae.should_have_convention
+            assert existing_siae.should_have_convention, (
+                f"siae {existing_siae.id} unexpectedly should not have convention"
+            )
             # Siret should have been fixed by update_siret_and_auth_email_of_existing_siaes().
             if existing_siae.source == CompanySource.ASP and existing_siae.siret != row.siret:
-                raise AssertionError(f"SIRET mismatch: {existing_siae.siret=}, {row.siret=}")
+                raise AssertionError(
+                    f"SIRET mismatch on siae {existing_siae.id}: {existing_siae.siret=}, {row.siret=}"
+                )
         try:
             existing_siae = Company.objects.get(siret=row.siret, kind=kind)
         except Company.DoesNotExist:
@@ -158,8 +162,12 @@ def create_new_siaes(siret_to_siae_row, conventions_by_siae_key):
             if existing_siae.source == CompanySource.ASP:
                 continue
             # Siae with this siret+kind already exists but with the wrong source.
-            assert existing_siae.source in [CompanySource.USER_CREATED, CompanySource.STAFF_CREATED]
-            assert existing_siae.should_have_convention
+            assert existing_siae.source in [CompanySource.USER_CREATED, CompanySource.STAFF_CREATED], (
+                f"unexpected source {existing_siae.source} for siae {existing_siae.id}"
+            )
+            assert existing_siae.should_have_convention, (
+                f"siae {existing_siae.id} unexpectedly should not have convention"
+            )
             print(
                 f"siae.id={existing_siae.id} already exists "
                 f"with wrong source={existing_siae.source} "

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -43,7 +43,6 @@ def get_filename(filename_prefix, filename_extension, description=None):
         raise RuntimeError(f"No match found for {description}")
     if len(filenames) > 1:
         raise RuntimeError(f"Too many matches for {description}")
-    assert len(filenames) == 1
 
     filename = filenames[0]
     print(f"Selected file {filename} for {description}.")

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -283,11 +283,6 @@ def anonymize_fluxiae_df(df):
             if deletable_keyword in column_name:
                 del df[column_name]
 
-    # Better safe than sorry when dealing with sensitive data!
-    for column_name in df.columns.tolist():
-        for deletable_keyword in deletable_keywords:
-            assert deletable_keyword not in column_name
-
     return df
 
 

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -77,13 +77,15 @@ def get_vue_structure_df():
     df = df[df.auth_email.notnull()]
     df = df[df.auth_email != ""]
 
-    for _, row in df.iterrows():
+    for idx, row in df.iterrows():
         validate_siret(row.siret)
         validate_siret(row.siret_signature)
         validate_naf(row.naf)
-        assert " " not in row.auth_email
-        assert "@" in row.auth_email
-        assert row.siret[:9] == row.siret_signature[:9]
+        assert " " not in row.auth_email, f"row {idx + 1} has email with space"
+        assert "@" in row.auth_email, f"row {idx + 1} has email without '@'"
+        assert row.siret[:9] == row.siret_signature[:9], (
+            f"row {idx + 1} has inconsistent SIREN {row.siret[:9]} and SIREN signature {row.siret_signature[:9]}"
+        )
 
     return df
 

--- a/itou/companies/management/commands/import_ea_eatt.py
+++ b/itou/companies/management/commands/import_ea_eatt.py
@@ -30,11 +30,15 @@ def build_ea_eatt(row):
     company = Company()
     company.siret = row.siret
     company.kind = row.kind
-    assert company.kind in [CompanyKind.EA, CompanyKind.EATT]
+    assert company.kind in [CompanyKind.EA, CompanyKind.EATT], (
+        f"file as unexpected kind {company.kind} for SIRET {company.siret}"
+    )
     company.source = CompanySource.EA_EATT
 
     company.name = row.name
-    assert not company.name.isnumeric()
+    assert not company.name.isnumeric(), (
+        f"company name is unexpectedly numeric {company.name} for SIRET {company.siret}"
+    )
 
     company.email = ""  # Do not make the authentification email public!
     company.auth_email = row.auth_email

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -266,7 +266,9 @@ class TestImportSiaeManagementCommands:
 
         # It should raise an error message and break.
         with freeze_time("2022-10-10"), django_capture_on_commit_callbacks(execute=True):
-            error_message = f"SIRET mismatch: existing_siae.siret='{company.siret}', row.siret='{new_siret}'"
+            error_message = (
+                f"SIRET mismatch on siae {company.id}: existing_siae.siret='{company.siret}', row.siret='{new_siret}'"
+            )
             with pytest.raises(AssertionError, match=error_message):
                 create_new_siaes(siret_to_siae, conventions_by_siae_key=get_conventions_by_siae_key(get_vue_af_df()))
         assert not Company.objects.filter(siret=new_siret).exists()


### PR DESCRIPTION
J'ai récemment lancé le script d'import SIAE, qui m'a sauté au nez avec une `AssertionError`: 

```python
assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()
```

Comme c'est dans une boucle, le traceback n'aide pas à savoir de quel élément il s'agit. Sentry peut donner quelques indications, mais pas forcément...

Cette PR modifie donc presque tous [1] les `assert` pour fournir un message indiquant l'objet et les valeurs problématiques. C'est un peu verbeux, mais si ça peut nous gagner du temps la prochaine fois que le script plante en plein milieu...

[1] Presque, parce que je n'ai pas modifié les `assert` qui sont hors de boucles, ni les 4 du fichier `_import_siae/vue_af.py`, que je n'ai pas bien compris...

P.S. : Il y a aussi 2 commits bonus de nettoyage, c'est vendredi, c'est plaisir. ;)