### PR TITLE
Interface : Correction dans le middleware de redirection vers le nouveau domaine (requêtes GET non vides)

### DIFF
--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -172,6 +172,6 @@ def _get_redirect_url(request):
         # other users once we're sure that everything is fine.
         return None
 
-    query = QueryDict(request.GET, mutable=True)
+    query = QueryDict(request.GET.urlencode(), mutable=True)
     query[REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM] = "1"
     return f"https://{settings.NEW_DOMAIN}{request.path}?{query.urlencode()}"

--- a/tests/www/middleware/tests.py
+++ b/tests/www/middleware/tests.py
@@ -15,9 +15,14 @@ class TestRedirectToNewDomainMiddleware:
         assert response.status_code == 200  # no redirect (not enabled)
 
         settings.REDIRECT_TO_NEW_DOMAIN = True
-        response = client.get("/admin/", HTTP_HOST="old.domain", follow=False)
+        response = client.get(
+            "/admin/",
+            query_params={"foo": "bar"},
+            HTTP_HOST="old.domain",
+            follow=False,
+        )
         assert response.status_code == 302
-        assert response.url == "https://new.domain/admin/?redirected-from-old-domain=1"
+        assert response.url == "https://new.domain/admin/?foo=bar&redirected-from-old-domain=1"
 
         response = client.get("/admin/", HTTP_HOST="new.domain")
         assert response.status_code == 200  # no redirect (already on new domain)


### PR DESCRIPTION
`QueryDict` expects a string or bytestring as its first argument. Passing an empty `QueryDict` worked, because there was a truthiness check that short-circuited the initialization. But passing a non-empty one raised an error:

      File "/path/.venv/lib/python3.13/site-packages/django/http/request.py", line 592, in __init__
        for key, value in parse_qsl(query_string, **parse_qsl_kwargs):
                          ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/path/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/urllib/parse.py", line 800, in parse_qsl
        qs = bytes(memoryview(qs))
                   ~~~~~~~~~~^^^^
    TypeError: memoryview: a bytes-like object is required, not 'dict'

