### PR TITLE
Connexion : Correction du titre (HTML) de la page de connexion

### DIFF
--- a/itou/templates/account/pre_login.html
+++ b/itou/templates/account/pre_login.html
@@ -6,7 +6,7 @@
 {% load redirection_fields %}
 {% load static %}
 
-{% block title %}Connexion candidat {{ block.super }}{% endblock %}
+{% block title %}Connexion {{ block.super }}{% endblock %}
 
 {% block title_content %}
     {% component_title c_title__main=c_title__main %}


### PR DESCRIPTION
Le titre HTML (pas le titre `<h1>`, qui est "Se connecter") était incorrect : la page de connexion est utilisée par tous les types d'utilisateurs.

Vu par Xavier.