### PR TITLE
Contrôle a posteriori : Ne contrôler que les SIAE conventionnées

### DIFF
--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -78,6 +78,13 @@ def _eligible_to_siae_evaluations(job_application):
     eligible = (
         job_application.approval_id is not None
         and job_application.to_company.kind in evaluation_enums.EvaluationSiaesKind.Evaluable
+        and (
+            job_application.to_company.is_active
+            or (
+                job_application.to_company.convention is not None
+                and not job_application.to_company.grace_period_has_expired
+            )
+        )
         and job_application.state == JobApplicationState.ACCEPTED
         and job_application.eligibility_diagnosis
         and job_application.eligibility_diagnosis.author_kind == AuthorKind.EMPLOYER

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -9,6 +9,7 @@ from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q
 from django.utils import timezone
 from django.utils.functional import cached_property
 
+from itou.companies.models import Company
 from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, SelectedAdministrativeCriteria
 from itou.eligibility.utils import iae_has_required_criteria
@@ -220,6 +221,9 @@ class EvaluationCampaign(models.Model):
             JobApplication.objects.exclude(approval=None)
             .select_related("approval", "to_company", "eligibility_diagnosis", "eligibility_diagnosis__author_siae")
             .filter(
+                # The hiring SIAE has to be conventioned, grace period included. Note that companies created by
+                # staff/support are considered active even without a convention.
+                Exists(Company.objects.active_or_in_grace_period().filter(pk=OuterRef("to_company_id"))),
                 to_company__department=self.institution.department,
                 to_company__kind__in=evaluation_enums.EvaluationSiaesKind.Evaluable,
                 state=JobApplicationState.ACCEPTED,

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -218,9 +218,32 @@
             (SELECT "job_applications_jobapplication"."to_company_id" AS "to_company"
              FROM "job_applications_jobapplication"
              INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-             INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
              INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+             INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
              WHERE (NOT ("job_applications_jobapplication"."approval_id" IS NULL)
+                    AND EXISTS
+                      (SELECT %s AS "a"
+                       FROM "companies_company" V0
+                       WHERE (NOT (V0."siret" = %s)
+                              AND NOT (V0."kind" IN (%s, %s))
+                              AND (V0."kind" IN (%s, %s)
+                                   OR (V0."is_searchable"
+                                       AND V0."kind" = %s)
+                                   OR V0."source" = %s
+                                   OR EXISTS
+                                     (SELECT %s AS "a"
+                                      FROM "companies_siaeconvention" U0
+                                      WHERE (U0."id" = (V0."convention_id")
+                                             AND U0."is_active")
+                                      LIMIT 1)
+                                   OR EXISTS
+                                     (SELECT %s AS "a"
+                                      FROM "companies_siaeconvention" U0
+                                      WHERE (U0."deactivated_at" >= %s
+                                             AND U0."id" = (V0."convention_id"))
+                                      LIMIT 1))
+                              AND V0."id" = ("job_applications_jobapplication"."to_company_id"))
+                       LIMIT 1)
                     AND "approvals_approval"."number"::text LIKE %s
                     AND "approvals_approval"."start_at" = ("job_applications_jobapplication"."hiring_start_at")
                     AND "eligibility_eligibilitydiagnosis"."author_kind" = %s
@@ -245,9 +268,32 @@
           SELECT "job_applications_jobapplication"."to_company_id" AS "to_company"
           FROM "job_applications_jobapplication"
           INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           WHERE (NOT ("job_applications_jobapplication"."approval_id" IS NULL)
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_company" V0
+                    WHERE (NOT (V0."siret" = %s)
+                           AND NOT (V0."kind" IN (%s, %s))
+                           AND (V0."kind" IN (%s, %s)
+                                OR (V0."is_searchable"
+                                    AND V0."kind" = %s)
+                                OR V0."source" = %s
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."id" = (V0."convention_id")
+                                          AND U0."is_active")
+                                   LIMIT 1)
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."deactivated_at" >= %s
+                                          AND U0."id" = (V0."convention_id"))
+                                   LIMIT 1))
+                           AND V0."id" = ("job_applications_jobapplication"."to_company_id"))
+                    LIMIT 1)
                  AND "approvals_approval"."number"::text LIKE %s
                  AND "approvals_approval"."start_at" = ("job_applications_jobapplication"."hiring_start_at")
                  AND "eligibility_eligibilitydiagnosis"."author_kind" = %s
@@ -294,9 +340,32 @@
           SELECT COUNT(*) AS "__count"
           FROM "job_applications_jobapplication"
           INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           WHERE (NOT ("job_applications_jobapplication"."approval_id" IS NULL)
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_company" V0
+                    WHERE (NOT (V0."siret" = %s)
+                           AND NOT (V0."kind" IN (%s, %s))
+                           AND (V0."kind" IN (%s, %s)
+                                OR (V0."is_searchable"
+                                    AND V0."kind" = %s)
+                                OR V0."source" = %s
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."id" = (V0."convention_id")
+                                          AND U0."is_active")
+                                   LIMIT 1)
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."deactivated_at" >= %s
+                                          AND U0."id" = (V0."convention_id"))
+                                   LIMIT 1))
+                           AND V0."id" = ("job_applications_jobapplication"."to_company_id"))
+                    LIMIT 1)
                  AND "approvals_approval"."number"::text LIKE %s
                  AND "approvals_approval"."start_at" = ("job_applications_jobapplication"."hiring_start_at")
                  AND "eligibility_eligibilitydiagnosis"."author_kind" = %s
@@ -465,10 +534,33 @@
                  "approvals_approval"."public_id"
           FROM "job_applications_jobapplication"
           INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          INNER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
           INNER JOIN "companies_company" T5 ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = T5."id")
           WHERE (NOT ("job_applications_jobapplication"."approval_id" IS NULL)
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_company" V0
+                    WHERE (NOT (V0."siret" = %s)
+                           AND NOT (V0."kind" IN (%s, %s))
+                           AND (V0."kind" IN (%s, %s)
+                                OR (V0."is_searchable"
+                                    AND V0."kind" = %s)
+                                OR V0."source" = %s
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."id" = (V0."convention_id")
+                                          AND U0."is_active")
+                                   LIMIT 1)
+                                OR EXISTS
+                                  (SELECT %s AS "a"
+                                   FROM "companies_siaeconvention" U0
+                                   WHERE (U0."deactivated_at" >= %s
+                                          AND U0."id" = (V0."convention_id"))
+                                   LIMIT 1))
+                           AND V0."id" = ("job_applications_jobapplication"."to_company_id"))
+                    LIMIT 1)
                  AND "approvals_approval"."number"::text LIKE %s
                  AND "approvals_approval"."start_at" = ("job_applications_jobapplication"."hiring_start_at")
                  AND "eligibility_eligibilitydiagnosis"."author_kind" = %s

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -11,7 +11,7 @@ from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertNumQueries, assertQuerySetEqual
 
 from itou.approvals.enums import Origin
-from itou.companies.enums import CompanyKind
+from itou.companies.enums import CompanyKind, CompanySource
 from itou.eligibility.enums import AdministrativeCriteriaKind, AuthorKind
 from itou.eligibility.models import AdministrativeCriteria
 from itou.institutions.enums import InstitutionKind
@@ -33,7 +33,7 @@ from itou.siae_evaluations.models import (
 )
 from itou.utils.models import InclusiveDateRange
 from tests.approvals.factories import ApprovalFactory
-from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory
+from tests.companies.factories import GRACE_PERIOD, CompanyFactory, CompanyWith2MembershipsFactory
 from tests.eligibility.factories import IAEEligibilityDiagnosisFactory, IAESelectedAdministrativeCriteriaFactory
 from tests.files.factories import FileFactory
 from tests.institutions.factories import (
@@ -224,6 +224,44 @@ class TestEvaluationCampaignManagerEligibleJobApplication:
         assert [] == list(evaluation_campaign.eligible_job_applications())
         for job_app in JobApplication.objects.all():
             assert _eligible_to_siae_evaluations(job_app) == "non"
+
+    def test_siae_convention_in_grace_period(self, campaign_eligible_job_app_objects):
+        evaluation_campaign = EvaluationCampaignFactory()
+        job_app = campaign_eligible_job_app_objects["job_app"]
+        convention = campaign_eligible_job_app_objects["siae"].convention
+        convention.is_active = False
+        convention.deactivated_at = timezone.now() - GRACE_PERIOD + datetime.timedelta(days=1)
+        convention.save()
+        assert [job_app] == list(evaluation_campaign.eligible_job_applications())
+        assert _eligible_to_siae_evaluations(job_app) == "oui"
+
+    def test_siae_convention_after_grace_period(self, campaign_eligible_job_app_objects):
+        evaluation_campaign = EvaluationCampaignFactory()
+        convention = campaign_eligible_job_app_objects["siae"].convention
+        convention.is_active = False
+        convention.deactivated_at = timezone.now() - GRACE_PERIOD - datetime.timedelta(days=1)
+        convention.save()
+        assert [] == list(evaluation_campaign.eligible_job_applications())
+        assert _eligible_to_siae_evaluations(campaign_eligible_job_app_objects["job_app"]) == "non"
+
+    def test_siae_without_convention(self, campaign_eligible_job_app_objects):
+        evaluation_campaign = EvaluationCampaignFactory()
+        siae = campaign_eligible_job_app_objects["siae"]
+        siae.convention = None
+        siae.save()
+        assert [] == list(evaluation_campaign.eligible_job_applications())
+        assert _eligible_to_siae_evaluations(campaign_eligible_job_app_objects["job_app"]) == "non"
+
+    def test_staff_created_siae_without_convention(self, campaign_eligible_job_app_objects):
+        # Staff created companies are considered active until the `import_siae` script brings in fresh data from ASP.
+        evaluation_campaign = EvaluationCampaignFactory()
+        job_app = campaign_eligible_job_app_objects["job_app"]
+        siae = campaign_eligible_job_app_objects["siae"]
+        siae.convention = None
+        siae.source = CompanySource.STAFF_CREATED
+        siae.save()
+        assert [job_app] == list(evaluation_campaign.eligible_job_applications())
+        assert _eligible_to_siae_evaluations(job_app) == "oui"
 
     def test_job_application_not_accepted(self, campaign_eligible_job_app_objects):
         evaluation_campaign = EvaluationCampaignFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

[[Carte Notion](https://app.notion.com/p/gip-inclusion/Corriger-le-script-de-s-lection-des-SIAE-soumises-au-contr-le-3c05f321b6048099b915fb9014a614b7)]

Le contrôle a posteriori ne doit plus concerner que des SIAE avec un **conventionnement en cours de validité**.

## :cake: Comment ?

Solution naïve toute simple : `to_company__convention__is_active=True` rajouté sur `EvaluationCampaign.eligible_job_applications()`.

On prend en compte l'état du conventionnement au moment exact où la campagne est créée. Est-ce que ça suffit ?

Conditions également rajoutées dans `export.py`.

## :desert_island: Comment tester ?

.

## :computer: Captures d'écran <!-- optionnel -->

.
