### PR TITLE
FIX: Formatting does not happen magically in exceptions.

### DIFF
--- a/itou/companies/management/commands/import_ea_eatt.py
+++ b/itou/companies/management/commands/import_ea_eatt.py
@@ -123,7 +123,7 @@ class Command(BaseCommand):
     def process_file(self, file, *, wet_run=False):
         header = next(file)
         if not header.startswith("L|ASP|EA|"):  # Start of file header
-            raise RuntimeError("File doesn't conform to the expected format: %s", "L|ASP|EA|")
+            raise RuntimeError("File doesn't conform to the expected format: L|ASP|EA|")
 
         columns = next(file).rstrip("\n|").split("|")[1:]
         rows = []
@@ -133,7 +133,7 @@ class Command(BaseCommand):
                 break
             rows.append(dict(zip(columns, line.rstrip("\n|").split("|")[1:])))
         else:
-            raise RuntimeError("File doesn't conform to the expected format: %s", "Z|ASP|EA|")
+            raise RuntimeError("File doesn't conform to the expected format: Z|ASP|EA|")
 
         if not rows:
             self.logger.info("No rows found in file '%s', nothing to be done", file.name)

--- a/itou/openid_connect/pro_connect/models.py
+++ b/itou/openid_connect/pro_connect/models.py
@@ -42,7 +42,7 @@ class ProConnectUserData(OIDConnectUserData):
 
     def join_org(self, user: User, safir: str):
         if not user.is_professional:
-            raise ValueError("Invalid user kind: %s", user.kind)
+            raise ValueError(f"Invalid user kind: {user.kind}")
         try:
             organization = PrescriberOrganization.objects.get(code_safir_pole_emploi=safir)
         except PrescriberOrganization.DoesNotExist:

--- a/itou/www/gps/views.py
+++ b/itou/www/gps/views.py
@@ -246,7 +246,7 @@ def get_user_kind_display(user):
         return "professionnel"
     elif user.is_job_seeker:
         return "candidat"
-    raise ValueError("Invalid user kind: %s", user.kind)
+    raise ValueError(f"Invalid user kind: {user.kind}")
 
 
 @require_POST
@@ -259,7 +259,7 @@ def display_contact_info(request, group_id, target_participant_public_id, mode):
         "phone": "gps/includes/member_phone.html",
     }.get(mode, None)
     if not template_name:
-        raise ValueError("Invalid mode: %s", mode)
+        raise ValueError(f"Invalid mode: {mode}")
 
     are_colleagues = False
 

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1622,7 +1622,7 @@ def display_advisor_contact_info(
         "phone": lambda assignment: assignment.advisor.phone,
     }.get(mode)
     if not getter:
-        raise ValueError("Invalid mode: %s", mode)
+        raise ValueError(f"Invalid mode: {mode}")
     assignment = get_object_or_404(
         JobSeekerAssignment.objects.select_related("company", "professional", "prescriber_organization"),
         pk=assignment_id,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les exceptions en python acceptent `*args`, mais ne font pas de formattage :

```python
>>> raise ValueError(1, 2, 3)
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    raise ValueError(1, 2, 3)
ValueError: (1, 2, 3)
>>> raise ValueError("%s", "a")
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    raise ValueError("%s", "a")
ValueError: ('%s', 'a')
```

## :cake: Comment ? <!-- optionnel -->

Je remplace par une f-string pour formatter au moment où l'exception est levée.

