### PR TITLE
Technique: Nettoyage de vieux code de test

### DIFF
--- a/tests/gps/test_views.py
+++ b/tests/gps/test_views.py
@@ -407,11 +407,6 @@ class TestGroupDetailsMembershipTab:
                     f"user_organization_id={prescriber.prescribermembership_set.get().organization_id}",
                     "user_organization_id=[PK of organization]",
                 ),
-                (
-                    "href",
-                    f"/gps/request-new-participant/{beneficiary.public_id}",
-                    "/gps/request-new-participant/[Public ID of beneficiary]",
-                ),
                 ("href", f"beneficiary_id={beneficiary.pk}", "beneficiary_id=[PK of beneficiary]"),
                 ("id", f"card-{prescriber.public_id}", "card-[Public ID of prescriber]"),
                 ("id", f"card-{participant.public_id}", "card-[Public ID of participant]"),

--- a/tests/www/apply/test_process_comments.py
+++ b/tests/www/apply/test_process_comments.py
@@ -97,17 +97,7 @@ def test_add_comment_htmx(client, snapshot, caplog):
     client.force_login(user)
     job_app_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_app.id})
     response = client.get(job_app_url)
-    simulated_page = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_app.job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    simulated_page = parse_response_to_soup(response, selector="#main")
 
     add_comment_url = reverse("apply:add_comment_for_company", kwargs={"job_application_id": job_app.id})
     response = client.post(
@@ -119,20 +109,7 @@ def test_add_comment_htmx(client, snapshot, caplog):
 
     # Check that a fresh reload gets the same state
     response = client.get(job_app_url)
-    assertSoupEqual(
-        parse_response_to_soup(
-            response,
-            selector="#main",
-            replace_in_attr=[
-                (
-                    "href",
-                    f"/gps/request-new-participant/{job_app.job_seeker.public_id}",
-                    "/gps/request-new-participant/[Public ID of JobSeeker]",
-                ),
-            ],
-        ),
-        simulated_page,
-    )
+    assertSoupEqual(parse_response_to_soup(response, selector="#main"), simulated_page)
 
     comment = JobApplicationComment.objects.filter(created_by=user).order_by("-created_at").first()
     soup = parse_response_to_soup(
@@ -141,11 +118,6 @@ def test_add_comment_htmx(client, snapshot, caplog):
         replace_in_attr=itertools.chain(
             [
                 ("href", f"/apply/{job_app.id}/siae/accept", "/apply/[Pk of JobApplication]/siae/accept"),
-                (
-                    "href",
-                    f"/gps/request-new-participant/{job_app.job_seeker.public_id}",
-                    "/gps/request-new-participant/[Public ID of JobSeeker]",
-                ),
                 (
                     "hx-post",
                     f"/apply/{job_app.id}/siae/comment/{comment.id}/delete",

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -80,49 +80,19 @@ def test_single_iae_diag_from_prescriber(client, snapshot):
 
     client.force_login(prescriber_membership.user)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with diag_and_update_eligibility")
 
     client.force_login(iae_employer)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with diag")
 
     non_iae_employer = CompanyMembershipFactory(company__not_subject_to_iae_rules=True).user
 
     client.force_login(non_iae_employer)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot without diag")
 
 
@@ -146,11 +116,6 @@ def test_with_approval_and_diagnosis_from_employer(client, snapshot):
         selector="#main",
         replace_in_attr=[
             ("href", f"/approvals/details/{approval.public_id}", "/approvals/details/[Public ID of Approval]"),
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
         ],
     )
     assert pretty_indented(soup) == snapshot(name="HTML page")
@@ -179,11 +144,6 @@ def test_with_approval_and_diagnosis_from_prescriber(client, snapshot):
         selector="#main",
         replace_in_attr=[
             ("href", f"/approvals/details/{approval.public_id}", "/approvals/details/[Public ID of Approval]"),
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
         ],
     )
     assert pretty_indented(soup) == snapshot(name="HTML page")
@@ -210,48 +170,18 @@ def test_single_geiq_diag_from_prescriber(client, snapshot):
 
     client.force_login(geiq_employer)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with diag and details")
 
     client.force_login(prescriber_membership.user)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with diag but without details")
 
     non_geiq_employer = CompanyMembershipFactory(company__subject_to_iae_rules=True).user
     client.force_login(non_geiq_employer)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot without diag")
 
 
@@ -279,17 +209,7 @@ def test_both_diag_from_prescriber(client, snapshot):
 
     client.force_login(prescriber_membership.user)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with GEIQ & IAE diag")
 
 
@@ -326,47 +246,17 @@ def test_both_diag_from_company(client, snapshot):
     authorized_prescriber = PrescriberMembershipFactory(organization__authorized=True).user
     client.force_login(authorized_prescriber)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with both diag")
 
     client.force_login(geiq_membership.user)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with GEIQ diag")
 
     client.force_login(iae_membership.user)
     response = client.get(url)
-    soup = parse_response_to_soup(
-        response,
-        selector="#main",
-        replace_in_attr=[
-            (
-                "href",
-                f"/gps/request-new-participant/{job_seeker.public_id}",
-                "/gps/request-new-participant/[Public ID of JobSeeker]",
-            ),
-        ],
-    )
+    soup = parse_response_to_soup(response, selector="#main")
     assert pretty_indented(soup) == snapshot(name="snapshot with IAE diag")
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les urls n'existent plus, ce n'est plus la peine de les nettoyer dans les snapshots
