### PR TITLE
Employeur : Repérer les salariés en fin de contrat et suggérer une suite de parcours

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -519,6 +519,10 @@ PRO_CONNECT_MFA_IDENTITY_PROVIDER_ALLOWLIST = [
 
 TALLY_URL = os.getenv("TALLY_URL")
 
+# Tally form id for the SIAE "suggest a next step" action (end of IAE contract). Empty until provided:
+# the action and the job seeker card banner stay hidden while it is not set.
+TALLY_SUGGEST_NEXT_STEP_FORM_ID = os.getenv("TALLY_SUGGEST_NEXT_STEP_FORM_ID")
+
 # Embedding signed Metabase dashboard
 METABASE_SITE_URL = os.getenv("METABASE_SITE_URL")
 METABASE_SECRET_KEY = os.getenv("METABASE_SECRET_KEY")

--- a/itou/templates/apply/includes/job_applications_filters/pass.html
+++ b/itou/templates/apply/includes/job_applications_filters/pass.html
@@ -1,6 +1,6 @@
 {% load django_bootstrap5 %}
 
-{% if filters_form.pass_iae_suspended %}
+{% if filters_form.approval_suspended %}
     <hr>
     <fieldset>
         <legend>
@@ -10,9 +10,9 @@
         </legend>
         <div class="my-3 collapse" id="collapsePassIAE">
             <ul>
-                <li>{% bootstrap_field filters_form.pass_iae_active wrapper_class="" %}</li>
-                <li>{% bootstrap_field filters_form.pass_iae_suspended wrapper_class="" %}</li>
-                <li>{% bootstrap_field filters_form.pass_iae_expired wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_active wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_suspended wrapper_class="" %}</li>
+                <li>{% bootstrap_field filters_form.approval_expired wrapper_class="" %}</li>
             </ul>
         </div>
     </fieldset>

--- a/itou/templates/dashboard/includes/employer_employees_card.html
+++ b/itou/templates/dashboard/includes/employer_employees_card.html
@@ -30,6 +30,17 @@
                     <span>Accompagnements</span>
                 </a>
             </li>
+            {% if contracts_ending_soon_count is not None %}
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    <a href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-fins-de-contrats" %}>
+                        <i class="ri-history-line ri-lg fw-normal" aria-hidden="true"></i>
+                        <span>Fins de contrats</span>
+                    </a>
+                    {% if contracts_ending_soon_count %}
+                        <span class="badge rounded-pill badge-xs bg-warning">{{ contracts_ending_soon_count }}</span>
+                    {% endif %}
+                </li>
+            {% endif %}
         {% endfragment %}
     {% endcomponent_box_dashboard %}
 </div>

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -44,6 +44,11 @@
                                         </div>
                                     </div>
                                 </div>
+                                {% if contract_ending_soon_date %}
+                                    <div class="col-12 order-1 order-xxl-1">
+                                        {% include "job_seekers_views/includes/fin_de_contrat_fiche_banner.html" with contract_ending_soon_date=contract_ending_soon_date suggest_next_step_url=suggest_next_step_url fiche_banner_extra_id=fiche_banner_extra_id request=request only %}
+                                    </div>
+                                {% endif %}
                                 <div class="col-12{% if approval %} col-xxl-8 col-xxxl-9{% endif %} order-3 order-xxl-2">
                                     <div class="c-box mb-3 mb-md-4">
                                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=None with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}

--- a/itou/templates/job_seekers_views/includes/fin_de_contrat_fiche_banner.html
+++ b/itou/templates/job_seekers_views/includes/fin_de_contrat_fiche_banner.html
@@ -1,0 +1,20 @@
+{% load components %}
+{% load matomo %}
+
+{% if contract_ending_soon_date %}
+    {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id=fiche_banner_extra_id extra_classes="mb-3 mb-md-4" %}
+        {% fragment as title %}
+            Le contrat arrive bientôt à échéance
+        {% endfragment %}
+        {% fragment as content %}
+            <p class="mb-0">
+                Le contrat de ce salarié arrive à échéance le {{ contract_ending_soon_date|date:"d/m/Y" }}. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+            </p>
+        {% endfragment %}
+        {% if suggest_next_step_url %}
+            {% fragment as call_to_action %}
+                <a class="btn btn-sm btn-primary" href="{{ suggest_next_step_url }}" target="_blank" rel="noopener noreferrer" {% matomo_event "employeurs" "clic" "suggerer-suite-parcours-fiche" %}>Suggérer une suite de parcours</a>
+            {% endfragment %}
+        {% endif %}
+    {% endcomponent_alert %}
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/fins_de_contrats_banner.html
+++ b/itou/templates/job_seekers_views/includes/fins_de_contrats_banner.html
@@ -1,0 +1,38 @@
+{% load components %}
+{% load matomo %}
+{% load str_filters %}
+
+{% if show_fins_de_contrats_banner %}
+    <div id="fins-de-contrats-banner"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
+        {% if end_of_journey_filter_active %}
+            {% component_alert title=title content=content variant="info" dismissible_once=True extra_id="fins-de-contrats-pedagogique" extra_classes="mb-3 mb-md-4" %}
+                {% fragment as title %}
+                    Suggérer une suite de parcours aux salariés
+                {% endfragment %}
+                {% fragment as content %}
+                    <p class="mb-0">
+                        Vous pouvez suggérer une suite de parcours directement depuis la fiche du salarié ou en cliquant sur « ⋮ » à droite de sa ligne.
+                    </p>
+                {% endfragment %}
+            {% endcomponent_alert %}
+        {% elif contracts_ending_soon_count %}
+            {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id="fins-de-contrats-decouverte" extra_classes="mb-3 mb-md-4" %}
+                {% fragment as title %}
+                    Vous avez {{ contracts_ending_soon_count }} salarié{{ contracts_ending_soon_count|pluralizefr }} en fin de contrat
+                {% endfragment %}
+                {% fragment as content %}
+                    <p class="mb-0">
+                        {% if contracts_ending_soon_count == 1 %}
+                            Le contrat de ce salarié arrive à échéance dans moins de 30 jours. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+                        {% else %}
+                            Le contrat de ces salariés arrive à échéance dans moins de 30 jours. Préparez au mieux leur fin de contrat en suggérant une suite de parcours adaptée à leur situation.
+                        {% endif %}
+                    </p>
+                {% endfragment %}
+                {% fragment as call_to_action %}
+                    <a class="btn btn-sm btn-primary" href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" {% matomo_event "employeurs" "clic" "afficher-fins-de-contrats" %}>Afficher ces salariés</a>
+                {% endfragment %}
+            {% endcomponent_alert %}
+        {% endif %}
+    </div>
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/approval_state.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/approval_state.html
@@ -17,9 +17,9 @@
             <li>
                 <strong class="dropdown-header">PASS IAE</strong>
             </li>
-            <li>{% bootstrap_field filters_form.pass_iae_active wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.pass_iae_expired wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.no_pass_iae wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.approval_active wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.approval_expired wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.no_approval wrapper_class="dropdown-item" %}</li>
         </ul>
     </div>
 {% else %}
@@ -53,13 +53,13 @@
         <div class="my-3 collapse" id="collapseApproval">
             <ul>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.pass_iae_active wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_active wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.pass_iae_expired wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_expired wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
                 <li>
-                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.no_pass_iae wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.no_approval wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
             </ul>
         </div>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
@@ -1,0 +1,34 @@
+{% load django_bootstrap5 %}
+
+{% if btn_dropdown_filter|default:False %}
+    <div class="dropdown">
+        <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+            Fin de parcours IAE à venir
+        </button>
+        <ul class="dropdown-menu">
+            <li>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
+        </ul>
+    </div>
+{% else %}
+    <fieldset>
+        <legend>
+            <button class="btn btn-outline-transparent has-collapse-caret collapsed"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#collapseEndOfJourney"
+                    type="button"
+                    aria-expanded="false"
+                    aria-controls="collapseEndOfJourney">Fin de parcours IAE à venir</button>
+        </legend>
+        <div class="my-3 collapse" id="collapseEndOfJourney">
+            <ul>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+                <li>
+                    {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.contract_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
@@ -1,6 +1,6 @@
 <div class="offcanvas-body" id="offcanvasApplyFiltersContent"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form only %}
-    {% if request.from_authorized_prescriber %}
+    {% if request.from_authorized_prescriber or request.from_employer and request.current_organization.is_subject_to_iae_rules %}
         <hr>
         {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form only %}
     {% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
@@ -1,5 +1,9 @@
 <div class="offcanvas-body" id="offcanvasApplyFiltersContent"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form only %}
+    {% if request.from_authorized_prescriber %}
+        <hr>
+        {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form only %}
+    {% endif %}
     {% if list_organization %}
         <hr>
         {% include "job_seekers_views/includes/job_seekers_filters/organization_members.html" with filters_form=filters_form only %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -19,6 +19,9 @@
                     </li>
                 </ul>
             </div>
+            {% if request.from_authorized_prescriber %}
+                {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form btn_dropdown_filter=True only %}
+            {% endif %}
             {% if list_organization %}
                 <button type="button" class="btn btn-ico btn-dropdown-filter" data-bs-toggle="offcanvas" data-bs-target="#offcanvasApplyFilters" aria-controls="offcanvasApplyFilters">
                     <i class="ri-sound-module-fill fw-medium" aria-hidden="true"></i>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -19,7 +19,7 @@
                     </li>
                 </ul>
             </div>
-            {% if request.from_authorized_prescriber %}
+            {% if request.from_authorized_prescriber or request.from_employer and request.current_organization.is_subject_to_iae_rules %}
                 {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form btn_dropdown_filter=True only %}
             {% endif %}
             {% if list_organization %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -73,6 +73,9 @@
                                         <i class="ri-more-2-fill" aria-hidden="true"></i>
                                     </button>
                                     <div class="dropdown-menu" aria-labelledby="dropdown_{{ forloop.counter }}_action_menu">
+                                        {% if suggest_next_step_url and job_seeker.contract_ending_soon %}
+                                            <a href="{{ suggest_next_step_url }}" class="dropdown-item" target="_blank" rel="noopener noreferrer" {% matomo_event "employeurs" "clic" "suggerer-suite-parcours-liste" %}>Suggérer une suite de parcours</a>
+                                        {% endif %}
                                         {% if request.current_organization.is_authorized %}
                                             {% if not job_seeker.has_valid_approval %}
                                                 <a href="{% url 'eligibility_views:update_iae' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="dropdown-item">
@@ -127,6 +130,7 @@
 </section>
 
 {% if request.htmx %}
+    {% include "job_seekers_views/includes/fins_de_contrats_banner.html" with show_fins_de_contrats_banner=show_fins_de_contrats_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count request=request only %}
     {% include "job_seekers_views/includes/list_counter.html" with paginator=page_obj.paginator request=request only %}
     {% include "job_seekers_views/includes/list_reset_filters.html" with btn_dropdown_filter=True filters_counter=filters_counter request=request list_organization=list_organization order=order only %}
     {% include "job_seekers_views/includes/job_seekers_filters/offcanvas_footer.html" %}

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -81,6 +81,7 @@
                 {% include "job_seekers_views/includes/job_seekers_filters/top_filters.html" with request=request filters_counter=filters_counter filters_form=filters_form list_organization=list_organization order=order ITOU_HELP_CENTER_URL=ITOU_HELP_CENTER_URL only %}
                 <input id="id_order" type="hidden" name="order" value="{{ order }}">
             </form>
+            {% include "job_seekers_views/includes/fins_de_contrats_banner.html" with show_fins_de_contrats_banner=show_fins_de_contrats_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count request=request only %}
             <div class="s-section__row row">
                 <div class="col-12">
                     <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
@@ -91,7 +92,7 @@
                             {% bootstrap_field filters_form.job_seeker wrapper_class="w-lg-400px" show_label=False %}
                         </div>
                     </div>
-                    {% include "job_seekers_views/includes/list_results.html" with page_obj=page_obj request=request csrf_token=csrf_token order=order can_orient_towards_insertion_service=can_orient_towards_insertion_service only %}
+                    {% include "job_seekers_views/includes/list_results.html" with page_obj=page_obj request=request csrf_token=csrf_token order=order can_orient_towards_insertion_service=can_orient_towards_insertion_service show_fins_de_contrats_banner=show_fins_de_contrats_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count suggest_next_step_url=suggest_next_step_url only %}
                 </div>
             </div>
         </div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -842,25 +842,25 @@ class FilterJobApplicationsForm(forms.Form):
         if states := data.get("states"):
             filters.append(Q(state__in=states))
 
-        pass_iae_key_to_filter = {
+        approval_key_to_filter = {
             # Simplification of CommonApprovalQuerySet.valid_lookup()
             # The date is not enough to know if an approval is valid or not
-            "pass_iae_active": Q(approval__end_at__gte=timezone.localdate(), has_suspended_approval=False),
+            "approval_active": Q(approval__end_at__gte=timezone.localdate(), has_suspended_approval=False),
             # This is NOT what we want but how things work currently:
-            # if you check pass_iae_active, the value of pass_iae_suspended is ignored
+            # if you check approval_active, the value of approval_suspended is ignored
             # Filter on the `has_suspended_approval` annotation, which is set in `with_list_related_data()`.
-            "pass_iae_suspended": Q(has_suspended_approval=True),
-            "pass_iae_expired": Q(approval__end_at__lt=timezone.localdate()),
+            "approval_suspended": Q(has_suspended_approval=True),
+            "approval_expired": Q(approval__end_at__lt=timezone.localdate()),
         }
 
-        if any([data.get(key) for key in pass_iae_key_to_filter.keys()]):
-            if data.get("pass_iae_active") or data.get("pass_iae_suspended"):
+        if any([data.get(key) for key in approval_key_to_filter.keys()]):
+            if data.get("approval_active") or data.get("approval_suspended"):
                 queryset = queryset.with_has_suspended_approval()
-            pass_status_filter = Q()
-            for key, filter in pass_iae_key_to_filter.items():
+            approval_status_filter = Q()
+            for key, filter in approval_key_to_filter.items():
                 if data.get(key):
-                    pass_status_filter |= filter
-            filters.append(pass_status_filter)
+                    approval_status_filter |= filter
+            filters.append(approval_status_filter)
 
         if start_date := data.get("start_date"):
             filters.append(Q(created_at__gte=start_date))
@@ -934,9 +934,9 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
             }
         ),
     )
-    pass_iae_suspended = forms.BooleanField(label="Suspendu", required=False)
-    pass_iae_active = forms.BooleanField(label="Actif", required=False)
-    pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
+    approval_suspended = forms.BooleanField(label="Suspendu", required=False)
+    approval_active = forms.BooleanField(label="Actif", required=False)
+    approval_expired = forms.BooleanField(label="Expiré", required=False)
     criteria = forms.MultipleChoiceField(required=False, label="", widget=Select2MultipleWidget)
     eligibility_validated = forms.BooleanField(label="Valide", required=False)
     eligibility_pending = forms.BooleanField(label="À valider", required=False)
@@ -1097,9 +1097,9 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
             del self.fields["criteria"]
             del self.fields["eligibility_validated"]
             del self.fields["eligibility_pending"]
-            del self.fields["pass_iae_active"]
-            del self.fields["pass_iae_suspended"]
-            del self.fields["pass_iae_expired"]
+            del self.fields["approval_active"]
+            del self.fields["approval_suspended"]
+            del self.fields["approval_expired"]
 
         if not company.can_have_prior_action:
             # Drop "pré-embauche" state from filter for non-GEIQ companies

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import logging
 
@@ -36,7 +37,7 @@ from itou.nexus.utils import activate_pilotage
 from itou.search.models import SavedSearch
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.users.enums import UserKind
-from itou.users.models import User
+from itou.users.models import JobSeekerAssignment, User
 from itou.users.notifications import (
     EditJobSeekerEmailNotification,
     EditJobSeekerInfoNotification,
@@ -57,6 +58,7 @@ from itou.www.dashboard.forms import (
     EditUserInfoForm,
     EditUserNotificationForm,
 )
+from itou.www.job_seekers_views.forms import IAE_CONTRACT_ENDING_SOON_DAYS, annotate_last_contract_end_date
 from itou.www.search_views.forms import SiaeSearchForm
 from itou.www.stats import utils as stats_utils
 from itou.www.stats.utils import get_stats_for_institution
@@ -113,7 +115,24 @@ def _employer_dashboard_context(request):
         category["counter"] = len([ja for ja in job_applications if ja["state"] in category["states"]])
         category["url"] = f"{reverse('apply:list_for_siae')}?{'&'.join([f'states={c}' for c in category['states']])}"
 
+    # Number of the SIAE assigned job seekers whose latest contract with this SIAE ends within 30 days.
+    # Same business definition as the "contract ending soon" list filter, so the counter matches the results.
+    contracts_ending_soon_count = None
+    if current_org.is_subject_to_iae_rules:
+        today = timezone.localdate()
+        contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+        siae_job_seekers = User.objects.filter(
+            kind=UserKind.JOB_SEEKER,
+            pk__in=JobSeekerAssignment.objects.filter(company=current_org).values("job_seeker"),
+        )
+        contracts_ending_soon_count = (
+            annotate_last_contract_end_date(siae_job_seekers, company=current_org)
+            .filter(last_contract_end_date__range=contract_window)
+            .count()
+        )
+
     return {
+        "contracts_ending_soon_count": contracts_ending_soon_count,
         "active_campaigns": (
             EvaluatedSiae.objects.for_company(current_org)
             .in_progress()
@@ -152,6 +171,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "active_geiq_campaign": None,
         "active_campaigns": [],
         "closed_campaigns": [],
+        "contracts_ending_soon_count": None,
         "job_applications_categories": [],
         "can_show_financial_annexes": False,
         "can_show_employee_records": False,

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.db.models import OuterRef, Q, Subquery
 from django.forms import ValidationError
@@ -9,6 +11,7 @@ from itou.approvals.models import Approval
 from itou.asp import models as asp_models
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
+from itou.companies.models import Contract
 from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.forms import JobSeekerProfileFieldsMixin, JobSeekerProfileModelForm
 from itou.users.models import JobSeekerProfile, JobSeekerProfileQuerySet, NirModificationRequest, User
@@ -18,6 +21,10 @@ from itou.utils.perms.utils import can_view_personal_information
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.validators import validate_nir
 from itou.utils.widgets import DuetDatePickerWidget
+
+
+APPROVAL_ENDING_SOON_DAYS = 90
+IAE_CONTRACT_ENDING_SOON_DAYS = 30
 
 
 class FilterForm(forms.Form):
@@ -44,12 +51,27 @@ class FilterForm(forms.Form):
         label="Nom de la personne", required=False, widget=Select2MultipleWidget
     )
 
+    # Fields only for authorized prescribers set in __init__
+    approval_ending_soon = None
+    contract_ending_soon = None
+
     def __init__(self, job_seeker_qs, data, *args, request, **kwargs):
         super().__init__(data, *args, **kwargs)
         self.fields["job_seeker"].choices = self._get_choices_for_job_seeker(job_seeker_qs, request)
         if request.current_organization:
             self.fields["organization_members"].choices = self._get_choices_for_organization_members(
                 job_seeker_qs, request.current_organization
+            )
+        if request.from_authorized_prescriber:
+            self.fields["approval_ending_soon"] = forms.BooleanField(
+                label="PASS IAE bientôt expiré",
+                required=False,
+                help_text=f"Dans les {APPROVAL_ENDING_SOON_DAYS} prochains jours",
+            )
+            self.fields["contract_ending_soon"] = forms.BooleanField(
+                label="Contrat IAE bientôt terminé",
+                required=False,
+                help_text=f"Dans les {IAE_CONTRACT_ENDING_SOON_DAYS} prochains jours",
             )
 
     def _get_choices_for_job_seeker(self, job_seeker_qs, request):
@@ -92,24 +114,58 @@ class FilterForm(forms.Form):
         elif self.cleaned_data.get("eligibility_pending") and not self.cleaned_data.get("eligibility_validated"):
             queryset = queryset.eligibility_pending()
 
-        # Approval (PASS IAE) status (all checkboxes checked = all cases, so do not filter out results)
-        approval_filters = [
+        today = timezone.localdate()
+
+        # There are 2 filters using the user approval :
+        # - The  status
+        # - The upcoming approval end
+
+        # Approval status (all checkboxes checked = all cases, so do not filter out results).
+        approval_status_filters = [
             self.cleaned_data.get(key) for key in ("approval_active", "approval_expired", "no_approval")
         ]
-        if any(approval_filters) and not all(approval_filters):
-            last_approval_end_at = Subquery(
-                Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
-            )
-            queryset = queryset.annotate(last_approval_end_at=last_approval_end_at)
+        use_approval_status = any(approval_status_filters) and not all(approval_status_filters)
 
+        # The "end of IAE journey" filters are reserved for authorized prescribers.
+        approval_ending_soon = self.cleaned_data.get("approval_ending_soon")
+
+        if use_approval_status or approval_ending_soon:
+            queryset = queryset.annotate(
+                last_approval_end_at=Subquery(
+                    Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
+                )
+            )
+
+        if use_approval_status:
             approval_status_filter = Q()
             if self.cleaned_data.get("approval_active"):
-                approval_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
+                approval_status_filter |= Q(last_approval_end_at__gte=today)
             if self.cleaned_data.get("approval_expired"):
-                approval_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
+                approval_status_filter |= Q(last_approval_end_at__lt=today)
             if self.cleaned_data.get("no_approval"):
                 approval_status_filter |= Q(last_approval_end_at__isnull=True)
             filters.append(approval_status_filter)
+
+        # Upcoming end of IAE journey (authorized prescribers only): the two conditions are combined
+        # with AND when both are checked. approval ending soon is reliable; IAE contract end dates come
+        # from ASP data that is partial and delayed by a few days.
+        contract_ending_soon = self.cleaned_data.get("contract_ending_soon")
+        if approval_ending_soon or contract_ending_soon:
+            end_of_journey_filter = Q()
+            if approval_ending_soon:
+                approval_window = (today, today + datetime.timedelta(days=APPROVAL_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_approval_end_at__range=approval_window)
+            if contract_ending_soon:
+                queryset = queryset.annotate(
+                    last_contract_end_date=Subquery(
+                        Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
+                        .order_by("-end_date")
+                        .values("end_date")[:1]
+                    )
+                )
+                contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+                end_of_journey_filter &= Q(last_contract_end_date__range=contract_window)
+            filters.append(end_of_journey_filter)
 
         if self.cleaned_data.get("is_stalled"):
             queryset = queryset.filter(

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -34,9 +34,9 @@ class FilterForm(forms.Form):
     eligibility_validated = forms.BooleanField(label="Valide", required=False)
     eligibility_pending = forms.BooleanField(label="À valider", required=False)
 
-    pass_iae_active = forms.BooleanField(label="Valide", required=False)
-    pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
-    no_pass_iae = forms.BooleanField(label="Aucun", required=False)
+    approval_active = forms.BooleanField(label="Valide", required=False)
+    approval_expired = forms.BooleanField(label="Expiré", required=False)
+    no_approval = forms.BooleanField(label="Aucun", required=False)
 
     is_stalled = forms.BooleanField(label="N’afficher que les usagers sans solution", required=False)
 
@@ -93,23 +93,23 @@ class FilterForm(forms.Form):
             queryset = queryset.eligibility_pending()
 
         # Approval (PASS IAE) status (all checkboxes checked = all cases, so do not filter out results)
-        pass_iae_filters = [
-            self.cleaned_data.get(key) for key in ("pass_iae_active", "pass_iae_expired", "no_pass_iae")
+        approval_filters = [
+            self.cleaned_data.get(key) for key in ("approval_active", "approval_expired", "no_approval")
         ]
-        if any(pass_iae_filters) and not all(pass_iae_filters):
+        if any(approval_filters) and not all(approval_filters):
             last_approval_end_at = Subquery(
                 Approval.objects.filter(user=OuterRef("pk")).order_by("-end_at").values("end_at")[:1]
             )
             queryset = queryset.annotate(last_approval_end_at=last_approval_end_at)
 
-            pass_status_filter = Q()
-            if self.cleaned_data.get("pass_iae_active"):
-                pass_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
-            if self.cleaned_data.get("pass_iae_expired"):
-                pass_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
-            if self.cleaned_data.get("no_pass_iae"):
-                pass_status_filter |= Q(last_approval_end_at__isnull=True)
-            filters.append(pass_status_filter)
+            approval_status_filter = Q()
+            if self.cleaned_data.get("approval_active"):
+                approval_status_filter |= Q(last_approval_end_at__gte=timezone.localdate())
+            if self.cleaned_data.get("approval_expired"):
+                approval_status_filter |= Q(last_approval_end_at__lt=timezone.localdate())
+            if self.cleaned_data.get("no_approval"):
+                approval_status_filter |= Q(last_approval_end_at__isnull=True)
+            filters.append(approval_status_filter)
 
         if self.cleaned_data.get("is_stalled"):
             queryset = queryset.filter(

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -27,6 +27,21 @@ APPROVAL_ENDING_SOON_DAYS = 90
 IAE_CONTRACT_ENDING_SOON_DAYS = 30
 
 
+def annotate_last_contract_end_date(queryset, *, company=None):
+    # Latest known IAE contract end date of the job seeker, optionally scoped to a single SIAE.
+    # Scoping to the current SIAE avoids counting a contract signed with another structure, and keeps
+    # a renewed employee out of the cohort (their latest contract with the SIAE ends later).
+    # Shared business definition reused by the dashboard counter, the filter, the discovery banner and
+    # the per-row end-of-contract flag. Idempotent so the list view can annotate for the row flag while
+    # the filter also annotates for the same SIAE, without raising on a duplicate annotation.
+    if "last_contract_end_date" in queryset.query.annotations:
+        return queryset
+    contracts = Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
+    if company is not None:
+        contracts = contracts.filter(company=company)
+    return queryset.annotate(last_contract_end_date=Subquery(contracts.order_by("-end_date").values("end_date")[:1]))
+
+
 class FilterForm(forms.Form):
     job_seeker = forms.ChoiceField(
         required=False,
@@ -51,7 +66,7 @@ class FilterForm(forms.Form):
         label="Nom de la personne", required=False, widget=Select2MultipleWidget
     )
 
-    # Fields only for authorized prescribers set in __init__
+    # Fields only for authorized prescribers and IAE employers, set in __init__
     approval_ending_soon = None
     contract_ending_soon = None
 
@@ -62,7 +77,13 @@ class FilterForm(forms.Form):
             self.fields["organization_members"].choices = self._get_choices_for_organization_members(
                 job_seeker_qs, request.current_organization
             )
-        if request.from_authorized_prescriber:
+        # A SIAE only looks at its own contracts; a prescriber keeps the job seeker global view (company=None).
+        self.company = (
+            request.current_organization
+            if request.from_employer and request.current_organization.is_subject_to_iae_rules
+            else None
+        )
+        if request.from_authorized_prescriber or self.company:
             self.fields["approval_ending_soon"] = forms.BooleanField(
                 label="PASS IAE bientôt expiré",
                 required=False,
@@ -126,7 +147,7 @@ class FilterForm(forms.Form):
         ]
         use_approval_status = any(approval_status_filters) and not all(approval_status_filters)
 
-        # The "end of IAE journey" filters are reserved for authorized prescribers.
+        # The "end of IAE journey" filters exist only for authorized prescribers and IAE employers.
         approval_ending_soon = self.cleaned_data.get("approval_ending_soon")
 
         if use_approval_status or approval_ending_soon:
@@ -156,13 +177,7 @@ class FilterForm(forms.Form):
                 approval_window = (today, today + datetime.timedelta(days=APPROVAL_ENDING_SOON_DAYS))
                 end_of_journey_filter &= Q(last_approval_end_at__range=approval_window)
             if contract_ending_soon:
-                queryset = queryset.annotate(
-                    last_contract_end_date=Subquery(
-                        Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
-                        .order_by("-end_date")
-                        .values("end_date")[:1]
-                    )
-                )
+                queryset = annotate_last_contract_end_date(queryset, company=self.company)
                 contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
                 end_of_journey_filter &= Q(last_contract_end_date__range=contract_window)
             filters.append(end_of_journey_filter)

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from django.conf import settings
@@ -45,13 +46,14 @@ from itou.utils.perms.utils import (
 )
 from itou.utils.readonly import ReadonlyViewMixin, http_methods, readonly_view
 from itou.utils.session import SessionNamespace, SessionNamespaceException
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import get_safe_url, get_tally_form_url
 from itou.utils.views import with_triggers_context
 from itou.www.apply.views.hire_views import HIRE_SESSION_KIND, HireWizardMixin
 from itou.www.apply.views.submit_views import APPLY_SESSION_KIND, ApplicationBaseView
 from itou.www.gps import utils as gps_utils
 from itou.www.job_seekers_views.enums import JobSeekerOrder, JobSeekerSessionKinds
 from itou.www.job_seekers_views.forms import (
+    IAE_CONTRACT_ENDING_SOON_DAYS,
     CheckJobSeekerInfoForm,
     CheckJobSeekerNirForm,
     CreateOrUpdateJobSeekerStep1Form,
@@ -61,6 +63,7 @@ from itou.www.job_seekers_views.forms import (
     JobSeekerExistsForm,
     NirModificationRequestForm,
     SwitchStalledStatusForm,
+    annotate_last_contract_end_date,
 )
 
 
@@ -206,7 +209,36 @@ class JobSeekerDetailView(UserPassesTestMixin, ReadonlyViewMixin, DetailView):
             .exists()
         )
 
+        # SIAE job seeker card banner: shown on the details tab when a contract with this SIAE ends within
+        # 30 days and the Tally form is configured. Same business definition (scoped to the current SIAE)
+        # as the list. Restricted to the details template so the query does not run on the other tabs.
+        contract_ending_soon_date = None
+        suggest_next_step_url = None
+        if (
+            self.template_name == "job_seekers_views/details.html"
+            and self.request.from_employer
+            and self.request.current_organization.is_subject_to_iae_rules
+            and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID
+        ):
+            today = timezone.localdate()
+            last_contract_end_date = (
+                Contract.objects.filter(
+                    job_seeker=self.object, company=self.request.current_organization, end_date__isnull=False
+                )
+                .order_by("-end_date")
+                .values_list("end_date", flat=True)
+                .first()
+            )
+            if last_contract_end_date and today <= last_contract_end_date <= today + datetime.timedelta(
+                days=IAE_CONTRACT_ENDING_SOON_DAYS
+            ):
+                contract_ending_soon_date = last_contract_end_date
+                suggest_next_step_url = get_tally_form_url(settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID)
+
         return super().get_context_data(**kwargs) | {
+            "contract_ending_soon_date": contract_ending_soon_date,
+            "suggest_next_step_url": suggest_next_step_url,
+            "fiche_banner_extra_id": f"fin-de-contrat-fiche-{self.object.public_id}",
             "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
             "iae_eligibility_diagnosis": iae_eligibility_diagnosis,
             "can_edit_iae_eligibility": can_edit_iae_eligibility,
@@ -387,10 +419,37 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         request=request,
     )
 
+    base_queryset = queryset
     filters_counter = 0
+    end_of_journey_filter_active = False
     if form.is_valid():
+        end_of_journey_filter_active = bool(
+            form.cleaned_data.get("approval_ending_soon") or form.cleaned_data.get("contract_ending_soon")
+        )
         queryset = form.filter(queryset)
         filters_counter = form.get_filters_counter()
+
+    # SIAE end-of-contract cohort: a job seeker whose latest IAE contract with this SIAE ends within
+    # IAE_CONTRACT_ENDING_SOON_DAYS. Same definition as the dashboard counter and the job seeker card banner.
+    show_fins_de_contrats_banner = request.from_employer and request.current_organization.is_subject_to_iae_rules
+    today = timezone.localdate()
+    contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+
+    # Discovery banner: count over the SIAE assigned job seekers (unfiltered), only shown when the
+    # end-of-journey filter is not active.
+    contracts_ending_soon_count = None
+    if show_fins_de_contrats_banner and not end_of_journey_filter_active:
+        contracts_ending_soon_count = (
+            annotate_last_contract_end_date(base_queryset, company=request.current_organization)
+            .filter(last_contract_end_date__range=contract_window)
+            .count()
+        )
+
+    # SIAE "suggest a next step" action (Tally). Offered on each row whose IAE contract with this SIAE ends
+    # soon, mirroring the job seeker card banner. Hidden while the form id is not configured.
+    suggest_next_step_url = None
+    if show_fins_de_contrats_banner and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID:
+        suggest_next_step_url = get_tally_form_url(settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID)
 
     try:
         order = JobSeekerOrder(request.GET.get("order"))
@@ -401,14 +460,22 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         .select_related("jobseeker_profile")
         .prefetch_related("approvals__suspension_set")
     )
+    if show_fins_de_contrats_banner:
+        queryset = annotate_last_contract_end_date(queryset, company=request.current_organization)
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_LARGE)
     for job_seeker in page_obj:
         job_seeker.user_can_view_personal_information = can_view_personal_information(request, job_seeker)
+        job_seeker.contract_ending_soon = bool(
+            show_fins_de_contrats_banner
+            and job_seeker.last_contract_end_date
+            and contract_window[0] <= job_seeker.last_contract_end_date <= contract_window[1]
+        )
         job_seeker.show_more_actions = (
             not job_seeker.has_valid_approval
             or job_seeker.jobseeker_profile.is_stalled
             or can_orient_towards_insertion_service(request)
+            or bool(suggest_next_step_url and job_seeker.contract_ending_soon)
         )
         job_seeker.services_search_url = build_services_search_url(request, job_seeker)
         professional, organization = request.user, request.current_organization
@@ -423,6 +490,10 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         "filters_counter": filters_counter,
         "order": order,
         "page_obj": page_obj,
+        "show_fins_de_contrats_banner": show_fins_de_contrats_banner,
+        "end_of_journey_filter_active": end_of_journey_filter_active,
+        "contracts_ending_soon_count": contracts_ending_soon_count,
+        "suggest_next_step_url": suggest_next_step_url,
     }
 
     return render(request, "job_seekers_views/includes/list_results.html" if request.htmx else template_name, context)

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -7612,8 +7612,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_active">
+                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_active">
                                       Actif
                                   </label>
                               </div>
@@ -7622,8 +7622,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_suspended">
+                                  <input class="form-check-input is-valid" id="id_approval_suspended" name="approval_suspended" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_suspended">
                                       Suspendu
                                   </label>
                               </div>
@@ -7632,8 +7632,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_expired">
                                       Expiré
                                   </label>
                               </div>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -5143,8 +5143,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_active">
+                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_active">
                                       Actif
                                   </label>
                               </div>
@@ -5153,8 +5153,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_suspended">
+                                  <input class="form-check-input is-valid" id="id_approval_suspended" name="approval_suspended" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_suspended">
                                       Suspendu
                                   </label>
                               </div>
@@ -5163,8 +5163,8 @@
                       <li>
                           <div class="">
                               <div class="form-check">
-                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                  <label class="form-check-label" for="id_approval_expired">
                                       Expiré
                                   </label>
                               </div>

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -481,7 +481,7 @@ class TestProcessListSiae:
         JobApplicationFactory(sent_by_prescriber_alone=True, to_company=company)
 
         # Without approval
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True})
         assert len(response.context["job_applications_page"].object_list) == 0
 
         # With a job_application with an approval
@@ -493,15 +493,15 @@ class TestProcessListSiae:
             approval__start_at=yesterday,
             to_company=company,
         )
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # Check that adding pass_iae_suspended does not hide the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True, "pass_iae_suspended": True})
+        # Check that adding approval_suspended does not hide the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True, "approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # But pass_iae_suspended alone does not show the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_suspended": True})
+        # But approval_suspended alone does not show the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_suspended": True})
         assert response.context["job_applications_page"].object_list == []
 
         # Now with a suspension
@@ -510,15 +510,15 @@ class TestProcessListSiae:
             start_at=yesterday,
             end_at=today + timezone.timedelta(days=2),
         )
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_suspended": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
-        # Check that adding pass_iae_active does not hide the application
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_active": True, "pass_iae_suspended": True})
+        # Check that adding approval_active does not hide the application
+        response = client.get(reverse("apply:list_for_siae"), {"approval_active": True, "approval_suspended": True})
         assert response.context["job_applications_page"].object_list == [job_application]
 
         # So far no approval was expired
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_expired": True})
+        response = client.get(reverse("apply:list_for_siae"), {"approval_expired": True})
         assert response.context["job_applications_page"].object_list == []
 
         jobapp_with_expired_pass = JobApplicationFactory(
@@ -531,8 +531,8 @@ class TestProcessListSiae:
             to_company=company,
         )
 
-        # The pass_iae_expired filter works as expected
-        response = client.get(reverse("apply:list_for_siae"), {"pass_iae_expired": True})
+        # The approval_expired filter works as expected
+        response = client.get(reverse("apply:list_for_siae"), {"approval_expired": True})
         assert response.context["job_applications_page"].object_list == [jobapp_with_expired_pass]
 
     def test_list_for_siae_filtered_by_eligibility_state(self, client):
@@ -706,7 +706,7 @@ class TestProcessListSiae:
                     "end_date": timezone.localdate(job_app.created_at).strftime(date_format),
                     "sender_prescriber_organizations": [job_app.sender_prescriber_organization.id],
                     "senders": [job_app.sender.id],
-                    "pass_iae_active": True,
+                    "approval_active": True,
                     "eligibility_validated": True,
                     "criteria": [level1_criterion.pk],
                     "departments": ["37"],

--- a/tests/www/apply/test_transfer.py
+++ b/tests/www/apply/test_transfer.py
@@ -431,7 +431,7 @@ def test_start_session_internal_transfer(client):
     client.force_login(employer)
 
     # This will set the session back url
-    list_url_with_params = reverse("apply:list_for_siae") + "?pass_iae_active=on"
+    list_url_with_params = reverse("apply:list_for_siae") + "?approval_active=on"
     client.get(
         reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
         + f"?back_url={quote(list_url_with_params)}"

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -50,7 +50,7 @@
 # ---
 # name: TestDashboardView.test_dashboard_siae_evaluation_campaign_notifications[view queries]
   dict({
-    'num_queries': 23,
+    'num_queries': 24,
     'queries': list([
       dict({
         'origin': list([
@@ -393,6 +393,30 @@
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "job_applications_jobapplication"."archived_at" IS NULL)
           ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_employer_dashboard_context[www/dashboard/views.py]',
+          'dashboard[www/dashboard/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "users_user"
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT U0."job_seeker_id" AS "job_seeker"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE U0."company_id" = %s)
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id")
+                           AND U0."company_id" = %s)
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
         ''',
       }),
       dict({

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -30,7 +30,7 @@ from itou.utils import constants as global_constants, triggers
 from itou.utils.models import InclusiveDateRange
 from itou.utils.templatetags.format_filters import format_approval_number, format_siret
 from tests.approvals.factories import ApprovalFactory, ProlongationRequestFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
+from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, ContractFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.employee_record.factories import EmployeeRecordFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory, LaborInspectorFactory
@@ -43,7 +43,13 @@ from tests.siae_evaluations.factories import (
     EvaluatedSiaeFactory,
     EvaluationCampaignFactory,
 )
-from tests.users.factories import EmployerFactory, ItouStaffFactory, JobSeekerFactory, PrescriberFactory
+from tests.users.factories import (
+    EmployerFactory,
+    ItouStaffFactory,
+    JobSeekerAssignmentFactory,
+    JobSeekerFactory,
+    PrescriberFactory,
+)
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
@@ -189,6 +195,42 @@ class TestDashboardView:
         response = client.get(url)
         assert response.status_code == 200
         assert response.context["num_rejected_employee_records"] == 0
+
+    @freeze_time("2026-01-15")
+    def test_dashboard_contracts_ending_soon_count(self, client):
+        company = CompanyFactory(with_membership=True, subject_to_iae_rules=True)
+        employer = company.members.first()
+        client.force_login(employer)
+        today = date(2026, 1, 15)
+        url = reverse("dashboard:index")
+
+        # No contract ending soon yet: the entry is shown without a badge.
+        response = client.get(url)
+        assertContains(response, "Fins de contrats")
+        assert response.context["contracts_ending_soon_count"] == 0
+
+        # A job seeker assigned to the SIAE with a contract with this SIAE ending in 20 days is counted.
+        job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+        ContractFactory(
+            job_seeker=job_seeker,
+            company=company,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=20),
+        )
+        # A contract with another SIAE must not be counted.
+        other_job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+        ContractFactory(
+            job_seeker=other_job_seeker,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=20),
+        )
+
+        response = client.get(url)
+        assert response.context["contracts_ending_soon_count"] == 1
+
+        # The dashboard counter matches the filtered "Accompagnements" list results.
+        list_response = client.get(reverse("job_seekers_views:list_organization"), {"contract_ending_soon": "on"})
+        assert list(list_response.context["page_obj"].object_list) == [job_seeker]
 
     def test_dashboard_applications_to_process(self, client):
         non_geiq_url = reverse("apply:list_for_siae") + "?states=new&amp;states=processing"

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -617,6 +617,1969 @@
   
   '''
 # ---
+# name: test_filtered_by_end_of_iae_journey[/job-seekers/list-organization]
+  dict({
+    'num_queries': 16,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_nexususer"."id",
+                 "nexus_nexususer"."source",
+                 "nexus_nexususer"."source_id",
+                 "nexus_nexususer"."source_kind",
+                 "nexus_nexususer"."first_name",
+                 "nexus_nexususer"."last_name",
+                 "nexus_nexususer"."email",
+                 "nexus_nexususer"."phone",
+                 "nexus_nexususer"."last_login",
+                 "nexus_nexususer"."auth",
+                 "nexus_nexususer"."kind",
+                 "nexus_nexususer"."updated_at",
+                 COALESCE(
+                            (SELECT U0."valid_since" AS "valid_since"
+                             FROM "nexus_nexusressourcesyncstatus" U0
+                             WHERE U0."service" = ("nexus_nexususer"."source")
+                             ORDER BY RANDOM() ASC
+                             LIMIT 1), %s) AS "_threshold"
+          FROM "nexus_nexususer"
+          WHERE ("nexus_nexususer"."updated_at" >= (COALESCE(
+                                                               (SELECT U0."valid_since" AS "valid_since"
+                                                                FROM "nexus_nexusressourcesyncstatus" U0
+                                                                WHERE U0."service" = ("nexus_nexususer"."source")
+                                                                ORDER BY RANDOM() ASC
+                                                                LIMIT 1), %s))
+                 AND "nexus_nexususer"."email" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_activatedservice"."id",
+                 "nexus_activatedservice"."user_id",
+                 "nexus_activatedservice"."service",
+                 "nexus_activatedservice"."created_at"
+          FROM "nexus_activatedservice"
+          WHERE "nexus_activatedservice"."user_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s))))
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41
+          ORDER BY "users_user"."last_name" ASC,
+                   "users_user"."first_name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE ("prescribers_prescribermembership"."organization_id" = %s
+                 AND "users_user"."id" IN
+                   (SELECT V1."professional_id" AS "job_seeker_assignments__professional"
+                    FROM "users_user" V0
+                    LEFT OUTER JOIN "users_jobseekerassignment" V1 ON (V0."id" = V1."job_seeker_id")
+                    WHERE (V0."kind" = %s
+                           AND V0."id" IN
+                             (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                              FROM "users_jobseekerassignment" U0
+                              WHERE ((U0."company_id" IS NULL
+                                      AND U0."prescriber_organization_id" IS NULL
+                                      AND U0."professional_id" = %s)
+                                     OR (U0."company_id" IS NULL
+                                         AND U0."prescriber_organization_id" = %s))))
+                    GROUP BY V0."id",
+                             1))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouPaginator.count[<site-packages>/django/core/paginator.py]',
+          'pager[utils/pagination.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                    COALESCE(
+                               (SELECT COUNT(U0."id") AS "count"
+                                FROM "job_applications_jobapplication" U0
+                                WHERE (((U0."sender_id" = %s
+                                         AND U0."sender_prescriber_organization_id" IS NULL)
+                                        OR U0."sender_prescriber_organization_id" = %s)
+                                       AND U0."job_seeker_id" = ("users_user"."id"))
+                                GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+               (SELECT MAX(U0."updated_at") AS "last_action_at"
+                FROM "users_jobseekerassignment" U0
+                WHERE (((U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" IS NULL
+                         AND U0."professional_id" = %s)
+                        OR (U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" = %s))
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                GROUP BY U0."job_seeker_id"
+                LIMIT 1) AS "last_updated_at",
+          
+               (SELECT U0."id" AS "id"
+                FROM "eligibility_eligibilitydiagnosis" U0
+                WHERE (U0."expires_at" > %s
+                       AND U0."author_kind" = %s
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY U0."created_at" DESC
+                LIMIT 1) AS "valid_eligibility_diagnosis",
+          
+               (SELECT U0."end_at" AS "end_at"
+                FROM "approvals_approval" U0
+                WHERE U0."user_id" = ("users_user"."id")
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_approval_end_at",
+          
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s)))
+                    AND
+                      (SELECT U0."end_at" AS "end_at"
+                       FROM "approvals_approval" U0
+                       WHERE U0."user_id" = ("users_user"."id")
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id",
+                      1,
+                      2,
+                      4) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors",
+          
+            (SELECT U0."end_at" AS "end_at"
+             FROM "approvals_approval" U0
+             WHERE U0."user_id" = ("users_user"."id")
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_approval_end_at",
+          
+            (SELECT U0."end_date" AS "end_date"
+             FROM "companies_contract" U0
+             WHERE (U0."end_date" IS NOT NULL
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_contract_end_date",
+                 "users_jobseekerprofile"."fields_history",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."ft_gps_id",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."ase_exit",
+                 "users_jobseekerprofile"."isolated_parent",
+                 "users_jobseekerprofile"."housing_issue",
+                 "users_jobseekerprofile"."refugee",
+                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
+                 "users_jobseekerprofile"."low_level_in_french",
+                 "users_jobseekerprofile"."mobility_issue",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."is_not_stalled_anymore"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s)))
+                 AND
+                   (SELECT U0."end_at" AS "end_at"
+                    FROM "approvals_approval" U0
+                    WHERE U0."user_id" = ("users_user"."id")
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41,
+                   "users_jobseekerprofile"."user_id"
+          ORDER BY 40 DESC,
+                   "users_user"."id" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."approval_id" IN (%s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[job_seekers_views/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[job_seekers_views/list.html]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
+        ''',
+      }),
+    ]),
+  })
+# ---
+# name: test_filtered_by_end_of_iae_journey[/job-seekers/list]
+  dict({
+    'num_queries': 16,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_nexususer"."id",
+                 "nexus_nexususer"."source",
+                 "nexus_nexususer"."source_id",
+                 "nexus_nexususer"."source_kind",
+                 "nexus_nexususer"."first_name",
+                 "nexus_nexususer"."last_name",
+                 "nexus_nexususer"."email",
+                 "nexus_nexususer"."phone",
+                 "nexus_nexususer"."last_login",
+                 "nexus_nexususer"."auth",
+                 "nexus_nexususer"."kind",
+                 "nexus_nexususer"."updated_at",
+                 COALESCE(
+                            (SELECT U0."valid_since" AS "valid_since"
+                             FROM "nexus_nexusressourcesyncstatus" U0
+                             WHERE U0."service" = ("nexus_nexususer"."source")
+                             ORDER BY RANDOM() ASC
+                             LIMIT 1), %s) AS "_threshold"
+          FROM "nexus_nexususer"
+          WHERE ("nexus_nexususer"."updated_at" >= (COALESCE(
+                                                               (SELECT U0."valid_since" AS "valid_since"
+                                                                FROM "nexus_nexusressourcesyncstatus" U0
+                                                                WHERE U0."service" = ("nexus_nexususer"."source")
+                                                                ORDER BY RANDOM() ASC
+                                                                LIMIT 1), %s))
+                 AND "nexus_nexususer"."email" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_service_users[nexus/utils.py]',
+          'dropdown_status[nexus/utils.py]',
+          'DropDownMiddleware.__call__[nexus/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "nexus_activatedservice"."id",
+                 "nexus_activatedservice"."user_id",
+                 "nexus_activatedservice"."service",
+                 "nexus_activatedservice"."created_at"
+          FROM "nexus_activatedservice"
+          WHERE "nexus_activatedservice"."user_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s
+                         AND U0."professional_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s
+                               AND U0."professional_id" = %s))))
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41
+          ORDER BY "users_user"."last_name" ASC,
+                   "users_user"."first_name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE ("prescribers_prescribermembership"."organization_id" = %s
+                 AND "users_user"."id" IN
+                   (SELECT V1."professional_id" AS "job_seeker_assignments__professional"
+                    FROM "users_user" V0
+                    LEFT OUTER JOIN "users_jobseekerassignment" V1 ON (V0."id" = V1."job_seeker_id")
+                    WHERE (V0."kind" = %s
+                           AND V0."id" IN
+                             (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                              FROM "users_jobseekerassignment" U0
+                              WHERE ((U0."company_id" IS NULL
+                                      AND U0."prescriber_organization_id" IS NULL
+                                      AND U0."professional_id" = %s)
+                                     OR (U0."company_id" IS NULL
+                                         AND U0."prescriber_organization_id" = %s
+                                         AND U0."professional_id" = %s))))
+                    GROUP BY V0."id",
+                             1))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouPaginator.count[<site-packages>/django/core/paginator.py]',
+          'pager[utils/pagination.py]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                    COALESCE(
+                               (SELECT COUNT(U0."id") AS "count"
+                                FROM "job_applications_jobapplication" U0
+                                WHERE (((U0."sender_id" = %s
+                                         AND U0."sender_prescriber_organization_id" IS NULL)
+                                        OR U0."sender_prescriber_organization_id" = %s)
+                                       AND U0."job_seeker_id" = ("users_user"."id"))
+                                GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+               (SELECT MAX(U0."updated_at") AS "last_action_at"
+                FROM "users_jobseekerassignment" U0
+                WHERE (((U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" IS NULL
+                         AND U0."professional_id" = %s)
+                        OR (U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" = %s
+                            AND U0."professional_id" = %s))
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                GROUP BY U0."job_seeker_id"
+                LIMIT 1) AS "last_updated_at",
+          
+               (SELECT U0."id" AS "id"
+                FROM "eligibility_eligibilitydiagnosis" U0
+                WHERE (U0."expires_at" > %s
+                       AND U0."author_kind" = %s
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY U0."created_at" DESC
+                LIMIT 1) AS "valid_eligibility_diagnosis",
+          
+               (SELECT U0."end_at" AS "end_at"
+                FROM "approvals_approval" U0
+                WHERE U0."user_id" = ("users_user"."id")
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_approval_end_at",
+          
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s
+                                  AND U0."professional_id" = %s)))
+                    AND
+                      (SELECT U0."end_at" AS "end_at"
+                       FROM "approvals_approval" U0
+                       WHERE U0."user_id" = ("users_user"."id")
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id",
+                      1,
+                      2,
+                      4) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
+                 COALESCE(
+                            (SELECT COUNT(U0."id") AS "count"
+                             FROM "job_applications_jobapplication" U0
+                             WHERE (((U0."sender_id" = %s
+                                      AND U0."sender_prescriber_organization_id" IS NULL)
+                                     OR U0."sender_prescriber_organization_id" = %s)
+                                    AND U0."job_seeker_id" = ("users_user"."id"))
+                             GROUP BY U0."job_seeker_id"), %s) AS "job_applications_nb",
+          
+            (SELECT MAX(U0."updated_at") AS "last_action_at"
+             FROM "users_jobseekerassignment" U0
+             WHERE (((U0."company_id" IS NULL
+                      AND U0."prescriber_organization_id" IS NULL
+                      AND U0."professional_id" = %s)
+                     OR (U0."company_id" IS NULL
+                         AND U0."prescriber_organization_id" = %s
+                         AND U0."professional_id" = %s))
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             GROUP BY U0."job_seeker_id"
+             LIMIT 1) AS "last_updated_at",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND U0."author_kind" = %s
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "valid_eligibility_diagnosis",
+                 ARRAY_AGG(DISTINCT "users_jobseekerassignment"."professional_id") AS "advisors",
+          
+            (SELECT U0."end_at" AS "end_at"
+             FROM "approvals_approval" U0
+             WHERE U0."user_id" = ("users_user"."id")
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_approval_end_at",
+          
+            (SELECT U0."end_date" AS "end_date"
+             FROM "companies_contract" U0
+             WHERE (U0."end_date" IS NOT NULL
+                    AND U0."job_seeker_id" = ("users_user"."id"))
+             ORDER BY 1 DESC
+             LIMIT 1) AS "last_contract_end_date",
+                 "users_jobseekerprofile"."fields_history",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."ft_gps_id",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."ase_exit",
+                 "users_jobseekerprofile"."isolated_parent",
+                 "users_jobseekerprofile"."housing_issue",
+                 "users_jobseekerprofile"."refugee",
+                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
+                 "users_jobseekerprofile"."low_level_in_french",
+                 "users_jobseekerprofile"."mobility_issue",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."is_not_stalled_anymore"
+          FROM "users_user"
+          LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE ((U0."company_id" IS NULL
+                            AND U0."prescriber_organization_id" IS NULL
+                            AND U0."professional_id" = %s)
+                           OR (U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" = %s
+                               AND U0."professional_id" = %s)))
+                 AND
+                   (SELECT U0."end_at" AS "end_at"
+                    FROM "approvals_approval" U0
+                    WHERE U0."user_id" = ("users_user"."id")
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
+          GROUP BY "users_user"."id",
+                   38,
+                   39,
+                   41,
+                   "users_jobseekerprofile"."user_id"
+          ORDER BY 40 DESC,
+                   "users_user"."id" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."approval_id" IN (%s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[job_seekers_views/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[job_seekers_views/list.html]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
+        ''',
+      }),
+    ]),
+  })
+# ---
 # name: test_multiple.1
   dict({
     'num_queries': 19,

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -103,8 +103,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_active-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_active" id="id_approval_active-offcanvas" name="approval_active" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_active-offcanvas">
                                           Valide
                                       </label>
                                   </div>
@@ -113,8 +113,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_expired-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_expired" id="id_approval_expired-offcanvas" name="approval_expired" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_expired-offcanvas">
                                           Expiré
                                       </label>
                                   </div>
@@ -123,8 +123,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
-                                      <label class="form-check-label" for="id_no_pass_iae-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_no_approval" id="id_no_approval-offcanvas" name="no_approval" type="checkbox"/>
+                                      <label class="form-check-label" for="id_no_approval-offcanvas">
                                           Aucun
                                       </label>
                                   </div>
@@ -213,8 +213,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_active">
+                                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_active">
                                                       Valide
                                                   </label>
                                               </div>
@@ -223,8 +223,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_expired">
                                                       Expiré
                                                   </label>
                                               </div>
@@ -233,8 +233,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_no_pass_iae" name="no_pass_iae" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_no_pass_iae">
+                                                  <input class="form-check-input is-valid" id="id_no_approval" name="no_approval" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_no_approval">
                                                       Aucun
                                                   </label>
                                               </div>
@@ -425,8 +425,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_active-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_active" id="id_approval_active-offcanvas" name="approval_active" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_active-offcanvas">
                                           Valide
                                       </label>
                                   </div>
@@ -435,8 +435,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
-                                      <label class="form-check-label" for="id_pass_iae_expired-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_approval_expired" id="id_approval_expired-offcanvas" name="approval_expired" type="checkbox"/>
+                                      <label class="form-check-label" for="id_approval_expired-offcanvas">
                                           Expiré
                                       </label>
                                   </div>
@@ -445,8 +445,8 @@
                           <li>
                               <div class="dropdown-item">
                                   <div class="form-check">
-                                      <input class="form-check-input" data-emplois-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
-                                      <label class="form-check-label" for="id_no_pass_iae-offcanvas">
+                                      <input class="form-check-input" data-emplois-sync-with="id_no_approval" id="id_no_approval-offcanvas" name="no_approval" type="checkbox"/>
+                                      <label class="form-check-label" for="id_no_approval-offcanvas">
                                           Aucun
                                       </label>
                                   </div>
@@ -518,8 +518,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_active">
+                                                  <input class="form-check-input is-valid" id="id_approval_active" name="approval_active" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_active">
                                                       Valide
                                                   </label>
                                               </div>
@@ -528,8 +528,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_pass_iae_expired" name="pass_iae_expired" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_pass_iae_expired">
+                                                  <input class="form-check-input is-valid" id="id_approval_expired" name="approval_expired" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_approval_expired">
                                                       Expiré
                                                   </label>
                                               </div>
@@ -538,8 +538,8 @@
                                       <li>
                                           <div class="dropdown-item">
                                               <div class="form-check">
-                                                  <input class="form-check-input is-valid" id="id_no_pass_iae" name="no_pass_iae" type="checkbox"/>
-                                                  <label class="form-check-label" for="id_no_pass_iae">
+                                                  <input class="form-check-input is-valid" id="id_no_approval" name="no_approval" type="checkbox"/>
+                                                  <label class="form-check-label" for="id_no_approval">
                                                       Aucun
                                                   </label>
                                               </div>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1128,6 +1128,40 @@ def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
     assert response.context["page_obj"].object_list == [job_seeker]
 
 
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_for_siae(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+
+    # The filter is now available for an IAE SIAE, like for authorized prescribers.
+    response = client.get(url)
+    assertContains(response, "Fin de parcours IAE à venir")
+    assertContains(response, "Contrat IAE bientôt terminé")
+
+    # A contract ending soon WITH this SIAE is in the cohort.
+    job_seeker_own = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_own,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    # A contract ending soon WITH ANOTHER SIAE must be ignored (scoping avoids the false positive).
+    job_seeker_other_company = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_other_company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_own]
+
+
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_suspended_approval_info_tooltip(client, url):
     organization = PrescriberOrganizationWith2MembershipFactory()

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -952,22 +952,22 @@ def test_filtered_by_approval_state(client, factory, url):
         with_job_seeker_assignment=True,
     ).job_seeker
 
-    response = client.get(url, {"pass_iae_active": "on"})
+    response = client.get(url, {"approval_active": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_expired_eligibility_valid_approval]
 
-    response = client.get(url, {"pass_iae_expired": "on"})
+    response = client.get(url, {"approval_expired": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_expired_eligibility_expired_approval]
 
-    response = client.get(url, {"no_pass_iae": "on"})
+    response = client.get(url, {"no_approval": "on"})
     assert response.context["page_obj"].object_list == [job_seeker_valid_eligibility_no_approval]
 
-    response = client.get(url, {"pass_iae_expired": "on", "no_pass_iae": "on"})
+    response = client.get(url, {"approval_expired": "on", "no_approval": "on"})
     assert response.context["page_obj"].object_list == [
         job_seeker_valid_eligibility_no_approval,
         job_seeker_expired_eligibility_expired_approval,
     ]
 
-    response = client.get(url, {"pass_iae_active": "on", "pass_iae_expired": "on", "no_pass_iae": "on"})
+    response = client.get(url, {"approval_active": "on", "approval_expired": "on", "no_approval": "on"})
     assert response.context["page_obj"].object_list == [
         job_seeker_valid_eligibility_no_approval,
         job_seeker_expired_eligibility_expired_approval,

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1162,6 +1162,91 @@ def test_end_of_iae_journey_filter_for_siae(client):
     assert response.context["page_obj"].object_list == [job_seeker_own]
 
 
+@freeze_time("2026-01-15")
+def test_fins_de_contrats_banners_for_siae(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+
+    # No contract ending soon: neither banner.
+    response = client.get(url)
+    assertNotContains(response, "Afficher ces salariés")
+    assertNotContains(response, "Suggérer une suite de parcours aux salariés")
+
+    # A salarié with a contract ending soon: discovery banner on the unfiltered list.
+    job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    response = client.get(url)
+    assertContains(response, "Vous avez 1 salarié en fin de contrat")
+    assertContains(response, "Afficher ces salariés")
+    assertNotContains(response, "Suggérer une suite de parcours aux salariés")
+
+    # When the end-of-journey filter is active: pedagogic banner replaces the discovery banner.
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assertContains(response, "Suggérer une suite de parcours aux salariés")
+    assertNotContains(response, "Afficher ces salariés")
+
+
+@freeze_time("2026-01-15")
+@override_settings(TALLY_URL="https://tally.example", TALLY_SUGGEST_NEXT_STEP_FORM_ID="wSUGGEST")
+def test_suggest_next_step_action_in_list(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+    ending_soon = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=ending_soon,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    # A salarié with no contract ending soon: no action on their row.
+    JobSeekerAssignmentFactory(professional=employer, company=company)
+
+    # Unfiltered: the action is offered on the row of the salarié ending soon (mirroring the card banner),
+    # exactly once, and it links to the configured Tally form.
+    response = client.get(url)
+    assertContains(response, "Suggérer une suite de parcours")
+    assertContains(response, "https://tally.example/r/wSUGGEST", count=1)
+
+    # With the end-of-journey filter active, only the salarié ending soon remains, still with the action.
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assertContains(response, "https://tally.example/r/wSUGGEST", count=1)
+
+
+@freeze_time("2026-01-15")
+@override_settings(TALLY_URL="https://tally.example", TALLY_SUGGEST_NEXT_STEP_FORM_ID="wSUGGEST")
+def test_suggest_next_step_banner_on_job_seeker_card(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    today = datetime.date(2026, 1, 15)
+    job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+
+    response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
+    assertContains(response, "Le contrat arrive bientôt à échéance")
+    assertContains(response, "04/02/2026")
+    assertContains(response, "https://tally.example/r/wSUGGEST")
+
+
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_suspended_approval_info_tooltip(client, url):
     organization = PrescriberOrganizationWith2MembershipFactory()

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -19,7 +19,12 @@ from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
 from itou.utils.templatetags.str_filters import mask_unless
 from tests.approvals.factories import ApprovalFactory, SuspensionFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, CompanyWith2MembershipsFactory
+from tests.companies.factories import (
+    CompanyFactory,
+    CompanyMembershipFactory,
+    CompanyWith2MembershipsFactory,
+    ContractFactory,
+)
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import (
@@ -973,6 +978,154 @@ def test_filtered_by_approval_state(client, factory, url):
         job_seeker_expired_eligibility_expired_approval,
         job_seeker_expired_eligibility_valid_approval,
     ]
+
+
+@freeze_time("2026-01-15")
+@pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
+def test_filtered_by_end_of_iae_journey(client, url, snapshot):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    authorized_prescriber = organization.members.first()
+    client.force_login(authorized_prescriber)
+
+    today = timezone.localdate()
+
+    def add_soon_ending_approval(job_seeker):
+        ApprovalFactory(
+            user=job_seeker,
+            start_at=today - datetime.timedelta(days=600),
+            end_at=today + datetime.timedelta(days=30),
+        )
+
+    def add_soon_ending_contract(job_seeker):
+        ContractFactory(
+            job_seeker=job_seeker,
+            start_date=today - datetime.timedelta(days=200),
+            end_date=today + datetime.timedelta(days=20),
+        )
+
+    # Only a PASS IAE ending soon.
+    job_seeker_pass_only = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_approval(job_seeker_pass_only)
+
+    # Only an IAE contract ending soon.
+    job_seeker_contract_only = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_contract(job_seeker_contract_only)
+
+    # Both a PASS IAE and an IAE contract ending soon.
+    job_seeker_both = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    add_soon_ending_approval(job_seeker_both)
+    add_soon_ending_contract(job_seeker_both)
+
+    # Neither ends soon.
+    job_seeker_neither = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ApprovalFactory(
+        user=job_seeker_neither,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=91),
+    )
+    ContractFactory(
+        job_seeker=job_seeker_neither,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=31),
+    )
+
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_pass_only, job_seeker_both}
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {job_seeker_contract_only, job_seeker_both}
+
+    # Both checked => AND: only the job seeker with both a soon PASS and a soon contract.
+    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_both]
+
+    # Check queries
+    with assertSnapshotQueries(snapshot):
+        client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_edge_cases(client):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    authorized_prescriber = organization.members.first()
+    client.force_login(authorized_prescriber)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+
+    # PASS ending exactly on the 90-day boundary is included (range is inclusive).
+    job_seeker_pass_boundary = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ApprovalFactory(
+        user=job_seeker_pass_boundary,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=90),
+    )
+
+    # Contract ending exactly on the 30-day boundary is included.
+    job_seeker_contract_boundary = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_contract_boundary,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=30),
+    )
+
+    # A contract without an end date (ongoing) is ignored.
+    job_seeker_contract_no_end = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_contract_no_end,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=None,
+    )
+
+    # Several contracts: only the latest end date counts (an older one already ended).
+    job_seeker_multiple_contracts = JobSeekerAssignmentFactory(professional=authorized_prescriber).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=400),
+        end_date=today - datetime.timedelta(days=200),
+    )
+    ContractFactory(
+        job_seeker=job_seeker_multiple_contracts,
+        start_date=today - datetime.timedelta(days=100),
+        end_date=today + datetime.timedelta(days=15),
+    )
+
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_pass_boundary]
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert set(response.context["page_obj"].object_list) == {
+        job_seeker_contract_boundary,
+        job_seeker_multiple_contracts,
+    }
+
+
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
+    # A non-authorized prescriber neither sees the filter nor is affected by its query params.
+    organization = PrescriberOrganizationFactory(with_membership=True)
+    prescriber = organization.members.first()
+    client.force_login(prescriber)
+    url = reverse("job_seekers_views:list")
+
+    today = datetime.date(2026, 1, 15)
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=prescriber,
+        author_prescriber_organization=organization,
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    # PASS ending far in the future: it would be filtered out if the filter applied.
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=100),
+        end_at=today + datetime.timedelta(days=200),
+    )
+
+    assertNotContains(client.get(url), "Fin de parcours IAE à venir")
+
+    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker]
 
 
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les SIAE ont besoin d'anticiper la fin de parcours IAE de leurs salariés pour préparer une suite adaptée (formation, emploi, accompagnement). Aujourd'hui, rien ne signale côté employeur qu'un contrat approche de son terme.

Cette PR s'appuie sur le filtre « Fin de parcours IAE à venir » introduit pour les prescripteurs habilités (#8500) et l'étend aux employeurs SIAE, avec les points d'entrée et les incitations pour repérer ces salariés et leur suggérer une suite de parcours.

> Empilée sur la branche de #8500 (`abdess/fin-parcours-iae`). À rebaser sur `main` une fois #8500 fusionnée ; le diff ne montre alors que les changements de cette PR.

## :cake: Comment ?

- **Filtre** : le filtre « Fin de parcours IAE à venir » est ouvert aux SIAE, avec la détection des contrats se terminant sous 30 jours **restreinte à la structure courante** (un contrat signé avec une autre structure, ou un contrat renouvelé, ne fausse pas la cohorte). Définition partagée par un seul helper (`annotate_last_contract_end_date`), réutilisé par le compteur, le filtre, l'encart et la fiche.
- **Tableau de bord** : une entrée « Fins de contrats » avec un compteur des salariés concernés.
- **Encarts** : un encart de découverte sur la liste non filtrée, remplacé par un encart pédagogique quand le filtre est actif.
- **Action « Suggérer une suite de parcours »** : proposée sur chaque salarié en fin de contrat, depuis le menu « ⋮ » de la liste comme depuis sa fiche, vers un formulaire Tally configurable par variable d'environnement (`TALLY_SUGGEST_NEXT_STEP_FORM_ID`). L'action reste masquée tant que le formulaire n'est pas configuré.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ? Non, aucun changement cassant.
- [ ] Ajouter l'étiquette « Bug » ? Non, nouvelle fonctionnalité.

## :desert_island: Comment tester ?

En tant qu'employeur d'une SIAE (soumise aux règles IAE), avec un salarié rattaché dont un contrat se termine dans moins de 30 jours :

1. **Tableau de bord** → carte employeur : entrée « Fins de contrats » avec le compteur.
2. **Accompagnements** (liste de la structure) sans filtre → encart de découverte « Vous avez N salarié·s en fin de contrat » + bouton « Afficher ces salariés ».
3. Cocher **« Contrat IAE bientôt terminé »** → la liste se réduit aux salariés concernés, l'encart devient pédagogique.
4. Sur la ligne d'un salarié en fin de contrat → menu **⋮** → **« Suggérer une suite de parcours »** (visible aussi sans filtre).
5. Fiche du salarié → encart « Le contrat arrive bientôt à échéance le … » avec le même bouton.

L'action « Suggérer une suite de parcours » n'apparaît que si `TALLY_SUGGEST_NEXT_STEP_FORM_ID` est configuré.
