### PR TITLE
Interface : Redirection vers le nouveau domaine + information des utilisateurs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -163,6 +163,7 @@ MIDDLEWARE = [
     "itou.www.middleware.TermsAcceptanceMiddleware",
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
     "itou.www.middleware.never_cache",
+    "itou.www.middleware.RedirectToNewDomainMiddleware",
     "itou.www.middleware.RateLimitMiddleware",
     "itou.nexus.middleware.AutoLoginMiddleware",
     "itou.nexus.middleware.DropDownMiddleware",
@@ -930,3 +931,6 @@ REQUIRE_MFA_ON_ORGANIZATION_IDS = _read_id_list("otp/data/mfa_required_organizat
 
 # Delay until job descriptions or spontaneous job applications are deactivated
 DEACTIVATION_DELAY = datetime.timedelta(days=90)
+
+REDIRECT_TO_NEW_DOMAIN = os.getenv("REDIRECT_TO_NEW_DOMAIN", "False") == "True"
+NEW_DOMAIN = "plateforme.inclusion.gouv.fr"

--- a/itou/templates/account/pre_login.html
+++ b/itou/templates/account/pre_login.html
@@ -14,6 +14,26 @@
             <h1>Se connecter</h1>
         {% endfragment %}
     {% endcomponent_title %}
+
+    {% if redirected_from_old_domain %}
+        {% component_alert title=title content=content variant="info" icon=False %}
+            {% fragment as title %}
+                La plateforme de l’inclusion change d’adresse.
+            {% endfragment %}
+            {% fragment as content %}
+                <p class="mb-2">
+                    Vous venez de l’ancienne adresse (emplois.inclusion.beta.gouv.fr). La plateforme de l’inclusion est désormais accessible à sa nouvelle adresse : <a href="https://plateforme.inclusion.gouv.fr">https://plateforme.inclusion.gouv.fr</a>.
+                </p>
+                <p class="mb-0">
+                    Nous vous invitons à mettre à jour vos favoris de
+                    navigateur, configurations d’auto-complétion de
+                    formulaire de connexion (gestionnaire de mots de passe),
+                    etc.
+                </p>
+            {% endfragment %}
+        {% endcomponent_alert %}
+    {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/itou/www/constants.py
+++ b/itou/www/constants.py
@@ -1,0 +1,1 @@
+REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM = "redirected-from-old-domain"

--- a/itou/www/home/views.py
+++ b/itou/www/home/views.py
@@ -3,11 +3,18 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 from itou.utils.readonly import readonly_view
+from itou.www.constants import REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM
 
 
 @login_not_required
 @readonly_view
 def home(request):
     if request.user.is_authenticated:
-        return HttpResponseRedirect(reverse("dashboard:index"))
-    return HttpResponseRedirect(reverse("search:employers_home"))
+        url = reverse("dashboard:index")
+    else:
+        url = reverse("search:employers_home")
+    # Handle REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM (and only that,
+    # there is no use case for any other query string parameter).
+    if REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM in request.GET:
+        url += f"?{REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM}=1"
+    return HttpResponseRedirect(url)

--- a/itou/www/login/views.py
+++ b/itou/www/login/views.py
@@ -14,6 +14,7 @@ from itou.users.enums import IDENTITY_PROVIDER_SUPPORTED_USER_KIND, IdentityProv
 from itou.users.models import User
 from itou.utils.auth import LoginNotRequiredMixin
 from itou.utils.urls import get_safe_url, get_url_param_value
+from itou.www.constants import REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM
 from itou.www.login.constants import ITOU_SESSION_LOGIN_EMAIL_KEY
 from itou.www.login.forms import FindExistingUserViaEmailForm, ItouLoginForm
 
@@ -86,7 +87,10 @@ class PreLoginView(LoginNotRequiredMixin, UserKindLoginMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        return context | {"redirect_field_value": self.next_url}
+        return context | {
+            "redirect_field_value": self.next_url,
+            "redirected_from_old_domain": REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM in (self.next_url or ""),
+        }
 
 
 class ExistingUserLoginView(LoginNotRequiredMixin, UserKindLoginMixin, LoginView):

--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -6,13 +6,14 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.files.storage import default_storage
 from django.db import connection
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import HttpResponseRedirect, JsonResponse, QueryDict
 from django.http.response import HttpResponse, HttpResponseServerError
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.cache import add_never_cache_headers
 
 from itou.utils.throttling import FailSafeAnonRateThrottle, FailSafeUserRateThrottle
+from itou.www.constants import REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM
 
 
 def never_cache(get_response):
@@ -131,3 +132,46 @@ class TermsAcceptanceMiddleware:
             return None
         url = reverse("legal-terms", query={"next": request.get_full_path()})
         return HttpResponseRedirect(url)
+
+
+class RedirectToNewDomainMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        url = _get_redirect_url(request)
+        if url is None:
+            return None
+        return HttpResponseRedirect(url)
+
+
+def _get_redirect_url(request):
+    if not settings.REDIRECT_TO_NEW_DOMAIN:
+        return None
+    if request.get_host() == settings.NEW_DOMAIN:
+        return None
+    if request.path.startswith("/api/"):
+        # Clients of our API may not handle redirections. Let them
+        # some time before redirecting (or maybe never redirect
+        # them if we still see calls to the old domain in logs).
+        return None
+    if request.method != "GET":
+        # Don't redirect POST, DELETE, etc.: if the user visits the
+        # old domain _before_ we enable the redirection for them, then
+        # POST data and we redirect them to the new domain where they
+        # never authenticated, they will lose data.
+        # FIXME (dbaty, 2026-08-20): remove this once all users
+        # are redirected to the new domain (see `if block below).
+        return None
+    user = request.user
+    if not (user and user.is_authenticated and user.is_staff):
+        # For now, redirect only staff users. We'll expand to
+        # other users once we're sure that everything is fine.
+        return None
+
+    query = QueryDict(request.GET, mutable=True)
+    query[REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM] = "1"
+    return f"https://{settings.NEW_DOMAIN}{request.path}?{query.urlencode()}"

--- a/tests/www/home/tests.py
+++ b/tests/www/home/tests.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertRedirects
 
+from itou.www.constants import REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM
 from tests.users.factories import PrescriberFactory
 
 
@@ -10,6 +11,10 @@ def test_home_anonymous(client):
     assertRedirects(response, reverse("search:employers_home"))
     assertContains(response, "Rechercher un emploi inclusif")
 
+    query = {REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM: "1"}
+    response = client.get(url, query_params=query)
+    assertRedirects(response, reverse("search:employers_home", query=query))
+
 
 def test_home_logged_in(client):
     client.force_login(PrescriberFactory(membership=True))
@@ -17,3 +22,7 @@ def test_home_logged_in(client):
     response = client.get(url, follow=True)
     assertRedirects(response, reverse("dashboard:index"))
     assertContains(response, "Rechercher un emploi inclusif")
+
+    query = {REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM: "1"}
+    response = client.get(url, query_params=query)
+    assertRedirects(response, reverse("dashboard:index", query=query))

--- a/tests/www/home/tests.py
+++ b/tests/www/home/tests.py
@@ -15,4 +15,5 @@ def test_home_logged_in(client):
     client.force_login(PrescriberFactory(membership=True))
     url = reverse("home:hp")
     response = client.get(url, follow=True)
+    assertRedirects(response, reverse("dashboard:index"))
     assertContains(response, "Rechercher un emploi inclusif")

--- a/tests/www/home/tests.py
+++ b/tests/www/home/tests.py
@@ -6,7 +6,6 @@ from tests.users.factories import PrescriberFactory
 
 def test_home_anonymous(client):
     url = reverse("home:hp")
-    response = client.get(url)
     response = client.get(url, follow=True)
     assertRedirects(response, reverse("search:employers_home"))
     assertContains(response, "Rechercher un emploi inclusif")

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -17,6 +17,7 @@ from itou.openid_connect.france_connect import constants as fc_constants
 from itou.openid_connect.ft_connect import constants as pe_constants
 from itou.users.enums import IdentityProvider
 from itou.utils import constants as global_constants
+from itou.www.constants import REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM
 from itou.www.login.constants import ITOU_SESSION_LOGIN_EMAIL_KEY
 from itou.www.login.forms import ItouLoginForm
 from itou.www.login.views import ExistingUserLoginView
@@ -137,6 +138,17 @@ class TestPreLogin:
                 assert response.status_code == 200
             response = client.post(url, data=form_data)
             assertContains(response, "trop de requêtes", status_code=429)
+
+    def test_login_show_redirect_from_old_domain_notice(self, client):
+        pre_login_url = reverse("account_login")
+        marker = "Vous venez de l’ancienne adresse"
+
+        response = client.get(pre_login_url)
+        assertNotContains(response, marker)
+
+        next_url = f"/next_url?{REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM}=1"
+        response = client.get(pre_login_url, query_params={"next": next_url})
+        assertContains(response, marker)
 
 
 class TestItouLoginForm:

--- a/tests/www/middleware/tests.py
+++ b/tests/www/middleware/tests.py
@@ -1,0 +1,46 @@
+from django.urls import reverse
+
+from tests.companies.factories import CompanyFactory
+from tests.users.factories import ItouStaffFactory, PrescriberFactory
+
+
+class TestRedirectToNewDomainMiddleware:
+    def test_redirect_staff(self, settings, client):
+        settings.NEW_DOMAIN = "new.domain"
+        settings.ALLOWED_HOSTS = ["old.domain", settings.NEW_DOMAIN]
+
+        user = ItouStaffFactory()
+        client.force_login(user)
+        response = client.get("/admin/", HTTP_HOST="old.domain")
+        assert response.status_code == 200  # no redirect (not enabled)
+
+        settings.REDIRECT_TO_NEW_DOMAIN = True
+        response = client.get("/admin/", HTTP_HOST="old.domain", follow=False)
+        assert response.status_code == 302
+        assert response.url == "https://new.domain/admin/?redirected-from-old-domain=1"
+
+        response = client.get("/admin/", HTTP_HOST="new.domain")
+        assert response.status_code == 200  # no redirect (already on new domain)
+
+    def test_do_not_redirect_non_staff(self, settings, client):
+        settings.NEW_DOMAIN = "new.domain"
+        settings.ALLOWED_HOSTS = ["old.domain", settings.NEW_DOMAIN]
+        settings.REDIRECT_TO_NEW_DOMAIN = True
+
+        response = client.get("/search/employers", HTTP_HOST="old.domain", follow=False)
+        assert response.status_code == 200
+
+        user = PrescriberFactory(membership=True)
+        client.force_login(user)
+        response = client.get("/dashboard/", HTTP_HOST="old.domain", follow=False)
+        assert response.status_code == 200
+
+    def test_do_not_redirect_api_clients(self, settings, api_client):
+        settings.NEW_DOMAIN = "new.domain"
+        settings.ALLOWED_HOSTS = ["old.domain", settings.NEW_DOMAIN]
+        settings.REDIRECT_TO_NEW_DOMAIN = True
+
+        user = CompanyFactory(with_membership=True).members.first()
+        api_client.force_authenticate(user)
+        response = api_client.get(reverse("v1:applicants-list"), HTTP_HOST="old.domain")
+        assert response.status_code == 200


### PR DESCRIPTION
Annule et remplace #8552.

[Carte Notion](https://app.notion.com/p/gip-inclusion/Redirection-de-l-ancien-nom-vers-le-nouveau-pour-le-grand-public-3995f321b604808982fbf9bdab7ecb26#3a45f321b60480b7a8cec243aa00d0e1) et [discussion Slack](https://gip-inclusion.slack.com/archives/C0BK7E98PRU/p1787216405419259).

On souhaite (et cette PR implémente) le comportement suivant : 

1. Ne sont concernés pour l'instant que les utilisateurs staff. Une fois certain qu'il n'y a pas de problème avec le nouveau domaine (et après une possible communication de masse ?), on pourra élargir la redirection à une partie ou tous les autres utilisateurs.
2.  Si un utilisateur concerné visite l'ancien domaine, on le redirige vers le nouveau domaine (avec un `?redirected-from-old-domain=1`).
3. Sur le nouveau domaine, on affiche un encart informatif **sur le formulaire d'authentification seulement**.

## :computer: Captures d'écran <!-- optionnel -->

<img width="2396" height="1147" alt="image" src="https://github.com/user-attachments/assets/121b8f50-34be-4f89-a203-06ea99613a34" />
