### PR TITLE
Tech : Tracking Matomo du filtre "Fin de parcours IAE à venir"

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/pass.html
+++ b/itou/templates/apply/includes/job_applications_filters/pass.html
@@ -1,6 +1,6 @@
 {% load django_bootstrap5 %}
 
-{% if filters_form.pass_iae_suspended %}
+{% if filters_form.approval_suspended %}
     <hr>
     <fieldset>
         <legend>
@@ -10,9 +10,9 @@
         </legend>
         <div class="my-3 collapse" id="collapsePassIAE">
             <ul>
-                <li>{% bootstrap_field filters_form.pass_iae_active wrapper_class="" %}</li>
-                <li>{% bootstrap_field filters_form.pass_iae_suspended wrapper_class="" %}</li>
-                <li>{% bootstrap_field filters_form.pass_iae_expired wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_active wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_suspended wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_expired wrapper_class="" %}</li>
             </ul>
         </div>
     </fieldset>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/approval_state.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/approval_state.html
@@ -17,9 +17,9 @@
             <li>
                 <strong class="dropdown-header">PASS IAE</strong>
             </li>
-            <li>{% bootstrap_field filters_form.pass_iae_active wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.pass_iae_expired wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.no_pass_iae wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.approval_active wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.approval_expired wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.no_approval wrapper_class="dropdown-item" %}</li>
         </ul>
     </div>
 {% else %}
@@ -53,13 +53,13 @@
         <div class="my-3 collapse" id="collapseApproval">
             <ul>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.pass_iae_active wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_active wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.pass_iae_expired wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_expired wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.no_pass_iae wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.no_approval wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
             </ul>
         </div>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
@@ -1,0 +1,34 @@
+{% load django_bootstrap5 %}
+
+{% if btn_dropdown_filter|default:False %}
+    <div class="dropdown">
+        <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+            Fin de parcours IAE à venir
+        </button>
+        <ul class="dropdown-menu">
+            <li>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
+        </ul>
+    </div>
+{% else %}
+    <fieldset>
+        <legend>
+            <button class="btn btn-outline-transparent has-collapse-caret collapsed"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#collapseEndOfJourney"
+                    type="button"
+                    aria-expanded="false"
+                    aria-controls="collapseEndOfJourney">Fin de parcours IAE à venir</button>
+        </legend>
+        <div class="my-3 collapse" id="collapseEndOfJourney">
+            <ul>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.contract_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load matomo %}
 
 {% if btn_dropdown_filter|default:False %}
     <div class="dropdown">
@@ -6,8 +7,8 @@
             Fin de parcours IAE à venir
         </button>
         <ul class="dropdown-menu">
-            <li>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-pass-iae" %}>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-contrat-iae" %}>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
         </ul>
     </div>
 {% else %}
@@ -22,10 +23,10 @@
         </legend>
         <div class="my-3 collapse" id="collapseEndOfJourney">
             <ul>
-                <li>
+                <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-pass-iae" %}>
                     {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
-                <li>
+                <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-contrat-iae" %}>
                     {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.contract_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
             </ul>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
@@ -1,5 +1,9 @@
 <div class="offcanvas-body" id="offcanvasApplyFiltersContent"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form only %}
+    {% if request.from_authorized_prescriber %}
+        <hr>
+        {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form only %}
+    {% endif %}
     {% if list_organization %}
         <hr>
         {% include "job_seekers_views/includes/job_seekers_filters/organization_members.html" with filters_form=filters_form only %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -19,6 +19,9 @@
                     </li>
                 </ul>
             </div>
+            {% if request.from_authorized_prescriber %}
+                {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form btn_dropdown_filter=True only %}
+            {% endif %}
             {% if list_organization %}
                 <button type="button" class="btn btn-ico btn-dropdown-filter" data-bs-toggle="offcanvas" data-bs-target="#offcanvasApplyFilters" aria-controls="offcanvasApplyFilters">
                     <i class="ri-sound-module-fill fw-medium" aria-hidden="true"></i>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -842,25 +842,25 @@ class FilterJobApplicationsForm(forms.Form):
         if states := data.get("states"):
             filters.append(Q(state__in=states))
 
-        pass_iae_key_to_filter = {
+        approval_key_to_filter = {
             # Simplification of CommonApprovalQuerySet.valid_lookup()
             # The date is not enough to know if an approval is valid or not
-            "pass_iae_active": Q(approval__end_at__gte=timezone.localdate(), has_suspended_approval=False),
+            "approval_active": Q(approval__end_at__gte=timezone.localdate(), has_suspended_approval=False),
             # This is NOT what we want but how things work currently:
-            # if you check pass_iae_active, the value of pass_iae_suspended is ignored
+            # if you check approval_active, the value of approval_suspended is ignored
             # Filter on the `has_suspended_approval` annotation, which is set in `with_list_related_data()`.
-            "pass_iae_suspended": Q(has_suspended_approval=True),
-            "pass_iae_expired": Q(approval__end_at__lt=timezone.localdate()),
+            "approval_suspended": Q(has_suspended_approval=True),
+            "approval_expired": Q(approval__end_at__lt=timezone.localdate()),
         }
 
-        if any([data.get(key) for key in pass_iae_key_to_filter.keys()]):
-            if data.get("pass_iae_active") or data.get("pass_iae_suspended"):
+        if any([data.get(key) for key in approval_key_to_filter.keys()]):
+            if data.get("approval_active") or data.get("approval_suspended"):
                 queryset = queryset.with_has_suspended_approval()
-            pass_status_filter = Q()
-            for key, filter in pass_iae_key_to_filter.items():
+            approval_status_filter = Q()
+            for key, filter in approval_key_to_filter.items():
                 if data.get(key):
-                    pass_status_filter |= filter
-            filters.append(pass_status_filter)
+                    approval_status_filter |= filter
+            filters.append(approval_status_filter)
 
         if start_date := data.get("start_date"):
             filters.append(Q(created_at__gte=start_date))
@@ -934,9 +934,9 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
             }
         ),
     )
-    pass_iae_suspended = forms.BooleanField(label="Suspendu", required=False)
-    pass_iae_active = forms.BooleanField(label="Actif", required=False)
-    pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
+    approval_suspended = forms.BooleanField(label="Suspendu", required=False)
+    approval_active = forms.BooleanField(label="Actif", required=False)
+    approval_expired = forms.BooleanField(label="Expiré", required=False)
     criteria = forms.MultipleChoiceField(required=False, label="", widget=Select2MultipleWidget)
     eligibility_validated = forms.BooleanField(label="Valide", required=False)
     eligibility_pending = forms.BooleanField(label="À valider", required=False)
@@ -1097,9 +1097,9 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
             del self.fields["criteria"]
             del self.fields["eligibility_validated"]
             del self.fields["eligibility_pending"]
-            del self.fields["pass_iae_active"]
-            del self.fields["pass_iae_suspended"]
-            del self.fields["pass_iae_expired"]
+            del self.fields["approval_active"]
+            del self.fields["approval_suspended"]
+            del self.fields["approval_expired"]
 
         if not company.can_have_prior_action:
             # Drop "pré-embauche" state from filter for non-GEIQ companies

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.db.models import OuterRef, Q, Subquery
 from django.forms import ValidationError
@@ -9,6 +11,7 @@ from itou.approvals.models import Approval
 from itou.asp import models as asp_models
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
+from itou.companies.models import Contract
 from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.forms import JobSeekerProfileFieldsMixin, JobSeekerProfileModelForm
 from itou.users.models import JobSeekerProfile, JobSeekerProfileQuerySet, NirModificationRequest, User
@@ -18,6 +21,10 @@ from itou.utils.perms.utils import can_view_personal_information
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.validators import validate_nir
 from itou.utils.widgets import DuetDatePickerWidget
+
+
+APPROVAL_ENDING_SOON_DAYS = 90
+IAE_CONTRACT_ENDING_SOON_DAYS = 30
 
 
 class FilterForm(forms.Form):
@@ -44,12 +51,27 @@ class FilterForm(forms.Form):
         label="Nom de la personne", required=False, widget=Select2MultipleWidget
     )
 
+    # Fields only for authorized prescribers set in __init__
+    approval_ending_soon = None
+    contract_ending_soon = None
+
     def __init__(self, job_seeker_qs, data, *args, request, **kwargs):
         super().__init__(data, *args, **kwargs)
         self.fields["job_seeker"].choices = self._get_choices_for_job_seeker(job_seeker_qs, request)
         if request.current_organization:
             self.fields["organization_members"].choices = self._get_choices_for_organization_members(
                 job_seeker_qs, request.current_organization
+            )
+        if request.from_authorized_prescriber:
+            self.fields["approval_ending_soon"] = forms.BooleanField(
+                label="PASS IAE bientôt expiré",
+                required=False,
+                help_text=f"Dans les {APPROVAL_ENDING_SOON_DAYS} prochains jours",
+            )
+            self.fields["contract_ending_soon"] = forms.BooleanField(
+                label="Contrat IAE bientôt terminé",
+                required=False,
+                help_text=f"Dans les {IAE_CONTRACT_ENDING_SOON_DAYS} prochains jours",
             )
 
     def _get_choices_for_job_seeker(self, job_seeker_qs, request):
@@ -92,24 +114,58 @@ class FilterForm(forms.Form):
         elif self.cleaned_data.get("eligibility_pending") and not self.cleaned_data.get("eligibility_validated"):
             queryset = queryset.eligibility_pending()
 
-        # Approval (PASS IAE) status (all checkboxes checked = all cases, so do not filter out results)
-        approval_filters = [
+        today = timezone.localdate()
+
+        # There are 2 filters using the user approval :
+        # - The  status
+        # - The upcoming approval end
+
+        # Approval status (all checkboxes checked = all cases, so do not filter out results).
+        approval_status_filters = [
             self.cleaned_data.get(key) for key in ("approval_active", "approval_expired", "no_approval")
         ]
-        if any(approval_filters) and not all(approval_filters):
-            last_approval_end_at = Subquery(
-                Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
-            )
-            queryset = queryset.annotate(last_approval_end_at=last_approval_end_at)
+        use_approval_status = any(approval_status_filters) and not all(approval_status_filters)
 
+        # The "end of IAE journey" filters are reserved for authorized prescribers.
+        approval_ending_soon = self.cleaned_data.get("approval_ending_soon")
+
+        if use_approval_status or approval_ending_soon:
+            queryset = queryset.annotate(
+                last_approval_end_at=Subquery(
+                    Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
+                )
+            )
+
+        if use_approval_status:
             approval_status_filter = Q()
             if self.cleaned_data.get("approval_active"):
-                approval_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
+                approval_status_filter |= Q(last_approval_end_at__gte=today)
             if self.cleaned_data.get("approval_expired"):
-                approval_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
+                approval_status_filter |= Q(last_approval_end_at__lt=today)
             if self.cleaned_data.get("no_approval"):
                 approval_status_filter |= Q(last_approval_end_at__isnull=True)
             filters.append(approval_status_filter)
+
+        # Upcoming end of IAE journey (authorized prescribers only): the two conditions are combined
+        # with AND when both are checked. approval ending soon is reliable; IAE contract end dates come
+        # from ASP data that is partial and delayed by a few days.
+        contract_ending_soon = self.cleaned_data.get("contract_ending_soon")
+        if approval_ending_soon or contract_ending_soon:
+            end_of_journey_filter = Q()
+            if approval_ending_soon:
+                approval_window = (today, today + datetime.timedelta(days=APPROVAL_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_approval_end_at__range=approval_window)
+            if contract_ending_soon:
+                queryset = queryset.annotate(
+                    last_contract_end_date=Subquery(
+                        Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
+                        .order_by("-end_date")
+                        .values("end_date")[:1]
+                    )
+                )
+                contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_contract_end_date__range=contract_window)
+            filters.append(end_of_journey_filter)
 
         if self.cleaned_data.get("is_stalled"):
             queryset = queryset.filter(

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -34,9 +34,9 @@ class FilterForm(forms.Form):
     eligibility_validated = forms.BooleanField(label="Valide", required=False)
     eligibility_pending = forms.BooleanField(label="À valider", required=False)
 
-    pass_iae_active = forms.BooleanField(label="Valide", required=False)
-    pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
-    no_pass_iae = forms.BooleanField(label="Aucun", required=False)
+    approval_active = forms.BooleanField(label="Valide", required=False)
+    approval_expired = forms.BooleanField(label="Expiré", required=False)
+    no_approval = forms.BooleanField(label="Aucun", required=False)
 
     is_stalled = forms.BooleanField(label="N’afficher que les usagers sans solution", required=False)
 
@@ -93,23 +93,23 @@ class FilterForm(forms.Form):
             queryset = queryset.eligibility_pending()
 
         # Approval (PASS IAE) status (all checkboxes checked = all cases, so do not filter out results)
-        pass_iae_filters = [
-            self.cleaned_data.get(key) for key in ("pass_iae_active", "pass_iae_expired", "no_pass_iae")
+        approval_filters = [
+            self.cleaned_data.get(key) for key in ("approval_active", "approval_expired", "no_approval")
         ]
-        if any(pass_iae_filters) and not all(pass_iae_filters):
+        if any(approval_filters) and not all(approval_filters):
             last_approval_end_at = Subquery(
                 Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
             )
             queryset = queryset.annotate(last_approval_end_at=last_approval_end_at)
 
-            pass_status_filter = Q()
-            if self.cleaned_data.get("pass_iae_active"):
-                pass_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
-            if self.cleaned_data.get("pass_iae_expired"):
-                pass_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
-            if self.cleaned_data.get("no_pass_iae"):
-                pass_status_filter |= Q(last_approval_end_at__isnull=True)
-            filters.append(pass_status_filter)
+            approval_status_filter = Q()
+            if self.cleaned_data.get("approval_active"):
+                approval_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
+            if self.cleaned_data.get("approval_expired"):
+                approval_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
+            if self.cleaned_data.get("no_approval"):
+                approval_status_filter |= Q(last_approval_end_at__isnull=True)
+            filters.append(approval_status_filter)
 
         if self.cleaned_data.get("is_stalled"):
             queryset = queryset.filter(

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -7612,8 +7612,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_active">
+                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_active">
                                       Actif
                                   </label>
                               </div>
@@ -7622,8 +7622,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_suspended">
+                                  <input class="form-check-input is-valid" id="id_approval_suspended" name="approval_suspended" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_suspended">
                                       Suspendu
                                   </label>
                               </div>
@@ -7632,8 +7632,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_expired">
                                       Expiré
                                   </label>
                               </div>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -5143,8 +5143,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_active">
+                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_active">
                                       Actif
                                   </label>
                               </div>
@@ -5153,8 +5153,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_suspended">
+                                  <input class="form-check-input is-valid" id="id_approval_suspended" name="approval_suspended" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_suspended">
                                       Suspendu
                                   </label>
                               </div>
@@ -5163,8 +5163,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_expired">
                                       Expiré
                                   </label>
                               </div>

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -481,7 +481,7 @@ class TestProcessListSiae:
         JobApplicationFactory(sent_by_prescriber_alone=True, to_company=company)
 
         # Without approval
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True})
         assert len(response.context["job_applications_page"].object_list) == 0
 
         # With a job_application with an approval
@@ -493,15 +493,15 @@ class TestProcessListSiae:
             approval__start_at=yesterday,
             to_company=company,
         )
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # Check that adding pass_iae_suspended does not hide the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True, "pass_iae_suspended": True})
+        # Check that adding approval_suspended does not hide the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True, "approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # But pass_iae_suspended alone does not show the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_suspended": True})
+        # But approval_suspended alone does not show the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_suspended": True})
         assert response.context["job_applications_page"].object_list == []
 
         # Now with a suspension
@@ -510,15 +510,15 @@ class TestProcessListSiae:
             start_at=yesterday,
             end_at=today + timezone.timedelta(days=2),
         )
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_suspended": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # Check that adding pass_iae_active does not hide the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True, "pass_iae_suspended": True})
+        # Check that adding approval_active does not hide the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True, "approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
         # So far no approval was expired
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_expired": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_expired": True})
         assert response.context["job_applications_page"].object_list == []
 
         jobapp_with_expired_pass = JobApplicationFactory(
@@ -531,8 +531,8 @@ class TestProcessListSiae:
             to_company=company,
         )
 
-        # The pass_iae_expired filter works as expected
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_expired": True})
+        # The approval_expired filter works as expected
+        response = client.get(reverse("apply:list_for_siae"), {"approval_expired": True})
         assert response.context["job_applications_page"].object_list == [jobapp_with_expired_pass]
 
     def test_list_for_siae_filtered_by_eligibility_state(self, client):
@@ -706,7 +706,7 @@ class TestProcessListSiae:
                     "end_date": timezone.localdate(job_app.created_at).strftime(date_format),
                     "sender_prescriber_organizations": [job_app.sender_prescriber_organization.id],
                     "senders": [job_app.sender.id],
-                    "pass_iae_active": True,
+                    "approval_active": True,
                     "eligibility_validated": True,
                     "criteria": [level1_criterion.pk],
                     "departments": ["37"],

--- a/tests/www/apply/test_transfer.py
+++ b/tests/www/apply/test_transfer.py
@@ -431,7 +431,7 @@ def test_start_session_internal_transfer(client):
     client.force_login(employer)
 
     # This will set the session back url
-    list_url_with_params = reverse("apply:list_for_siae") + "?pass_iae_active=on"
+    list_url_with_params = reverse("apply:list_for_siae") + "?approval_active=on"
     client.get(
         reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
         + f"?back_url={quote(list_url_with_params)}"

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -617,6 +617,1969 @@
   
   '''
 # ---
+# name: test_filtered_by_end_of_iae_journey[/job-seekers/list-organization]
+  dict({
+    'num_queries': 16,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_nexususer"."id",
+                 "nexus_nexususer"."source",
+                 "nexus_nexususer"."source_id",
+                 "nexus_nexususer"."source_kind",
+                 "nexus_nexususer"."first_name",
+                 "nexus_nexususer"."last_name",
+                 "nexus_nexususer"."email",
+                 "nexus_nexususer"."phone",
+                 "nexus_nexususer"."last_login",
+                 "nexus_nexususer"."auth",
+                 "nexus_nexususer"."kind",
+                 "nexus_nexususer"."updated_at",
+                 COALESCE(
+                            (SELECT U0."valid_since" AS "valid_since"
+                             FROM "nexus_nexusressourcesyncstatus" U0
+                             WHERE U0."service" = ("nexus_nexususer"."source")
+                             ORDER BY RANDOM() ASC
+                             LIMIT 1), %s) AS "_threshold"
+          FROM "nexus_nexususer"
+          WHERE ("nexus_nexususer"."updated_at" >= (COALESCE(
+                                                               (SELECT U0."valid_since" AS "valid_since"
+                                                                FROM "nexus_nexusressourcesyncstatus" U0
+                                                                WHERE U0."service" = ("nexus_nexususer"."source")
+                                                                ORDER BY RANDOM() ASC
+                                                                LIMIT 1), %s))
+                 AND "nexus_nexususer"."email" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_activatedservice"."id",
+                 "nexus_activatedservice"."user_id",
+                 "nexus_activatedservice"."service",
+                 "nexus_activatedservice"."created_at"
+          FROM "nexus_activatedservice"
+          WHERE "nexus_activatedservice"."user_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s))))
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41
+          ORDER BY "users_user"."last_name" ASC,
+                   "users_user"."first_name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE ("prescribers_prescribermembership"."organization_id" = %s
+                 AND "users_user"."id" IN
+                   (SELECT V1."professional_id" AS "job_seeker_assignments__professional"
+                    FROM "users_user" V0
+                    LEFT OUTER JOIN "users_jobseekerassignment" V1 ON (V0."id" = V1."job_seeker_id")
+                    WHERE (V0."kind" = %s
+                           AND V0."id" IN
+                             (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                              FROM "users_jobseekerassignment" U0
+                              WHERE ((U0."company_id" IS NULL
+                                      AND U0."prescriber_organization_id" IS NULL
+                                      AND U0."professional_id" = %s)
+                                     OR (U0."company_id" IS NULL
+                                         AND U0."prescriber_organization_id" = %s))))
+                    GROUP BY V0."id",
+                             1))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouPaginator.count[<site-packages>/django/core/paginator.py]',
+          'pager[utils/pagination.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                    COALESCE(
+                               (SELECT COUNT(U0."id") AS "count"
+                                FROM "job_applications_jobapplication" U0
+                                WHERE (((U0."sender_id" = %s
+                                         AND U0."sender_prescriber_organization_id" IS NULL)
+                                        OR U0."sender_prescriber_organization_id" = %s)
+                                       AND U0."job_seeker_id" = ("users_user"."id"))
+                                GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+               (SELECT MAX(U0."updated_at") AS "last_action_at"
+                FROM "users_jobseekerassignment" U0
+                WHERE (((U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" IS NULL
+                         AND U0."professional_id" = %s)
+                        OR (U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" = %s))
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                GROUP BY U0."job_seeker_id"
+                LIMIT 1) AS "last_updated_at",
+          
+               (SELECT U0."id" AS "id"
+                FROM "eligibility_eligibilitydiagnosis" U0
+                WHERE (U0."expires_at" > %s
+                       AND U0."author_kind" = %s
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY U0."created_at" DESC
+                LIMIT 1) AS "valid_eligibility_diagnosis",
+          
+               (SELECT U0."end_at" AS "end_at"
+                FROM "approvals_approval" U0
+                WHERE U0."user_id" = ("users_user"."id")
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_approval_end_at",
+          
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s)))
+                    AND
+                      (SELECT U0."end_at" AS "end_at"
+                       FROM "approvals_approval" U0
+                       WHERE U0."user_id" = ("users_user"."id")
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id",
+                      1,
+                      2,
+                      4) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors",
+          
+            (SELECT U0."end_at" AS "end_at"
+             FROM "approvals_approval" U0
+             WHERE U0."user_id" = ("users_user"."id")
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_approval_end_at",
+          
+            (SELECT U0."end_date" AS "end_date"
+             FROM "companies_contract" U0
+             WHERE (U0."end_date" IS NOT NULL
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_contract_end_date",
+                 "users_jobseekerprofile"."fields_history",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."ft_gps_id",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."ase_exit",
+                 "users_jobseekerprofile"."isolated_parent",
+                 "users_jobseekerprofile"."housing_issue",
+                 "users_jobseekerprofile"."refugee",
+                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
+                 "users_jobseekerprofile"."low_level_in_french",
+                 "users_jobseekerprofile"."mobility_issue",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."is_not_stalled_anymore"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s)))
+                 AND
+                   (SELECT U0."end_at" AS "end_at"
+                    FROM "approvals_approval" U0
+                    WHERE U0."user_id" = ("users_user"."id")
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41,
+                   "users_jobseekerprofile"."user_id"
+          ORDER BY 40 DESC,
+                   "users_user"."id" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."approval_id" IN (%s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[job_seekers_views/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[job_seekers_views/list.html]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
+        ''',
+      }),
+    ]),
+  })
+# ---
+# name: test_filtered_by_end_of_iae_journey[/job-seekers/list]
+  dict({
+    'num_queries': 16,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_nexususer"."id",
+                 "nexus_nexususer"."source",
+                 "nexus_nexususer"."source_id",
+                 "nexus_nexususer"."source_kind",
+                 "nexus_nexususer"."first_name",
+                 "nexus_nexususer"."last_name",
+                 "nexus_nexususer"."email",
+                 "nexus_nexususer"."phone",
+                 "nexus_nexususer"."last_login",
+                 "nexus_nexususer"."auth",
+                 "nexus_nexususer"."kind",
+                 "nexus_nexususer"."updated_at",
+                 COALESCE(
+                            (SELECT U0."valid_since" AS "valid_since"
+                             FROM "nexus_nexusressourcesyncstatus" U0
+                             WHERE U0."service" = ("nexus_nexususer"."source")
+                             ORDER BY RANDOM() ASC
+                             LIMIT 1), %s) AS "_threshold"
+          FROM "nexus_nexususer"
+          WHERE ("nexus_nexususer"."updated_at" >= (COALESCE(
+                                                               (SELECT U0."valid_since" AS "valid_since"
+                                                                FROM "nexus_nexusressourcesyncstatus" U0
+                                                                WHERE U0."service" = ("nexus_nexususer"."source")
+                                                                ORDER BY RANDOM() ASC
+                                                                LIMIT 1), %s))
+                 AND "nexus_nexususer"."email" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_activatedservice"."id",
+                 "nexus_activatedservice"."user_id",
+                 "nexus_activatedservice"."service",
+                 "nexus_activatedservice"."created_at"
+          FROM "nexus_activatedservice"
+          WHERE "nexus_activatedservice"."user_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s
+                         AND U0."professional_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s
+                               AND U0."professional_id" = %s))))
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41
+          ORDER BY "users_user"."last_name" ASC,
+                   "users_user"."first_name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE ("prescribers_prescribermembership"."organization_id" = %s
+                 AND "users_user"."id" IN
+                   (SELECT V1."professional_id" AS "job_seeker_assignments__professional"
+                    FROM "users_user" V0
+                    LEFT OUTER JOIN "users_jobseekerassignment" V1 ON (V0."id" = V1."job_seeker_id")
+                    WHERE (V0."kind" = %s
+                           AND V0."id" IN
+                             (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                              FROM "users_jobseekerassignment" U0
+                              WHERE ((U0."company_id" IS NULL
+                                      AND U0."prescriber_organization_id" IS NULL
+                                      AND U0."professional_id" = %s)
+                                     OR (U0."company_id" IS NULL
+                                         AND U0."prescriber_organization_id" = %s
+                                         AND U0."professional_id" = %s))))
+                    GROUP BY V0."id",
+                             1))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouPaginator.count[<site-packages>/django/core/paginator.py]',
+          'pager[utils/pagination.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                    COALESCE(
+                               (SELECT COUNT(U0."id") AS "count"
+                                FROM "job_applications_jobapplication" U0
+                                WHERE (((U0."sender_id" = %s
+                                         AND U0."sender_prescriber_organization_id" IS NULL)
+                                        OR U0."sender_prescriber_organization_id" = %s)
+                                       AND U0."job_seeker_id" = ("users_user"."id"))
+                                GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+               (SELECT MAX(U0."updated_at") AS "last_action_at"
+                FROM "users_jobseekerassignment" U0
+                WHERE (((U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" IS NULL
+                         AND U0."professional_id" = %s)
+                        OR (U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" = %s
+                            AND U0."professional_id" = %s))
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                GROUP BY U0."job_seeker_id"
+                LIMIT 1) AS "last_updated_at",
+          
+               (SELECT U0."id" AS "id"
+                FROM "eligibility_eligibilitydiagnosis" U0
+                WHERE (U0."expires_at" > %s
+                       AND U0."author_kind" = %s
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY U0."created_at" DESC
+                LIMIT 1) AS "valid_eligibility_diagnosis",
+          
+               (SELECT U0."end_at" AS "end_at"
+                FROM "approvals_approval" U0
+                WHERE U0."user_id" = ("users_user"."id")
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_approval_end_at",
+          
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s
+                                  AND U0."professional_id" = %s)))
+                    AND
+                      (SELECT U0."end_at" AS "end_at"
+                       FROM "approvals_approval" U0
+                       WHERE U0."user_id" = ("users_user"."id")
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id",
+                      1,
+                      2,
+                      4) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s
+                         AND U0."professional_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors",
+          
+            (SELECT U0."end_at" AS "end_at"
+             FROM "approvals_approval" U0
+             WHERE U0."user_id" = ("users_user"."id")
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_approval_end_at",
+          
+            (SELECT U0."end_date" AS "end_date"
+             FROM "companies_contract" U0
+             WHERE (U0."end_date" IS NOT NULL
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_contract_end_date",
+                 "users_jobseekerprofile"."fields_history",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."ft_gps_id",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."ase_exit",
+                 "users_jobseekerprofile"."isolated_parent",
+                 "users_jobseekerprofile"."housing_issue",
+                 "users_jobseekerprofile"."refugee",
+                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
+                 "users_jobseekerprofile"."low_level_in_french",
+                 "users_jobseekerprofile"."mobility_issue",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."is_not_stalled_anymore"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s
+                               AND U0."professional_id" = %s)))
+                 AND
+                   (SELECT U0."end_at" AS "end_at"
+                    FROM "approvals_approval" U0
+                    WHERE U0."user_id" = ("users_user"."id")
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41,
+                   "users_jobseekerprofile"."user_id"
+          ORDER BY 40 DESC,
+                   "users_user"."id" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."approval_id" IN (%s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[job_seekers_views/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[job_seekers_views/list.html]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
+        ''',
+      }),
+    ]),
+  })
+# ---
 # name: test_multiple.1
   dict({
     'num_queries': 19,

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -103,8 +103,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_active-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_active" id="id_approval_active-offcanvas" name="approval_active" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_active-offcanvas">
                                           Valide
                                       </label>
                                   </div>
@@ -113,8 +113,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_expired-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_expired" id="id_approval_expired-offcanvas" name="approval_expired" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_expired-offcanvas">
                                           Expiré
                                       </label>
                                   </div>
@@ -123,8 +123,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
-                                      <label class="form-check-label" for="id_no_pass_iae-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_no_approval" id="id_no_approval-offcanvas" name="no_approval" type="checkbox"/>
+                                      <label class="form-check-label" for="id_no_approval-offcanvas">
                                           Aucun
                                       </label>
                                   </div>
@@ -213,8 +213,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_active">
+                                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_active">
                                                       Valide
                                                   </label>
                                               </div>
@@ -223,8 +223,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_expired">
                                                       Expiré
                                                   </label>
                                               </div>
@@ -233,8 +233,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_no_pass_iae" name="no_pass_iae" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_no_pass_iae">
+                                                  <input class="form-check-input is-valid" id="id_no_approval" name="no_approval" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_no_approval">
                                                       Aucun
                                                   </label>
                                               </div>
@@ -425,8 +425,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_active-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_active" id="id_approval_active-offcanvas" name="approval_active" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_active-offcanvas">
                                           Valide
                                       </label>
                                   </div>
@@ -435,8 +435,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_expired-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_expired" id="id_approval_expired-offcanvas" name="approval_expired" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_expired-offcanvas">
                                           Expiré
                                       </label>
                                   </div>
@@ -445,8 +445,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
-                                      <label class="form-check-label" for="id_no_pass_iae-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_no_approval" id="id_no_approval-offcanvas" name="no_approval" type="checkbox"/>
+                                      <label class="form-check-label" for="id_no_approval-offcanvas">
                                           Aucun
                                       </label>
                                   </div>
@@ -518,8 +518,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_active">
+                                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_active">
                                                       Valide
                                                   </label>
                                               </div>
@@ -528,8 +528,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_expired">
                                                       Expiré
                                                   </label>
                                               </div>
@@ -538,8 +538,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_no_pass_iae" name="no_pass_iae" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_no_pass_iae">
+                                                  <input class="form-check-input is-valid" id="id_no_approval" name="no_approval" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_no_approval">
                                                       Aucun
                                                   </label>
                                               </div>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1128,6 +1128,15 @@ def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
     assert response.context["page_obj"].object_list == [job_seeker]
 
 
+def test_end_of_iae_journey_filter_has_matomo_tracking(client):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    client.force_login(organization.members.first())
+
+    response = client.get(reverse("job_seekers_views:list"))
+    assertContains(response, 'data-matomo-option="filtre-fin-de-parcours-pass-iae"')
+    assertContains(response, 'data-matomo-option="filtre-fin-de-parcours-contrat-iae"')
+
+
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_suspended_approval_info_tooltip(client, url):
     organization = PrescriberOrganizationWith2MembershipFactory()

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -952,22 +952,22 @@ def test_filtered_by_approval_state(client, factory, url):
         with_job_seeker_assignment=True,
     ).job_seeker
 
-    response = client.get(url, {"pass_iae_active": "on"})
+    response = client.get(url, {"approval_active": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_expired_eligibility_valid_approval]
 
-    response = client.get(url, {"pass_iae_expired": "on"})
+    response = client.get(url, {"approval_expired": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_expired_eligibility_expired_approval]
 
-    response = client.get(url, {"no_pass_iae": "on"})
+    response = client.get(url, {"no_approval": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_valid_eligibility_no_approval]
 
-    response = client.get(url, {"pass_iae_expired": "on", "no_pass_iae": "on"})
+    response = client.get(url, {"approval_expired": "on", "no_approval": "on"})
     assert response.context["page_obj"].object_list == [
         job_seeker_valid_eligibility_no_approval,
         job_seeker_expired_eligibility_expired_approval,
     ]
 
-    response = client.get(url, {"pass_iae_active": "on", "pass_iae_expired": "on", "no_pass_iae": "on"})
+    response = client.get(url, {"approval_active": "on", "approval_expired": "on", "no_approval": "on"})
     assert response.context["page_obj"].object_list == [
         job_seeker_valid_eligibility_no_approval,
         job_seeker_expired_eligibility_expired_approval,

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -19,7 +19,12 @@ from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
 from itou.utils.templatetags.str_filters import mask_unless
 from tests.approvals.factories import ApprovalFactory, SuspensionFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, CompanyWith2MembershipsFactory
+from tests.companies.factories import (
+    CompanyFactory,
+    CompanyMembershipFactory,
+    CompanyWith2MembershipsFactory,
+    ContractFactory,
+)
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import (
@@ -973,6 +978,154 @@ def test_filtered_by_approval_state(client, factory, url):
         job_seeker_expired_eligibility_expired_approval,
         job_seeker_expired_eligibility_valid_approval,
     ]
+
+
+@freeze_time("2026-01-15")
+@pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
+def test_filtered_by_end_of_iae_journey(client, url, snapshot):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    authorized_prescriber = organization.members.first()
+    client.force_login(authorized_prescriber)
+
+    today = timezone.localdate()
+
+    def add_soon_ending_approval(job_seeker):
+        ApprovalFactory(
+            user=job_seeker,
+            start_at=today - datetime.timedelta(days=600),
+            end_at=today + datetime.timedelta(days=30),
+        )
+
+    def add_soon_ending_contract(job_seeker):
+        ContractFactory(
+            job_seeker=job_seeker,
+            start_date=today - datetime.timedelta(days=200),
+            end_date=today + datetime.timedelta(days=20),
+        )
+
+    # Only a PASS IAE ending soon.
+    job_seeker_pass_only = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_approval(job_seeker_pass_only)
+
+    # Only an IAE contract ending soon.
+    job_seeker_contract_only = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_contract(job_seeker_contract_only)
+
+    # Both a PASS IAE and an IAE contract ending soon.
+    job_seeker_both = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_approval(job_seeker_both)
+    add_soon_ending_contract(job_seeker_both)
+
+    # Neither ends soon.
+    job_seeker_neither = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ApprovalFactory(
+        user=job_seeker_neither,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=91),
+    )
+    ContractFactory(
+        job_seeker=job_seeker_neither,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=31),
+    )
+
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_pass_only, job_seeker_both}
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_contract_only, job_seeker_both}
+
+    # Both checked => AND: only the job seeker with both a soon PASS and a soon contract.
+    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_both]
+
+    # Check queries
+    with assertSnapshotQueries(snapshot):
+        client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_edge_cases(client):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    authorized_prescriber = organization.members.first()
+    client.force_login(authorized_prescriber)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+
+    # PASS ending exactly on the 90-day boundary is included (range is inclusive).
+    job_seeker_pass_boundary = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ApprovalFactory(
+        user=job_seeker_pass_boundary,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=90),
+    )
+
+    # Contract ending exactly on the 30-day boundary is included.
+    job_seeker_contract_boundary = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_contract_boundary,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=30),
+    )
+
+    # A contract without an end date (ongoing) is ignored.
+    job_seeker_contract_no_end = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_contract_no_end,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=None,
+    )
+
+    # Several contracts: only the latest end date counts (an older one already ended).
+    job_seeker_multiple_contracts = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=400),
+        end_date=today - datetime.timedelta(days=200),
+    )
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=today + datetime.timedelta(days=15),
+    )
+
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_pass_boundary]
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {
+        job_seeker_contract_boundary,
+        job_seeker_multiple_contracts,
+    }
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
+    # A non-authorized prescriber neither sees the filter nor is affected by its query params.
+    organization = PrescriberOrganizationFactory(with_membership=True)
+    prescriber = organization.members.first()
+    client.force_login(prescriber)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=prescriber,
+        author_prescriber_organization=organization,
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    # PASS ending far in the future: it would be filtered out if the filter applied.
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=200),
+    )
+
+    assertNotContains(client.get(url), "Fin de parcours IAE à venir")
+
+    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker]
 
 
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])


### PR DESCRIPTION
## 🤔 Pourquoi ?

Le filtre « Fin de parcours IAE à venir » (PR #8500) ne remonte aujourd'hui aucune donnée d'usage. Ce petit ajout met en place un suivi Matomo sur les deux cases du filtre, pour mesurer leur utilisation par les prescripteurs habilités et savoir laquelle est la plus mobilisée.

## 🍰 Comment ?

Un événement Matomo sur chaque case (variantes dropdown et offcanvas), sur le même patron que `contract_status_filter.html` :

* `candidat / clic / filtre-fin-de-parcours-pass-iae`
* `candidat / clic / filtre-fin-de-parcours-contrat-iae`

PR à merger dans la branche `abdess/fin-parcours-iae` pour être intégrée à la #8500.

## 🏝️ Comment tester ?

Sur « Mes accompagnements » en tant que prescripteur habilité, ouvrir le filtre « Fin de parcours IAE à venir » et cocher une case : l'événement Matomo correspondant est émis.
