### PR TITLE
FIX: querystring urlencode ses arguments, les encoder doublement casse le lien.

### DIFF
--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -23,7 +23,7 @@
                 <p>
                     Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
                     {% if can_view_personal_information and not request.user.is_job_seeker %}
-                        <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker_public_id=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
+                        <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker_public_id=job_seeker.public_id from_url=request.get_full_path %}">Vérifier le profil</a>
                     {% endif %}
                     {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>{% endif %}
                 </p>

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -18,9 +18,7 @@
         {% endfragment %}
         {% fragment as c_title__cta %}
             {% url "job_seekers_views:get_or_create_start" as get_or_create_url %}
-            <a href="{% url_add_query get_or_create_url tunnel='standalone' from_url=request.path|urlencode %}"
-               {% matomo_event "compte-candidat" "clic" "creer-un-compte-candidat" %}
-               class="btn btn-lg btn-secondary btn-ico">
+            <a href="{% url_add_query get_or_create_url tunnel='standalone' from_url=request.path %}" {% matomo_event "compte-candidat" "clic" "creer-un-compte-candidat" %} class="btn btn-lg btn-secondary btn-ico">
                 <i class="ri-user-add-line fw-medium" aria-hidden="true"></i>
                 <span>Ajouter un usager</span>
             </a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sur la page apply:application_jobs qui contient un lien "Vérifier le profil", le lien est subtilement cassé, il contient un "from_url" doublement encodé, lorsque l'utilisateur touche ce `from_url` il se prend donc une 404 en touchant :

    https://demo.emplois.inclusion.beta.gouv.fr/apply/32e835b1-97e2-46de-a8c2-a23e1e75f3fb/create/select_jobs%3Fjob_seeker_public_id%253Daede5ec4-a533-4dfc-a709-833f7c334405

à la place de

    https://demo.emplois.inclusion.beta.gouv.fr/apply/32e835b1-97e2-46de-a8c2-a23e1e75f3fb/create/select_jobs?job_seeker_public_id=aede5ec4-a533-4dfc-a709-833f7c334405

(c'est subtil et hors écran, ça se passe après `select_jobs`, où on trouve un `%3F` à la place de `?` puis plus loin un `%253D` à la place de `=`, le `%253D` est le double encodage de `=`, qui se transforme d'abord en `%3D` puis en `%253D`, `25` étant le code de `%`) 


## :cake: Comment ? <!-- optionnel -->

Il suffit d'enlever un étage d'urlencode, le plus compliqué et le test, j'ignore s'il a beaucoup de valeur.


## :desert_island: Comment tester ?

- Aller sur https://demo.emplois.inclusion.beta.gouv.fr/search/employers/results?city=belfort-90
- Cliquer sur Postuler sur une entreprise
- Remplir jusqu'à arriver sur la page "Postuler pour ... ..." contenant sous "Éligibilité IAE à valider" un lien "Vérifier le profil"
- Cliquer sur "Vérifier le profil"
- Cliquer sur Suivant trois fois, inutile de changer le contenu des formulaires.
- Cliquer sur "Valider les informations"
- Erreur 404.

J'ignore si un bug qui n'avait pas été remonté mérite son entrée dans le changelog ?
