### PR TITLE
Documenting alternative to docker packaged on Debian: podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,20 @@ sont rendues disponibles par [Docker](https://docs.docker.com/) et
 - [Installer Docker Compose](https://docs.docker.com/compose/install/)
 
 Démarrez les dépendances de développement avec la commande :
+
 ```sh
 docker compose up
+# ou
+podman compose up
 ```
 
 **Note** : Vous pouvez personnaliser la configuration des dépendances gérées
 par Docker Compose en créant [un fichier
 `.env`](https://docs.docker.com/compose/env-file/) au même niveau que le
 fichier `README.md`.
+
+**Note** : Podman s'installe sur Debian via `sudo apt install podman
+podman-compose`.
 
 ### Dépendances Python
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: minio/minio
+    image: docker.io/minio/minio
     container_name: itou_minio
     restart: unless-stopped
     environment:
@@ -17,7 +17,7 @@ services:
   # https://hub.docker.com/r/mdillon/postgis/tags
   postgres:
     container_name: itou_postgres
-    image: postgis/postgis:17-master
+    image: docker.io/postgis/postgis:17-master
     # Disable some safety switches for a faster postgres: https://www.postgresql.org/docs/current/non-durability.html
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     environment:
@@ -45,7 +45,7 @@ services:
       - "127.0.0.1:${POSTGRES_PORT_ON_DOCKER_HOST:-5432}:5432"
 
   redis:
-    image: redis
+    image: docker.io/redis
     container_name: itou_redis
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## :thinking: Pourquoi ?

docker n'est pas packagé pour Debian, j'essaye, pour des raisons d'aisance de mise à jour (et de sécurité) de ne jamais installer de paquets sur ma Debian s'ils ne sont pas distribués par Debian.

Aussi `podman` semble plus sûr que `docker` : contrairement à Docker, `podman` n'a besoin d'aucun accès root, ni aucun service `root`.


## :cake: Comment ? <!-- optionnel -->

Il suffit d'installer podman `sudo apt install podman podman-compose` et d'utiliser `podman compose up` à la place de `docker compose up`, ce que j'ai documenté dans ce commit.

Podman ne prend pas ses images de docker par défaut, il faut donc soit le configurer (dans `/etc/comtainers/`, c'est une étape supplémentaire pour tout le monde), soit utiliser des noms d'images explicites (ce que j'ai préféré ici, la modification semble compatible avec Docker [selon la doc de docker-compose](https://docs.docker.com/reference/compose-file/services/#image) mais je n'ai pas essayé).