### PR TITLE
Accompagnements : Restreindre l'utilisation des filtres IAE

### DIFF
--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -38,12 +38,12 @@ class FilterForm(forms.Form):
         ),
     )
 
-    eligibility_validated = forms.BooleanField(label="Valide", required=False)
-    eligibility_pending = forms.BooleanField(label="À valider", required=False)
-
-    approval_active = forms.BooleanField(label="Valide", required=False)
-    approval_expired = forms.BooleanField(label="Expiré", required=False)
-    no_approval = forms.BooleanField(label="Aucun", required=False)
+    # IAE-specific fields are only created for IAE actors
+    eligibility_validated = None
+    eligibility_pending = None
+    approval_active = None
+    approval_expired = None
+    no_approval = None
 
     is_stalled = forms.BooleanField(label="N’afficher que les usagers sans solution", required=False)
 
@@ -62,6 +62,12 @@ class FilterForm(forms.Form):
             self.fields["organization_members"].choices = self._get_choices_for_organization_members(
                 job_seeker_qs, request.current_organization
             )
+        if request.from_iae_actor:
+            self.fields["eligibility_validated"] = forms.BooleanField(label="Valide", required=False)
+            self.fields["eligibility_pending"] = forms.BooleanField(label="À valider", required=False)
+            self.fields["approval_active"] = forms.BooleanField(label="Valide", required=False)
+            self.fields["approval_expired"] = forms.BooleanField(label="Expiré", required=False)
+            self.fields["no_approval"] = forms.BooleanField(label="Aucun", required=False)
         if request.from_authorized_prescriber:
             self.fields["approval_ending_soon"] = forms.BooleanField(
                 label="PASS IAE bientôt expiré",

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1013,6 +1013,80 @@ def test_filtered_by_approval_state(client, factory, url):
     ]
 
 
+def test_iae_filters_as_non_iae_actor(client, subtests):
+    company = CompanyFactory(not_subject_to_iae_rules=True)
+    user = EmployerFactory(membership=True, membership__company=company)
+
+    # Eligibility and approval both expired
+    job_seeker_expired_eligibility_expired_approval = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        expired=True,
+        job_seeker__first_name="expired eligibility, expired approval",
+        job_seeker__last_name="Zorro",
+    ).job_seeker
+    ApprovalFactory(user=job_seeker_expired_eligibility_expired_approval, expired=True)
+
+    # Eligibility validated
+    job_seeker_valid_eligibility_no_approval = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        job_seeker__first_name="valid eligibility, no approval",
+        job_seeker__last_name="Zorro",
+    ).job_seeker
+
+    # Eligibility to validate
+    job_seeker_expired_eligibility_no_approval = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        expired=True,
+        job_seeker__first_name="expired eligibility, no approval",
+        job_seeker__last_name="Zorro",
+    ).job_seeker
+
+    # Eligibility expired and valid approval
+    job_seeker_expired_eligibility_valid_approval = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        expired=True,
+        job_seeker__first_name="expired eligibility, valid approval",
+        job_seeker__last_name="Zorro",
+    ).job_seeker
+    ApprovalFactory(user=job_seeker_expired_eligibility_valid_approval)
+
+    # Valid eligibility and valid approval
+    job_seeker_valid_eligibility_valid_approval = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        job_seeker__first_name="valid eligibility, valid approval",
+        job_seeker__last_name="Zorro",
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    ApprovalFactory(user=job_seeker_valid_eligibility_valid_approval)
+
+    job_seekers = [
+        job_seeker_expired_eligibility_expired_approval,
+        job_seeker_valid_eligibility_no_approval,
+        job_seeker_expired_eligibility_no_approval,
+        job_seeker_expired_eligibility_valid_approval,
+        job_seeker_valid_eligibility_valid_approval,
+    ]
+
+    for job_seeker in reversed(job_seekers):
+        JobSeekerAssignmentFactory(professional=user, company=company, job_seeker=job_seeker)
+
+    url = reverse("job_seekers_views:list_organization")
+    iae_filters = {
+        "eligibility pending": {"eligibility_pending": "on"},
+        "eligibility validated": {"eligibility_validated": "on"},
+        "approval active": {"approval_active": "on"},
+        "approval expired": {"approval_expired": "on"},
+        "no approval": {"no_approval": "on"},
+        "approval expired or no approval": {"approval_expired": "on", "no_approval": "on"},
+    }
+    client.force_login(user)
+
+    for label, iae_filter in iae_filters.items():
+        with subtests.test(filters=label):
+            response = client.get(url, iae_filter)
+            assert response.context["page_obj"].object_list == job_seekers
+
+
 @freeze_time("2026-01-15")
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_filtered_by_end_of_iae_journey(client, url, snapshot):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les filtres sur la situation IAE d'un usager ne sont pas affichés sur les accompagnements des GEIQ et OPCS, mais peuvent être utilisés malgré tout tant qu'ils sont spécifiés dans l'URL.

## :cake: Comment ? <!-- optionnel -->

Créer les champs liés aux filtres IAE uniquement pour les acteurs IAE.
On pourrait aussi récupérer `request.from_iae_actor` et appliquer les filtres (ou non) dans `filter()` selon. Je n'ai pas de préférence.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

J'ai créé des utilisateurs avec une situation IAE distincte, et vérifié qu'en toute circonstance, peu importe les filtres utilisés, la liste des accompagnements ne change pas.