### PR TITLE
Contrôle a posteriori : Améliorations UI/UX

### DIFF
--- a/itou/templates/siae_evaluations/evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_detail.html
@@ -69,7 +69,7 @@
                     </p>
 
                     {% if not evaluated_siae.evaluation_is_final %}
-                        <div class="c-box p-3 p-md-4 d-flex align-items-center">
+                        <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
                             <div class="p-0 flex-grow-1 m-0">
                                 Lorsque vous aurez contrôlé <strong>tous vos justificatifs</strong> pour cette SIAE, veuillez valider le contrôle effectué pour la notifier de son résultat.
                             </div>
@@ -142,7 +142,7 @@
                     {% endfor %}
 
                     {% if not evaluated_siae.evaluation_is_final and evaluated_siae.can_review %}
-                        <div class="c-box p-3 p-md-4 d-flex align-items-center">
+                        <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
                             <div class="p-0 flex-grow-1 m-0">
                                 Lorsque vous aurez contrôlé <strong>tous vos justificatifs</strong> pour cette SIAE, veuillez valider le contrôle effectué pour la notifier de son résultat.
                             </div>

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -29,5 +29,5 @@
         {% endfor %}
     {% endif %}
 
-    {% itou_buttons_form primary_label="Enregistrer ce(s) critère(s)" %}
+    {% itou_buttons_form primary_label="Enregistrer ce(s) critère(s)" reset_url=back_url %}
 </form>

--- a/itou/templates/siae_evaluations/includes/criterion_validation.html
+++ b/itou/templates/siae_evaluations/includes/criterion_validation.html
@@ -4,9 +4,9 @@
            rel="noopener"
            target="_blank"
            class="btn btn-sm btn-link"
-           aria-label="Vérifier ce justificatif (ouverture dans un nouvel onglet)">
+           aria-label="Consulter ce justificatif (ouverture dans un nouvel onglet)">
             {% if evaluated_siae.state == "SUBMITTED" or evaluated_siae.state == "ACCEPTED" or evaluated_siae.state == "REFUSED" %}
-                Vérifier ce justificatif
+                Consulter ce justificatif
             {% else %}
                 Revoir ce justificatif
             {% endif %}

--- a/itou/templates/siae_evaluations/includes/submit_proofs_box.html
+++ b/itou/templates/siae_evaluations/includes/submit_proofs_box.html
@@ -1,0 +1,19 @@
+<div class="c-box p-3 p-md-4 d-flex align-items-center">
+    <div class="p-0 flex-grow-1 m-0">
+        {% if proofs_submitted %}
+            Vos justificatifs ont bien été <strong>transmis</strong>.
+        {% else %}
+            Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>, veuillez les soumettre à validation.
+            <br>
+        {% endif %}
+        La DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
+    </div>
+    {% if not proofs_submitted %}
+        <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
+            {% csrf_token %}
+            <button class="btn {% if is_submittable %}btn-primary{% else %}btn-primary disabled{% endif %}">
+                Soumettre à validation
+            </button>
+        </form>
+    {% endif %}
+</div>

--- a/itou/templates/siae_evaluations/includes/submit_proofs_box.html
+++ b/itou/templates/siae_evaluations/includes/submit_proofs_box.html
@@ -11,9 +11,7 @@
     {% if not proofs_submitted %}
         <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
             {% csrf_token %}
-            <button class="btn {% if is_submittable %}btn-primary{% else %}btn-primary disabled{% endif %}">
-                Soumettre à validation
-            </button>
+            <button class="btn btn-primary{% if not is_submittable %} disabled{% endif %}">Soumettre à validation</button>
         </form>
     {% endif %}
 </div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -33,19 +33,7 @@
                     <p class="h2 mb-0">Liste de mes auto-prescriptions à justifier</p>
                     <p>Contrôle initié le {{ evaluated_siae.evaluation_campaign.evaluations_asked_at|date:"d F Y" }}</p>
 
-                    <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
-                        <div class="p-0 flex-grow-1 m-0">
-                            Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>, veuillez les soumettre à validation.
-                            <br>
-                            La DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
-                        </div>
-                        <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
-                            {% csrf_token %}
-                            <button class="btn {% if is_submittable %}btn-primary{% else %}btn-primary disabled{% endif %}">
-                                Soumettre à validation
-                            </button>
-                        </form>
-                    </div>
+                    {% include "siae_evaluations/includes/submit_proofs_box.html" with csrf_token=csrf_token evaluated_siae=evaluated_siae is_submittable=is_submittable proofs_submitted=proofs_submitted only %}
 
                     {% for evaluated_job_application in evaluated_job_applications %}
                         {% with should_select_criteria=evaluated_job_application.should_select_criteria %}
@@ -54,17 +42,7 @@
                     {% endfor %}
 
                     {% if is_submittable %}
-                        <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
-                            <div class="p-0 flex-grow-1 m-0">
-                                Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>, veuillez les soumettre à validation.
-                                <br>
-                                La DDETS effectuera un contrôle de ceux-ci et reviendra vers vous.
-                            </div>
-                            <form method="post" action="{% url 'siae_evaluations_views:siae_submit_proofs' evaluated_siae.pk %}">
-                                {% csrf_token %}
-                                <button class="btn btn-primary">Soumettre à validation</button>
-                            </form>
-                        </div>
+                        {% include "siae_evaluations/includes/submit_proofs_box.html" with csrf_token=csrf_token evaluated_siae=evaluated_siae is_submittable=is_submittable proofs_submitted=proofs_submitted only %}
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -33,7 +33,7 @@
                     <p class="h2 mb-0">Liste de mes auto-prescriptions à justifier</p>
                     <p>Contrôle initié le {{ evaluated_siae.evaluation_campaign.evaluations_asked_at|date:"d F Y" }}</p>
 
-                    <div class="c-box p-3 p-md-4 d-flex align-items-center">
+                    <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
                         <div class="p-0 flex-grow-1 m-0">
                             Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>, veuillez les soumettre à validation.
                             <br>
@@ -54,7 +54,7 @@
                     {% endfor %}
 
                     {% if is_submittable %}
-                        <div class="c-box p-3 p-md-4 d-flex align-items-center">
+                        <div class="c-box p-3 p-md-4 d-flex align-items-center gap-3">
                             <div class="p-0 flex-grow-1 m-0">
                                 Lorsque vous aurez ajouté <strong>tous vos justificatifs</strong>, veuillez les soumettre à validation.
                                 <br>

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -827,7 +827,7 @@ def siae_submit_proofs(request, evaluated_siae_pk):
         request,
         (
             "Justificatifs transmis||Leur contrôle est à la charge de votre DDETS."
-            "Une fois finalisée, vous serez notifié du résultat par email."
+            "Une fois finalisé, vous serez notifié du résultat par email."
         ),
         extra_tags="toast",
     )

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -652,6 +652,7 @@ def siae_job_applications_list(
         "evaluated_siae": evaluated_siae,
         "evaluated_job_applications": evaluated_job_applications,
         "is_submittable": evaluated_siae.can_submit,
+        "proofs_submitted": evaluated_siae.state == evaluation_enums.EvaluatedSiaeState.SUBMITTED,
         "back_url": back_url,
     }
     return render(request, template_name, context)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -607,7 +607,7 @@ def institution_evaluated_siae_validation(request, evaluated_siae_pk):
         messages.success(
             request,
             mark_safe(
-                "<b>Résultats enregistrés !</b><br>Merci d'avoir pris le temps de contrôler les pièces justificatives."
+                "<b>Résultats enregistrés</b><br>Merci d'avoir pris le temps de contrôler les pièces justificatives."
             ),
         )
 
@@ -826,7 +826,7 @@ def siae_submit_proofs(request, evaluated_siae_pk):
     messages.success(
         request,
         (
-            "Justificatifs transmis !||Leur contrôle est à la charge de votre DDETS."
+            "Justificatifs transmis||Leur contrôle est à la charge de votre DDETS."
             "Une fois finalisée, vous serez notifié du résultat par email."
         ),
         extra_tags="toast",

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -643,6 +643,7 @@ def siae_job_applications_list(
             "job_application__approval",
         )
         .prefetch_related("evaluated_administrative_criteria")
+        .order_by("job_application__job_seeker__last_name", "job_application__job_seeker__first_name")
     )
 
     back_url = get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))

--- a/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
@@ -627,7 +627,8 @@
           LEFT OUTER JOIN "siae_evaluations_calendar" ON ("siae_evaluations_evaluationcampaign"."calendar_id" = "siae_evaluations_calendar"."id")
           INNER JOIN "companies_company" ON ("siae_evaluations_evaluatedsiae"."siae_id" = "companies_company"."id")
           WHERE "siae_evaluations_evaluatedjobapplication"."evaluated_siae_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "users_user"."last_name" ASC,
+                   "users_user"."first_name" ASC
         ''',
       }),
       dict({

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -4268,7 +4268,7 @@ class TestInstitutionEvaluatedSiaeValidationView:
             [
                 messages.Message(
                     messages.SUCCESS,
-                    "<b>Résultats enregistrés !</b><br>"
+                    "<b>Résultats enregistrés</b><br>"
                     "Merci d'avoir pris le temps de contrôler les pièces justificatives.",
                 )
             ],
@@ -4291,7 +4291,7 @@ class TestInstitutionEvaluatedSiaeValidationView:
             [
                 messages.Message(
                     messages.SUCCESS,
-                    "<b>Résultats enregistrés !</b><br>"
+                    "<b>Résultats enregistrés</b><br>"
                     "Merci d'avoir pris le temps de contrôler les pièces justificatives.",
                 )
             ],

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -493,7 +493,10 @@ class TestSiaeJobApplicationListView:
         evaluated_administrative_criteria.submitted_at = fake_now
         evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = client.get(self.url(evaluated_job_application.evaluated_siae))
-        assertContains(response, submit_disabled, html=True, count=1)
+        # Nothing left to submit: tell the SIAE uploaded proofs have been transmitted.
+        assertNotContains(response, submit_disabled, html=True)
+        assertNotContains(response, submit_active, html=True)
+        assertContains(response, "Vos justificatifs ont bien été <strong>transmis</strong>.", count=1)
         assertNotContains(response, select_criteria)
         assertNotContains(response, upload_proof)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quelques retouches – essentiellement cosmétiques – visant à rendre la navigation du **contrôle a posteriori** plus agréable.

## :cake: Comment ?

- Ajout d'une marge entre le texte et le bouton :
<img width="2204" height="202" alt="image" src="https://github.com/user-attachments/assets/5dcf6ef8-0578-4495-9500-f79ba5e6f7e6" />

- Tri des auto-prescriptions par nom de famille – elles n'étaient pas triées. (On aurait pu vouloir les trier par statut mais celui-ci est calculé dynamiquement donc pas terrible.)
<img width="1454" height="1316" alt="image" src="https://github.com/user-attachments/assets/6bbf7470-cdf4-4f39-b1b6-d7ab7c98defb" />

- Sur la vue en liste des auto-prescriptions à justifier (côté SIAE), le contenu du bloc `Lorsque vous aurez ajouté tous vos justificatifs...` change une fois les justificatifs soumis, et ce, afin d'indiquer clairement à l'utilisateur qu'il a _fait le job_. [Partial créé pour ce bloc qui est répété en bas de la page lorsque la SIAE peut transmettre les justificatifs.]

AVANT :
<img width="1824" height="202" alt="image" src="https://github.com/user-attachments/assets/318bccc7-9a70-40c8-9ead-e94fa581208d" />
APRÈS :
<img width="1824" height="150" alt="image" src="https://github.com/user-attachments/assets/cf1f15cd-7696-456c-b4af-c4034e5903da" />

- Côté DDETS, un bouton `Retour` ramène sur la page de sélection de la SIAE à contrôler – il n'apparaissait plus après consultation d'une SIAE. [`fallback_url` ajoutée + ancres sur le template.] **[Curieusement, les tests avaient l'air de prévoir ce comportement ; à vérifier.]**

AVANT :
<img width="2560" height="940" alt="image" src="https://github.com/user-attachments/assets/a6b8cb43-5078-4bdf-af79-3d500ae57019" />
APRÈS :
<img width="2560" height="1058" alt="image" src="https://github.com/user-attachments/assets/dcee38ff-e341-4f45-a0ab-7f2a306d33a7" />

- Côté DDETS, ajout des informations sur la SIAE contrôlée :
<img width="2940" height="1436" alt="image" src="https://github.com/user-attachments/assets/cc015967-45a2-4f11-b41b-8b9a3fac764b" />

## :desert_island: Comment tester ?

🤖

## :computer: Captures d'écran

.

