### PR TITLE
ROME import management commands has changed.

### DIFF
--- a/itou/jobs/models.py
+++ b/itou/jobs/models.py
@@ -60,7 +60,8 @@ class AppellationQuerySet(models.QuerySet):
 class Appellation(models.Model):
     """
     A ROME's appellation.
-    Data is provided by django-admin commands `generate_appellations_for_romes` and `import_appellations_for_romes`.
+
+    Data is provided by django-admin command `sync_romes_and_appellations`.
 
     A job is characterized by a ROME code and a name, but it can have many different appellations.
 


### PR DESCRIPTION
They were removed in ea4abcf168edc045a088081c009cd012596c88a2.

## :thinking: Pourquoi ?

Je lisais le code, j'ai constaté que ces commandes n'existaient plus.

