### PR TITLE
Settings (insertion) : Correction de l’import d’une variable d’environnement

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -784,7 +784,9 @@ DORA_WWW_BASE_URL = os.getenv("DORA_WWW_BASE_URL", "https://dora.inclusion.gouv.
 DORA_API_BASE_URL = os.getenv("DORA_API_BASE_URL", "https://api.dora.inclusion.gouv.fr")
 DORA_API_TOKEN = os.getenv("DORA_API_TOKEN")
 
-NON_ORIENTABLE_DI_SOURCES = os.getenv("NON_ORIENTABLE_DI_SOURCES", [])
+NON_ORIENTABLE_DI_SOURCES = {
+    _source.strip() for _source in os.getenv("NON_ORIENTABLE_DI_SOURCES", "").split(",") if _source.strip()
+}
 
 # GPS
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cette variable est utilisée avec `in` (eg. `if "var" in settings.NON_ORIENTABLE_DI_SOURCES`), donc c’était fonctionnel, mais avouons que ce n’est pas très propre.

