### PR TITLE
Admin: ajout d'un champ texte pour commenter les passe IAE annulés

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -740,7 +740,7 @@ class ProlongationAdmin(InconsistencyCheckMixin, ProlongationCommonAdmin):
 
 
 @admin.register(models.CancelledApproval)
-class CancelledApprovalAdmin(ReadonlyMixin, ItouModelAdmin):
+class CancelledApprovalAdmin(ItouModelAdmin):
     list_display = (
         "number",
         "start_at",
@@ -758,9 +758,22 @@ class CancelledApprovalAdmin(ReadonlyMixin, ItouModelAdmin):
         "user_nir",
         "origin_siae_siret",
     )
+    readonly_fields = list_display + (
+        "user_birthdate",
+        "pe_notification_status",
+        "pe_notification_time",
+        "pe_notification_endpoint",
+        "pe_notification_exit_code",
+        "user_id_national_pe",
+        "origin_siae_kind",
+        "origin_sender_kind",
+        "origin_prescriber_organization_kind",
+    )  # All but the support remark inline.
+
     list_filter = ("origin_siae_kind", "origin_sender_kind", "origin_prescriber_organization_kind")
     change_list_template = "admin/approvals/change_list_with_stats.html"
     stats_url = reverse_lazy("admin:approvals_cancelledapproval_sent_to_pe_stats")
+    inlines = (PkSupportRemarkInline,)
 
     def get_urls(self):
         additional_urls = [

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -159,6 +159,24 @@ class TestApprovalAdmin:
         assertContains(response, "<h2>PASS IAE : 1</h2>")
         assertContains(response, "<h2>PASS IAE annulés : 1</h2>")
 
+    def test_cancelled_approvals_admin_is_readonly(self, admin_client):
+        """Except for the textarea to comment a cancelled approval, nothing can be modified."""
+        approval = CancelledApprovalFactory()
+        response = admin_client.get(
+            reverse("admin:approvals_cancelledapproval_change", kwargs={"object_id": approval.pk})
+        )
+        soup = parse_response_to_soup(response)
+        assert not soup.select("input[type=text]")
+        assert not soup.select("select")
+
+    def test_cancelled_approvals_can_be_commented(self, admin_client):
+        approval = CancelledApprovalFactory()
+        response = admin_client.get(
+            reverse("admin:approvals_cancelledapproval_change", kwargs={"object_id": approval.pk})
+        )
+        soup = parse_response_to_soup(response)
+        assert soup.select("textarea")
+
     def test_check_inconsistency_check(self, admin_client):
         consistent_approval = ApprovalFactory()
 

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -159,22 +159,17 @@ class TestApprovalAdmin:
         assertContains(response, "<h2>PASS IAE : 1</h2>")
         assertContains(response, "<h2>PASS IAE annulés : 1</h2>")
 
-    def test_cancelled_approvals_admin_is_readonly(self, admin_client):
+    def test_cancelled_approvals_admin_is_readonly_and_can_be_commented(self, admin_client):
         """Except for the textarea to comment a cancelled approval, nothing can be modified."""
         approval = CancelledApprovalFactory()
         response = admin_client.get(
             reverse("admin:approvals_cancelledapproval_change", kwargs={"object_id": approval.pk})
         )
         soup = parse_response_to_soup(response)
+        # The page should be read-only:
         assert not soup.select("input[type=text]")
         assert not soup.select("select")
-
-    def test_cancelled_approvals_can_be_commented(self, admin_client):
-        approval = CancelledApprovalFactory()
-        response = admin_client.get(
-            reverse("admin:approvals_cancelledapproval_change", kwargs={"object_id": approval.pk})
-        )
-        soup = parse_response_to_soup(response)
+        # But contain a single textarea to comment it the cancellation:
         assert soup.select("textarea")
 
     def test_check_inconsistency_check(self, admin_client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

[carte notion](https://app.notion.com/p/gip-inclusion/ADMIN-ajouter-un-espace-commentaire-dans-la-page-d-un-PASS-annul-3b25f321b60480658e6ed3b275dc82ea?v=28f5f321b6048050bcd4000cbfcb3eca).

## :cake: Comment ? <!-- optionnel -->

Comme pour les autres admin, j'ai mis un `PkSupportRemarkInline`, pas besoin d'éditer la base de donnée : c'est une `GenericForeignKey` derrière.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->


Catégorie changelog: Admin.
