### PR TITLE
Réparation d'un test flacky sur Sentry

### DIFF
--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -4,27 +4,27 @@ import sentry_sdk
 
 def test_before_send_http_breadcrumb_sanitizer(mocker, respx_mock):
     mocker.spy(sentry_sdk.client._Client, "_prepare_event")
-    with sentry_sdk.new_scope() as scope:
-        url = "https://example.com/"
-        params = {
-            "foobar": 34,
-            "nomNaissance": "Martin",
-            "prenoms[]": "Jean",
-            "jourDateNaissance": 12,
-            "moisDateNaissance": 5,
-            "anneeDateNaissance": 1980,
-        }
-        respx_mock.get(url, params=params).mock(return_value=httpx.Response(418))
-        httpx.get(url, params=params)
-        scope.capture_message("Test message")
+    sentry_sdk.get_isolation_scope().clear_breadcrumbs()
+    url = "https://example.com/"
+    params = {
+        "foobar": 34,
+        "nomNaissance": "Martin",
+        "prenoms[]": "Jean",
+        "jourDateNaissance": 12,
+        "moisDateNaissance": 5,
+        "anneeDateNaissance": 1980,
+    }
+    respx_mock.get(url, params=params).mock(return_value=httpx.Response(418))
+    httpx.get(url, params=params)
+    sentry_sdk.capture_message("Test message")
     assert sentry_sdk.client._Client._prepare_event.call_count == 1
     assert sentry_sdk.client._Client._prepare_event.spy_return["message"] == "Test message"
-    http_breacrumbs = [
+    http_breadcrumbs = [
         breadcrumb
         for breadcrumb in sentry_sdk.client._Client._prepare_event.spy_return["breadcrumbs"]["values"]
         if breadcrumb["type"] == "http"
     ]
-    [http_breadcrumb] = http_breacrumbs
+    [http_breadcrumb] = http_breadcrumbs
     assert http_breadcrumb["data"]["http.query"] == (
         "foobar=34&nomNaissance=_REDACTED_&prenoms%5B%5D=_REDACTED_&jourDateNaissance=_REDACTED_&moisDateNaissance=_REDACTED_&anneeDateNaissance=_REDACTED_"
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce test a échoué une fois dans une de mes PR. @dbaty constate aussi qu'il est Flacky.

Je suis assez étranger aux rouages internes de Sentry mais après avoir lu le code il s'avère que les breadcrumbs récupérés en trop viennent du « isolation_scope », le nettoyer avant de lancer le test suffit donc.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
