### PR TITLE
Notifications: Retirer les mentions relatives aux enquêtes de satisfactions dans les emails transactionnels

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -84,11 +84,6 @@ class PassAcceptedProfessionalNotification(ProfessionalNotification, EmailNotifi
     subject_template = "approvals/email/deliver_subject.txt"
     body_template = "approvals/email/deliver_body.txt"
 
-    def get_context(self):
-        context = super().get_context()
-        context.setdefault("siae_survey_link", context["job_application"].to_company.accept_survey_url)
-        return context
-
     def validate_context(self):
         if not self.context["job_application"].approval:
             raise RuntimeError("No approval found for this job application.")

--- a/itou/job_applications/notifications.py
+++ b/itou/job_applications/notifications.py
@@ -128,16 +128,6 @@ class JobApplicationAcceptedForProxyNotification(ProxyNotification):
     subject_template = "apply/email/accept_for_proxy_subject.txt"
     body_template = "apply/email/accept_for_proxy_body.txt"
 
-    def get_context(self):
-        context = super().get_context()
-        job_application = context["job_application"]
-        if job_application.sender_prescriber_organization:
-            # Include the survey link for all prescribers's organizations.
-            context["prescriber_survey_link"] = job_application.sender_prescriber_organization.accept_survey_url
-        else:
-            context["prescriber_survey_link"] = None
-        return context
-
 
 @notifications_registry.register
 class JobApplicationRefusedForJobSeekerNotification(JobSeekerNotification, EmailNotification):

--- a/itou/templates/apply/email/accept_for_proxy_body.txt
+++ b/itou/templates/apply/email/accept_for_proxy_body.txt
@@ -23,14 +23,4 @@ Ces dates sont uniquement pour information.
 {{ job_application.answer }}
 {% endif %}
 
-{% if prescriber_survey_link %}
----
-
-Afin de nous aider à évaluer la performance de notre service, accepteriez-vous de répondre à quelques questions ?
-
-Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ prescriber_survey_link }}
-
-Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
-{% endif %}
-
 {% endblock body %}

--- a/itou/templates/apply/email/accept_for_proxy_subject.txt
+++ b/itou/templates/apply/email/accept_for_proxy_subject.txt
@@ -1,4 +1,4 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
-Candidature acceptée et votre avis sur les emplois de l'inclusion
+Candidature acceptée
 {% endblock %}

--- a/itou/templates/approvals/email/deliver_body.txt
+++ b/itou/templates/approvals/email/deliver_body.txt
@@ -25,11 +25,6 @@ Au sein de la structure :
 
 Votre contact : {{ itou_help_center_url }}
 
-Afin de nous aider à évaluer la performance de notre service, accepteriez-vous de répondre à quelques questions ?
-Prenez 30 secondes pour nous donner votre avis ! Cliquez sur : {{ siae_survey_link }}
-
-Merci de votre participation et à très bientôt sur les emplois de l'inclusion !
-
 
 * Le reliquat est calculé sur la base d’un nombre de jours calendaires.
 Si le PASS IAE n'est pas suspendu, il décroit donc tous les jours (samedi, dimanche et jours fériés compris).

--- a/itou/templates/approvals/email/deliver_subject.txt
+++ b/itou/templates/approvals/email/deliver_subject.txt
@@ -1,7 +1,7 @@
 {% extends "layout/base_email_text_subject.txt" %}
 {% block subject %}
 {% if job_application.to_company.is_subject_to_iae_rules %}
-PASS IAE pour {{ job_application.job_seeker.get_inverted_full_name }} et avis sur les emplois de l'inclusion
+PASS IAE pour {{ job_application.job_seeker.get_inverted_full_name }}
 {% else %}
 Confirmation de l'embauche
 {% endif %}

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1365,7 +1365,7 @@ class TestJobApplicationNotifications:
         assert len(email.to) == 1
         assert len(email.bcc) == 0
         # Subject.
-        assert "Candidature acceptée et votre avis sur les emplois de l'inclusion" in email.subject
+        assert "Candidature acceptée" in email.subject
         # Body.
         assertion = assertIn if is_authorized_prescriber else assertNotInCaseFolded
         assertion(job_application.job_seeker.get_inverted_full_name(), email.body)
@@ -1381,8 +1381,6 @@ class TestJobApplicationNotifications:
             assert "Non référencé" in email.body
         else:
             assert job_application.job_seeker.last_assignment.advisor.get_full_name() in email.body
-        if is_authorized_prescriber:
-            assert job_application.sender_prescriber_organization.accept_survey_url in email.body
 
     def test_accept_for_proxy_without_hiring_end_at(self):
         job_application = JobApplicationFactory(sent_by_authorized_prescriber=True, hiring_end_at=None)
@@ -1725,7 +1723,7 @@ class TestJobApplicationNotifications:
 
 class TestJobApplicationWorkflow:
     SENT_PASS_EMAIL_SUBJECT = "PASS IAE pour"
-    ACCEPT_EMAIL_SUBJECT_PROXY = "Candidature acceptée et votre avis sur les emplois de l'inclusion"
+    ACCEPT_EMAIL_SUBJECT_PROXY = "Candidature acceptée"
     ACCEPT_EMAIL_SUBJECT_JOB_SEEKER = "Candidature acceptée"
 
     @pytest.fixture(autouse=True)

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1547,7 +1547,6 @@ class TestJobApplicationNotifications:
         assert job_application.to_company.post_code in email.body
         assert job_application.to_company.city in email.body
         assert global_constants.ITOU_HELP_CENTER_URL in email.body
-        assert job_application.to_company.accept_survey_url in email.body
 
     def test_notifications_deliver_approval_without_hiring_end_at(self):
         job_seeker = JobSeekerFactory()
@@ -1571,10 +1570,7 @@ class TestJobApplicationNotifications:
 
         email = job_application.notifications_deliver_approval(job_application.to_company.members.first()).build()
 
-        assert (
-            f"[TEST] PASS IAE pour {job_application.job_seeker.get_inverted_full_name()} et avis sur les emplois "
-            "de l'inclusion" == email.subject
-        )
+        assert f"[TEST] PASS IAE pour {job_application.job_seeker.get_inverted_full_name()}" == email.subject
         assert "PASS IAE" in email.body
 
     def test_notifications_deliver_approval_when_not_subject_to_eligibility_rules(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela fait doublon avec la question NPS dispo sur les interfaces.
[Carte Notion](https://app.notion.com/p/gip-inclusion/2845f321b60480348f9bc3c2c5fdf002?v=3025f321b60480a2b909000c5485eb3b&p=3a45f321b604803db39ae9f329e8fbe5&pm=s)

## :cake: Comment ? <!-- optionnel -->
Retirer toutes les références aux enquêtes de satisfaction présentes dans les templates de mail.

## :rotating_light: À vérifier

Il faut mettre à jour [le figma des notifs emails](https://www.figma.com/board/lkN2OepJYud4m1jKM70oYU/Notifications-e-mail--Les-Emplois-de-l-inclusion-?node-id=0-1&p=f&t=GQRUMwykP7T9GBnP-0) également, mais je vois pas trop quoi modifier ? :thinking: 


## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
