### PR TITLE
Faire en sorte que le Makefile fonctionne aussi sur Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,4 @@ $(DBDUMP): itou/fixtures/*/*.sql itou/fixtures/*/*.json itou/*/fixtures.py itou/
 
 # Recreate the database when fixtures change.
 resetdb: $(DBDUMP)
-	if (( $(DBREADY) == 0 )); then $(MAKE) dumprestore; fi
+	if [ $(DBREADY) = 0 ]; then $(MAKE) dumprestore; fi


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec la version actuelle je ne peux pas utiliser `make resetdb` :

```bash
$ make resetdb
if (( 0 == 0 )); then make dumprestore; fi
/bin/sh: 1: 0: not found
```

## :cake: Comment ? <!-- optionnel -->

Le problème provient d'un `bashism` : `((` n'existe qu'en `bash`, pas dans `sh`. Ça se contourne aisément en utilisant `test` ou `[` à la place, qui est valide en `sh`.

Je me demande cependant comment ça pouvait fonctionner chez les autres, si quelqu'un a un indice, je prends.
