### PR TITLE
Insertion: Les services DI avec un lien externe l'utilisent pour la mobilisation des orientations

### DIFF
--- a/itou/insertion/models.py
+++ b/itou/insertion/models.py
@@ -462,6 +462,10 @@ class Service(GeolocatedAddressMixin, models.Model):
         return self.source.value in settings.NON_ORIENTABLE_DI_SOURCES
 
     @property
+    def should_mobilize_via_external_link(self) -> bool:
+        return not self.is_dora and bool(self.mobilization_modes_professionals_external_form_link)
+
+    @property
     def has_orientation_action(self):
         return (self.is_orientable_with_form and not self.from_non_orientable_di_source) or bool(
             self.mobilization_modes_professionals_external_form_link

--- a/itou/templates/insertion/includes/orientation_external_link_button.html
+++ b/itou/templates/insertion/includes/orientation_external_link_button.html
@@ -1,0 +1,16 @@
+{% load matomo %}
+<a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
+   data-emplois-mobilization-kind="{{ MobilizationEventKind.SERVICE_EXT_LINK }}"
+   data-emplois-mobilization-external-link="{{ service.mobilization_modes_professionals_external_form_link }}"
+   rel="noopener"
+   target="_blank"
+   href="{{ service.mobilization_modes_professionals_external_form_link }}"
+   {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}> <span>
+    {% if service.mobilization_modes_professionals_external_form_link_text %}
+        {{ service.mobilization_modes_professionals_external_form_link_text }}
+    {% elif request.GET.job_seeker_public_id %}
+        Orienter le bénéficiaire
+    {% else %}
+        Orienter un bénéficiaire
+    {% endif %}
+</span> </a>

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -41,7 +41,7 @@
                             {% if request.GET.job_seeker_public_id %}
                                 {% url_add_query start_orientation_url job_seeker_public_id=request.GET.job_seeker_public_id as start_orientation_url %}
                             {% endif %}
-                            {% if not service.is_dora and service.mobilization_modes_professionals_external_form_link %}
+                            {% if service.should_mobilize_via_external_link %}
                                 {% include "insertion/includes/orientation_external_link_button.html" with service=service MobilizationEventKind=MobilizationEventKind request=request only %}
                             {% elif service.is_orientable_with_form and not service.from_non_orientable_di_source %}
                                 {% if can_orient_towards_insertion_service %}

--- a/itou/templates/insertion/service_card.html
+++ b/itou/templates/insertion/service_card.html
@@ -41,7 +41,9 @@
                             {% if request.GET.job_seeker_public_id %}
                                 {% url_add_query start_orientation_url job_seeker_public_id=request.GET.job_seeker_public_id as start_orientation_url %}
                             {% endif %}
-                            {% if service.is_orientable_with_form and not service.from_non_orientable_di_source %}
+                            {% if not service.is_dora and service.mobilization_modes_professionals_external_form_link %}
+                                {% include "insertion/includes/orientation_external_link_button.html" with service=service MobilizationEventKind=MobilizationEventKind request=request only %}
+                            {% elif service.is_orientable_with_form and not service.from_non_orientable_di_source %}
                                 {% if can_orient_towards_insertion_service %}
                                     <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
                                        data-emplois-mobilization-kind="{{ MobilizationEventKind.SERVICE_ORIENTATION }}"
@@ -65,21 +67,7 @@
                                     </span> </a>
                                 {% endif %}
                             {% else %}
-                                <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center"
-                                   data-emplois-mobilization-kind="{{ MobilizationEventKind.SERVICE_EXT_LINK }}"
-                                   data-emplois-mobilization-external-link="{{ service.mobilization_modes_professionals_external_form_link }}"
-                                   rel="noopener"
-                                   target="_blank"
-                                   href="{{ service.mobilization_modes_professionals_external_form_link }}"
-                                   {% matomo_event "fiche-service" "clic" "orienter-un-bénéficiaire" %}> <span>
-                                    {% if service.mobilization_modes_professionals_external_form_link_text %}
-                                        {{ service.mobilization_modes_professionals_external_form_link_text }}
-                                    {% elif request.GET.job_seeker_public_id %}
-                                        Orienter le bénéficiaire
-                                    {% else %}
-                                        Orienter un bénéficiaire
-                                    {% endif %}
-                                </span> </a>
+                                {% include "insertion/includes/orientation_external_link_button.html" with service=service MobilizationEventKind=MobilizationEventKind request=request only %}
                             {% endif %}
                         </div>
                     {% endif %}

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -236,6 +236,8 @@ def start_orientation(request, service_uid):
         uid=service_uid,
         is_orientable_with_form=True,
     )
+    if service.should_mobilize_via_external_link:
+        return HttpResponseRedirect(reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid}))
     if not (job_seeker_public_id := request.GET.get("job_seeker_public_id")):
         logger.info(
             "orientation wizard start_without_job_seeker user=%s service_uid=%s",
@@ -272,6 +274,10 @@ class OrientationSelectJobSeekerView(FormView):
     def dispatch(self, request, *args, **kwargs):
         if not (request.from_employer or request.from_prescriber):
             raise PermissionDenied("Vous n'êtes pas autorisé à orienter un usager.")
+        if self.service.should_mobilize_via_external_link:
+            return HttpResponseRedirect(
+                reverse("insertion_views:service_detail", kwargs={"service_uid": self.service.uid})
+            )
         return super().dispatch(request, *args, **kwargs)
 
     def setup(self, request, *args, service_uid, **kwargs):

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -2694,6 +2694,114 @@
   
   '''
 # ---
+# name: TestServices.test_di_service_orientable_with_external_link_prefers_link
+  '''
+  <div class="c-box c-box--action">
+      <h2 class="visually-hidden">
+          Actions rapides
+      </h2>
+      <div class="form-row align-items-center gx-3">
+          <div class="form-group col-12 col-lg-auto">
+              <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-emplois-mobilization-external-link="https://test.example.com" data-emplois-mobilization-kind="service_ext_link" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://test.example.com" rel="noopener" target="_blank">
+                  <span>
+                      Lien externe
+                  </span>
+              </a>
+          </div>
+          <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
+              <div class="dropdown">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
+                      <i aria-hidden="true" class="ri-more-2-fill fw-medium">
+                      </i>
+                  </button>
+                  <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-ext-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                          <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+                          </i>
+                          <span>
+                              Copier le lien de cette page
+                          </span>
+                      </button>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestServices.test_dora_service_not_orientable_with_form_prefers_external_link
+  '''
+  <div class="c-box c-box--action">
+      <h2 class="visually-hidden">
+          Actions rapides
+      </h2>
+      <div class="form-row align-items-center gx-3">
+          <div class="form-group col-12 col-lg-auto">
+              <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-emplois-mobilization-external-link="https://test.example.com" data-emplois-mobilization-kind="service_ext_link" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="https://test.example.com" rel="noopener" target="_blank">
+                  <span>
+                      Lien externe
+                  </span>
+              </a>
+          </div>
+          <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
+              <div class="dropdown">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
+                      <i aria-hidden="true" class="ri-more-2-fill fw-medium">
+                      </i>
+                  </button>
+                  <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-ext-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                          <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+                          </i>
+                          <span>
+                              Copier le lien de cette page
+                          </span>
+                      </button>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestServices.test_dora_service_orientable_with_form_and_external_link_prefers_wizard
+  '''
+  <div class="c-box c-box--action">
+      <h2 class="visually-hidden">
+          Actions rapides
+      </h2>
+      <div class="form-row align-items-center gx-3">
+          <div class="form-group col-12 col-lg-auto">
+              <a class="btn btn-lg btn-white btn-block btn-ico justify-content-center" data-emplois-mobilization-kind="service_orientation" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="orienter-un-bénéficiaire" href="/insertion/orientations/test-orientable-ext-uid/start/">
+                  <span>
+                      Orienter un bénéficiaire
+                  </span>
+              </a>
+          </div>
+          <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
+              <div class="dropdown">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
+                      <i aria-hidden="true" class="ri-more-2-fill fw-medium">
+                      </i>
+                  </button>
+                  <div aria-labelledby="other_actions_orientation" class="dropdown-menu dropdown-menu-lg-end">
+                      <button class="btn btn-ico justify-content-start dropdown-item" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://testserver/insertion/services/test-orientable-ext-uid/" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="copier-lien-page" type="button">
+                          <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+                          </i>
+                          <span>
+                              Copier le lien de cette page
+                          </span>
+                      </button>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
 # name: TestStructures.test_card_view_anonymous_renders_description_tab
   dict({
     'num_queries': 6,

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -430,7 +430,7 @@ class TestServices:
             uid="test-external-uid",
             name="Service avec lien externe",
             updated_on="2025-01-15",
-            is_orientable_with_form=False,
+            is_orientable_with_form=True,
             mobilization_modes_professionals_external_form_link="https://test.example.com",
             mobilization_modes_professionals_external_form_link_text="Test link",
             structure__uid="test-structure-external-uid",
@@ -460,12 +460,12 @@ class TestServices:
         assertContains(response, self.ORIENT_BTN_LABEL)
         assertContains(response, f'href="{external_link}"')
 
-    def test_detail_orientable_with_external_link_prefers_wizard(self, client):
+    def test_di_service_orientable_with_external_link_prefers_link(self, client, snapshot):
         user = PrescriberFactory(membership=True)
         external_link = "https://test.example.com"
         service = ServiceFactory(
             uid="test-orientable-ext-uid",
-            name="Service orientable avec lien externe",
+            name="DI service orientable avec lien externe",
             updated_on="2025-01-15",
             is_orientable_with_form=True,
             mobilization_modes_professionals_external_form_link=external_link,
@@ -473,10 +473,51 @@ class TestServices:
             structure__uid="test-structure-orientable-ext-uid",
             structure__updated_on="2025-01-15",
         )
+
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertContains(response, f'href="{external_link}"')
+        assertNotContains(response, reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid}))
+        assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
+
+    def test_dora_service_orientable_with_form_and_external_link_prefers_wizard(self, client, snapshot):
+        user = PrescriberFactory(membership=True)
+        external_link = "https://test.example.com"
+        service = ServiceFactory(
+            uid="test-orientable-ext-uid",
+            name="Dora service orientable avec lien externe",
+            updated_on="2025-01-15",
+            is_orientable_with_form=True,
+            mobilization_modes_professionals_external_form_link=external_link,
+            mobilization_modes_professionals_external_form_link_text="Lien externe",
+            structure__uid="test-structure-orientable-ext-uid",
+            structure__updated_on="2025-01-15",
+            source__value="dora",
+        )
         client.force_login(user)
         response = client.get(self.get_service_url(service))
         assertContains(response, reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid}))
-        assertNotContains(response, f'href="{external_link}"')
+        assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
+
+    def test_dora_service_not_orientable_with_form_prefers_external_link(self, client, snapshot):
+        user = PrescriberFactory(membership=True)
+        external_link = "https://test.example.com"
+        service = ServiceFactory(
+            uid="test-orientable-ext-uid",
+            name="Dora service pas orientable avec le formulaire qui a un lien externe",
+            updated_on="2025-01-15",
+            is_orientable_with_form=False,
+            mobilization_modes_professionals_external_form_link=external_link,
+            mobilization_modes_professionals_external_form_link_text="Lien externe",
+            structure__uid="test-structure-orientable-ext-uid",
+            structure__updated_on="2025-01-15",
+            source__value="dora",
+        )
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertContains(response, f'href="{external_link}"')
+        assertNotContains(response, reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid}))
+        assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
 
     def test_detail_orientable_and_user_authenticated(self, client, snapshot):
         user = PrescriberFactory(membership=True)

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -283,6 +283,40 @@ def test_start_with_non_orientable_di_sources(client, settings, is_blacklisted, 
     assert response.status_code == status_code
 
 
+def test_start_orientation_redirects_when_external_link_preferred(client):
+    # A DI service that both is form-orientable and has an external link prefers the link:
+    # direct access to the form flow must bounce back to the service detail page.
+    prescriber = PrescriberFactory(membership=True)
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        source__value="other",
+        mobilization_modes_professionals_external_form_link="https://test.example.com",
+    )
+    assert service.should_mobilize_via_external_link
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+    service_detail_url = reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid})
+    client.force_login(prescriber)
+
+    response = client.get(start_url)
+    assertRedirects(response, service_detail_url, fetch_redirect_response=False)
+
+
+def test_orientation_select_job_seeker_redirects_when_external_link_preferred(client):
+    prescriber = PrescriberFactory(membership=True)
+    service = ServiceFactory(
+        is_orientable_with_form=True,
+        source__value="other",
+        mobilization_modes_professionals_external_form_link="https://test.example.com",
+    )
+    assert service.should_mobilize_via_external_link
+    select_url = reverse("insertion_views:orientation_select_job_seeker", kwargs={"service_uid": service.uid})
+    service_detail_url = reverse("insertion_views:service_detail", kwargs={"service_uid": service.uid})
+    client.force_login(prescriber)
+
+    response = client.get(select_url)
+    assertRedirects(response, service_detail_url, fetch_redirect_response=False)
+
+
 def test_session_isolation_between_users(client):
     prescriber = PrescriberFactory(membership=True)
     job_seeker = JobSeekerFactory(phone="0606060606")


### PR DESCRIPTION
## :thinking: Pourquoi ?

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

Cette PR change le comportement du bouton "Orienter le bénéficiaire" pour que les services DI qui ont un lien externe pour la mobilisation l'utilisent au lieu du formulaire d'orientation des emplois. 

Au cas où il y a des services dora qui sont pas orientables avec le formulaire, on garde le lien externe comme un fallback pour maintenir le comportement actuel. 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
