### PR TITLE
Employeur : Repérer les salariés en fin de contrat et suggérer une suite de parcours

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -520,6 +520,10 @@ PRO_CONNECT_MFA_IDENTITY_PROVIDER_ALLOWLIST = [
 
 TALLY_URL = os.getenv("TALLY_URL")
 
+# Tally form id for the SIAE "suggest a next step" action (end of IAE contract). Empty until provided:
+# the action and the job seeker card banner stay hidden while it is not set.
+TALLY_SUGGEST_NEXT_STEP_FORM_ID = os.getenv("TALLY_SUGGEST_NEXT_STEP_FORM_ID")
+
 # Embedding signed Metabase dashboard
 METABASE_SITE_URL = os.getenv("METABASE_SITE_URL")
 METABASE_SECRET_KEY = os.getenv("METABASE_SECRET_KEY")

--- a/itou/templates/dashboard/includes/employer_employees_card.html
+++ b/itou/templates/dashboard/includes/employer_employees_card.html
@@ -30,6 +30,17 @@
                     <span>Accompagnements</span>
                 </a>
             </li>
+            {% if contracts_ending_soon_count is not None %}
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    <a href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-fins-de-contrats" %}>
+                        <i class="ri-history-line ri-lg fw-normal" aria-hidden="true"></i>
+                        <span>Fins de contrats</span>
+                    </a>
+                    {% if contracts_ending_soon_count %}
+                        <span class="badge rounded-pill badge-xs bg-warning">{{ contracts_ending_soon_count }}</span>
+                    {% endif %}
+                </li>
+            {% endif %}
         {% endfragment %}
     {% endcomponent_box_dashboard %}
 </div>

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -44,6 +44,11 @@
                                         </div>
                                     </div>
                                 </div>
+                                {% if contract_ending_soon_date %}
+                                    <div class="col-12 order-1 order-xxl-1">
+                                        {% include "job_seekers_views/includes/end_of_contract_card_banner.html" with contract_ending_soon_date=contract_ending_soon_date suggest_next_step_url=suggest_next_step_url fiche_banner_extra_id=fiche_banner_extra_id request=request only %}
+                                    </div>
+                                {% endif %}
                                 <div class="col-12 col-xxl-8 col-xxxl-9 order-3 order-xxl-2">
                                     <div class="c-box mb-3 mb-md-4">
                                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=None with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}

--- a/itou/templates/job_seekers_views/includes/end_of_contract_card_banner.html
+++ b/itou/templates/job_seekers_views/includes/end_of_contract_card_banner.html
@@ -1,0 +1,20 @@
+{% load components %}
+{% load matomo %}
+
+{% if contract_ending_soon_date %}
+    {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id=fiche_banner_extra_id extra_classes="mb-3 mb-md-4" %}
+        {% fragment as title %}
+            Le contrat arrive bientôt à échéance
+        {% endfragment %}
+        {% fragment as content %}
+            <p class="mb-0">
+                Le contrat de ce salarié arrive à échéance le {{ contract_ending_soon_date|date:"d/m/Y" }}. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+            </p>
+        {% endfragment %}
+        {% if suggest_next_step_url %}
+            {% fragment as call_to_action %}
+                <a class="btn btn-sm btn-primary has-external-link" href="{{ suggest_next_step_url }}" target="_blank" rel="noopener noreferrer" {% matomo_event "employeurs" "clic" "suggerer-suite-parcours-fiche" %}>Suggérer une suite de parcours</a>
+            {% endfragment %}
+        {% endif %}
+    {% endcomponent_alert %}
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/end_of_contracts_banner.html
+++ b/itou/templates/job_seekers_views/includes/end_of_contracts_banner.html
@@ -1,0 +1,38 @@
+{% load components %}
+{% load matomo %}
+{% load str_filters %}
+
+{% if show_end_of_contracts_banner %}
+    <div id="fins-de-contrats-banner"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
+        {% if end_of_journey_filter_active %}
+            {% component_alert title=title content=content variant="info" dismissible_once=True extra_id="end-of-contract-info-suggest" extra_classes="mb-3 mb-md-4" %}
+                {% fragment as title %}
+                    Suggérer une suite de parcours aux salariés
+                {% endfragment %}
+                {% fragment as content %}
+                    <p class="mb-0">
+                        Vous pouvez suggérer une suite de parcours directement depuis la fiche du salarié ou en cliquant sur « ⋮ » à droite de sa ligne.
+                    </p>
+                {% endfragment %}
+            {% endcomponent_alert %}
+        {% elif contracts_ending_soon_count %}
+            {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id="end-of-contract-ending-soon-banner" extra_classes="mb-3 mb-md-4" %}
+                {% fragment as title %}
+                    Vous avez {{ contracts_ending_soon_count }} salarié{{ contracts_ending_soon_count|pluralizefr }} en fin de contrat
+                {% endfragment %}
+                {% fragment as content %}
+                    <p class="mb-0">
+                        {% if contracts_ending_soon_count == 1 %}
+                            Le contrat de ce salarié arrive à échéance dans moins de 30 jours. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+                        {% else %}
+                            Le contrat de ces salariés arrive à échéance dans moins de 30 jours. Préparez au mieux leur fin de contrat en suggérant une suite de parcours adaptée à leur situation.
+                        {% endif %}
+                    </p>
+                {% endfragment %}
+                {% fragment as call_to_action %}
+                    <a class="btn btn-sm btn-primary" href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" {% matomo_event "employeurs" "clic" "afficher-fins-de-contrats" %}>Afficher ce{{ contracts_ending_soon_count|pluralizefr }} salarié{{ contracts_ending_soon_count|pluralizefr }}</a>
+                {% endfragment %}
+            {% endcomponent_alert %}
+        {% endif %}
+    </div>
+{% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/offcanvas_body.html
@@ -1,6 +1,6 @@
 <div class="offcanvas-body" id="offcanvasApplyFiltersContent"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form only %}
-    {% if request.from_authorized_prescriber %}
+    {% if request.from_authorized_prescriber or request.from_employer and request.current_organization.is_subject_to_iae_rules %}
         <hr>
         {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form only %}
     {% endif %}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -21,7 +21,7 @@
                     </li>
                 </ul>
             </div>
-            {% if request.from_authorized_prescriber %}
+            {% if request.from_authorized_prescriber or request.from_employer and request.current_organization.is_subject_to_iae_rules %}
                 {% include "job_seekers_views/includes/job_seekers_filters/end_of_journey.html" with filters_form=filters_form btn_dropdown_filter=True only %}
             {% endif %}
             {% if list_organization and request.from_iae_actor %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -75,6 +75,9 @@
                                         <i class="ri-more-2-fill" aria-hidden="true"></i>
                                     </button>
                                     <div class="dropdown-menu" aria-labelledby="dropdown_{{ forloop.counter }}_action_menu">
+                                        {% if suggest_next_step_url and job_seeker.contract_ending_soon %}
+                                            <a href="{{ suggest_next_step_url }}" class="dropdown-item has-external-link" target="_blank" rel="noopener noreferrer" {% matomo_event "employeurs" "clic" "suggerer-suite-parcours-liste" %}>Suggérer une suite de parcours</a>
+                                        {% endif %}
                                         {% if request.current_organization.is_authorized %}
                                             {% if not job_seeker.has_valid_approval %}
                                                 <a href="{% url 'eligibility_views:update_iae' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="dropdown-item">
@@ -129,6 +132,7 @@
 </section>
 
 {% if request.htmx %}
+    {% include "job_seekers_views/includes/end_of_contracts_banner.html" with show_end_of_contracts_banner=show_end_of_contracts_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count request=request only %}
     {% include "job_seekers_views/includes/list_counter.html" with paginator=page_obj.paginator request=request only %}
     {% include "job_seekers_views/includes/list_reset_filters.html" with btn_dropdown_filter=True filters_counter=filters_counter request=request list_organization=list_organization order=order only %}
     {% include "job_seekers_views/includes/job_seekers_filters/offcanvas_footer.html" %}

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -81,6 +81,7 @@
                 {% include "job_seekers_views/includes/job_seekers_filters/top_filters.html" with request=request filters_counter=filters_counter filters_form=filters_form list_organization=list_organization order=order ITOU_HELP_CENTER_URL=ITOU_HELP_CENTER_URL only %}
                 <input id="id_order" type="hidden" name="order" value="{{ order }}">
             </form>
+            {% include "job_seekers_views/includes/end_of_contracts_banner.html" with show_end_of_contracts_banner=show_end_of_contracts_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count request=request only %}
             <div class="s-section__row row">
                 <div class="col-12">
                     <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
@@ -91,7 +92,7 @@
                             {% bootstrap_field filters_form.job_seeker wrapper_class="w-lg-400px" show_label=False %}
                         </div>
                     </div>
-                    {% include "job_seekers_views/includes/list_results.html" with page_obj=page_obj request=request csrf_token=csrf_token order=order can_orient_towards_insertion_service=can_orient_towards_insertion_service only %}
+                    {% include "job_seekers_views/includes/list_results.html" with page_obj=page_obj request=request csrf_token=csrf_token order=order can_orient_towards_insertion_service=can_orient_towards_insertion_service show_end_of_contracts_banner=show_end_of_contracts_banner end_of_journey_filter_active=end_of_journey_filter_active contracts_ending_soon_count=contracts_ending_soon_count suggest_next_step_url=suggest_next_step_url only %}
                 </div>
             </div>
         </div>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import logging
 
@@ -36,7 +37,7 @@ from itou.nexus.utils import activate_pilotage
 from itou.search.models import SavedSearch
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.users.enums import UserKind
-from itou.users.models import User
+from itou.users.models import JobSeekerAssignment, User
 from itou.users.notifications import (
     EditJobSeekerEmailNotification,
     EditJobSeekerInfoNotification,
@@ -57,6 +58,7 @@ from itou.www.dashboard.forms import (
     EditUserInfoForm,
     EditUserNotificationForm,
 )
+from itou.www.job_seekers_views.forms import IAE_CONTRACT_ENDING_SOON_DAYS, annotate_last_contract_end_date
 from itou.www.search_views.forms import SiaeSearchForm
 from itou.www.stats import utils as stats_utils
 from itou.www.stats.utils import get_stats_for_institution
@@ -113,7 +115,22 @@ def _employer_dashboard_context(request):
         category["counter"] = len([ja for ja in job_applications if ja["state"] in category["states"]])
         category["url"] = f"{reverse('apply:list_for_siae')}?{'&'.join([f'states={c}' for c in category['states']])}"
 
+    contracts_ending_soon_count = None
+    if current_org.is_subject_to_iae_rules:
+        today = timezone.localdate()
+        contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+        siae_job_seekers = User.objects.filter(
+            kind=UserKind.JOB_SEEKER,
+            pk__in=JobSeekerAssignment.objects.filter(company=current_org).values("job_seeker"),
+        )
+        contracts_ending_soon_count = (
+            annotate_last_contract_end_date(siae_job_seekers, company=current_org)
+            .filter(last_contract_end_date__range=contract_window)
+            .count()
+        )
+
     return {
+        "contracts_ending_soon_count": contracts_ending_soon_count,
         "active_campaigns": (
             EvaluatedSiae.objects.for_company(current_org)
             .in_progress()
@@ -152,6 +169,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "active_geiq_campaign": None,
         "active_campaigns": [],
         "closed_campaigns": [],
+        "contracts_ending_soon_count": None,
         "job_applications_categories": [],
         "can_show_financial_annexes": False,
         "can_show_employee_records": False,

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -27,6 +27,21 @@ APPROVAL_ENDING_SOON_DAYS = 90
 IAE_CONTRACT_ENDING_SOON_DAYS = 30
 
 
+def annotate_last_contract_end_date(queryset, *, company=None):
+    # Latest known IAE contract end date of the job seeker, optionally scoped to a single SIAE.
+    # Scoping to the current SIAE avoids counting a contract signed with another structure, and keeps
+    # a renewed employee out of the cohort (their latest contract with the SIAE ends later).
+    # Shared business definition reused by the dashboard counter, the filter, the discovery banner and
+    # the per-row end-of-contract flag. Idempotent so the list view can annotate for the row flag while
+    # the filter also annotates for the same SIAE, without raising on a duplicate annotation.
+    if "last_contract_end_date" in queryset.query.annotations:
+        return queryset
+    contracts = Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
+    if company is not None:
+        contracts = contracts.filter(company=company)
+    return queryset.annotate(last_contract_end_date=Subquery(contracts.order_by("-end_date").values("end_date")[:1]))
+
+
 class FilterForm(forms.Form):
     job_seeker = forms.ChoiceField(
         required=False,
@@ -51,7 +66,7 @@ class FilterForm(forms.Form):
         label="Nom de la personne", required=False, widget=Select2MultipleWidget
     )
 
-    # Fields only for authorized prescribers set in __init__
+    # Fields only for authorized prescribers and IAE employers, set in __init__
     approval_ending_soon = None
     contract_ending_soon = None
 
@@ -68,7 +83,13 @@ class FilterForm(forms.Form):
             self.fields["approval_active"] = forms.BooleanField(label="Valide", required=False)
             self.fields["approval_expired"] = forms.BooleanField(label="Expiré", required=False)
             self.fields["no_approval"] = forms.BooleanField(label="Aucun", required=False)
-        if request.from_authorized_prescriber:
+        # A SIAE only looks at its own contracts; a prescriber keeps the job seeker global view (company=None).
+        self.company = (
+            request.current_organization
+            if request.from_employer and request.current_organization.is_subject_to_iae_rules
+            else None
+        )
+        if request.from_authorized_prescriber or self.company:
             self.fields["approval_ending_soon"] = forms.BooleanField(
                 label="PASS IAE bientôt expiré",
                 required=False,
@@ -132,7 +153,7 @@ class FilterForm(forms.Form):
         ]
         use_approval_status = any(approval_status_filters) and not all(approval_status_filters)
 
-        # The "end of IAE journey" filters are reserved for authorized prescribers.
+        # The "end of IAE journey" filters exist only for authorized prescribers and IAE employers.
         approval_ending_soon = self.cleaned_data.get("approval_ending_soon")
 
         if use_approval_status or approval_ending_soon:
@@ -162,13 +183,7 @@ class FilterForm(forms.Form):
                 approval_window = (today, today + datetime.timedelta(days=APPROVAL_ENDING_SOON_DAYS))
                 end_of_journey_filter &= Q(last_approval_end_at__range=approval_window)
             if contract_ending_soon:
-                queryset = queryset.annotate(
-                    last_contract_end_date=Subquery(
-                        Contract.objects.filter(job_seeker=OuterRef("pk"), end_date__isnull=False)
-                        .order_by("-end_date")
-                        .values("end_date")[:1]
-                    )
-                )
+                queryset = annotate_last_contract_end_date(queryset, company=self.company)
                 contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
                 end_of_journey_filter &= Q(last_contract_end_date__range=contract_window)
             filters.append(end_of_journey_filter)

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -485,11 +485,10 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     if form.is_valid():
         queryset = form.filter(queryset)
         filters_counter = form.get_filters_counter()
-        # The upcoming-end-of-IAE-journey filter is reserved for authorized prescribers (see FilterForm).
-        end_of_journey_filter_active = request.from_authorized_prescriber and bool(
+        end_of_journey_filter_active = bool(
             form.cleaned_data.get("approval_ending_soon") or form.cleaned_data.get("contract_ending_soon")
         )
-        if end_of_journey_filter_active:
+        if end_of_journey_filter_active and request.from_authorized_prescriber:
             # Contracts are the most precise, but they are delayed.
             # Fallback to job applications if needs be.
             queryset = queryset.annotate(
@@ -541,7 +540,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         job_seeker.pro_support_request_mailto = None
         if (
             end_of_journey_filter_active
-            and job_seeker.pro_support_request_company_email
+            and getattr(job_seeker, "pro_support_request_company_email", None)
             # This last condition avoid the job seeker's name to leak
             # to unauthorized users.
             and job_seeker.user_can_view_personal_information

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import urllib.parse
 from functools import cached_property
@@ -42,12 +43,13 @@ from itou.utils.pagination import pager
 from itou.utils.perms.utils import can_edit_personal_information, can_view_personal_information
 from itou.utils.readonly import ReadonlyViewMixin, http_methods, readonly_view
 from itou.utils.session import SessionNamespace, SessionNamespaceException
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import get_safe_url, get_tally_form_url
 from itou.utils.views import with_triggers_context
 from itou.www.apply.views.hire_views import HIRE_SESSION_KIND, HireWizardMixin
 from itou.www.apply.views.submit_views import APPLY_SESSION_KIND, ApplicationBaseView
 from itou.www.job_seekers_views.enums import JobSeekerOrder, JobSeekerSessionKinds
 from itou.www.job_seekers_views.forms import (
+    IAE_CONTRACT_ENDING_SOON_DAYS,
     CheckJobSeekerInfoForm,
     CheckJobSeekerNirForm,
     CreateOrUpdateJobSeekerStep1Form,
@@ -57,6 +59,7 @@ from itou.www.job_seekers_views.forms import (
     JobSeekerExistsForm,
     NirModificationRequestForm,
     SwitchStalledStatusForm,
+    annotate_last_contract_end_date,
 )
 
 
@@ -189,8 +192,40 @@ class JobSeekerDetailTabView(BaseJobSeekerDetailView):
         if self.request.from_authorized_prescriber and self.approval is None:
             can_edit_iae_eligibility = True
 
+        # SIAE job seeker card banner: shown when a contract with this SIAE ends within 30 days and the
+        # Tally form is configured. Same business definition (scoped to the current SIAE) as the list.
+        # Lives in the details tab view only, so the query does not run on the other tabs.
+        contract_ending_soon_date = None
+        suggest_next_step_url = None
+        if (
+            self.request.from_employer
+            and self.request.current_organization.is_subject_to_iae_rules
+            and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID
+        ):
+            today = timezone.localdate()
+            last_contract_end_date = (
+                Contract.objects.filter(
+                    job_seeker=self.object, company=self.request.current_organization, end_date__isnull=False
+                )
+                .order_by("-end_date")
+                .values_list("end_date", flat=True)
+                .first()
+            )
+            if last_contract_end_date and today <= last_contract_end_date <= today + datetime.timedelta(
+                days=IAE_CONTRACT_ENDING_SOON_DAYS
+            ):
+                contract_ending_soon_date = last_contract_end_date
+                suggest_next_step_url = get_tally_form_url(
+                    settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID,
+                    iduser=self.request.user.pk,
+                    kindcompany=self.request.current_organization.kind,
+                )
+
         return context | {
             "approval": self.approval,
+            "contract_ending_soon_date": contract_ending_soon_date,
+            "suggest_next_step_url": suggest_next_step_url,
+            "fiche_banner_extra_id": f"fin-de-contrat-fiche-{self.object.public_id}",
             "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
             "iae_eligibility_diagnosis": iae_eligibility_diagnosis,
             "can_edit_iae_eligibility": can_edit_iae_eligibility,
@@ -480,6 +515,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         request=request,
     )
 
+    base_queryset = queryset
     filters_counter = 0
     end_of_journey_filter_active = False
     if form.is_valid():
@@ -528,11 +564,37 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         )
     )
 
+    show_end_of_contracts_banner = request.from_employer and request.current_organization.is_subject_to_iae_rules
+    today = timezone.localdate()
+    contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+
+    # Discovery banner: count over the SIAE assigned job seekers (unfiltered), only shown when the
+    # end-of-journey filter is not active.
+    contracts_ending_soon_count = None
+    if show_end_of_contracts_banner and not end_of_journey_filter_active:
+        contracts_ending_soon_count = (
+            annotate_last_contract_end_date(base_queryset, company=request.current_organization)
+            .filter(last_contract_end_date__range=contract_window)
+            .count()
+        )
+
+    # SIAE "suggest a next step" action (Tally). Offered on each row whose IAE contract with this SIAE ends
+    # soon, mirroring the job seeker card banner. Hidden while the form id is not configured.
+    suggest_next_step_url = None
+    if show_end_of_contracts_banner and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID:
+        suggest_next_step_url = get_tally_form_url(
+            settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID,
+            iduser=request.user.pk,
+            kindcompany=request.current_organization.kind,
+        )
+
     try:
         order = JobSeekerOrder(request.GET.get("order"))
     except ValueError:
         order = JobSeekerOrder.LAST_ACTION_AT_DESC
     queryset = queryset.order_by(*order.order_by)
+    if show_end_of_contracts_banner:
+        queryset = annotate_last_contract_end_date(queryset, company=request.current_organization)
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_LARGE)
     for job_seeker in page_obj:
@@ -549,11 +611,17 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
                 job_seeker.pro_support_request_company_email,
                 job_seeker.get_full_name(),
             )
+        job_seeker.contract_ending_soon = bool(
+            show_end_of_contracts_banner
+            and job_seeker.last_contract_end_date
+            and contract_window[0] <= job_seeker.last_contract_end_date <= contract_window[1]
+        )
         job_seeker.show_more_actions = (
             not job_seeker.has_valid_approval
             or job_seeker.jobseeker_profile.is_stalled
             or can_orient_towards_insertion_service(request)
             or bool(job_seeker.pro_support_request_mailto)
+            or bool(suggest_next_step_url and job_seeker.contract_ending_soon)
         )
         job_seeker.services_search_url = build_services_search_url(request, job_seeker)
         professional, organization = request.user, request.current_organization
@@ -571,6 +639,10 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         "filters_counter": filters_counter,
         "order": order,
         "page_obj": page_obj,
+        "show_end_of_contracts_banner": show_end_of_contracts_banner,
+        "end_of_journey_filter_active": end_of_journey_filter_active,
+        "contracts_ending_soon_count": contracts_ending_soon_count,
+        "suggest_next_step_url": suggest_next_step_url,
     }
 
     return render(request, "job_seekers_views/includes/list_results.html" if request.htmx else template_name, context)

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -50,7 +50,7 @@
 # ---
 # name: TestDashboardView.test_dashboard_siae_evaluation_campaign_notifications[view queries]
   dict({
-    'num_queries': 23,
+    'num_queries': 24,
     'queries': list([
       dict({
         'origin': list([
@@ -392,6 +392,30 @@
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "job_applications_jobapplication"."archived_at" IS NULL)
           ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_employer_dashboard_context[www/dashboard/views.py]',
+          'dashboard[www/dashboard/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "users_user"
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" IN
+                   (SELECT U0."job_seeker_id" AS "job_seeker"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE U0."company_id" = %s)
+                 AND
+                   (SELECT U0."end_date" AS "end_date"
+                    FROM "companies_contract" U0
+                    WHERE (U0."end_date" IS NOT NULL
+                           AND U0."job_seeker_id" = ("users_user"."id")
+                           AND U0."company_id" = %s)
+                    ORDER BY 1 DESC
+                    LIMIT 1) BETWEEN %s AND %s)
         ''',
       }),
       dict({

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -30,7 +30,7 @@ from itou.utils import constants as global_constants, triggers
 from itou.utils.models import InclusiveDateRange
 from itou.utils.templatetags.format_filters import format_approval_number, format_siret
 from tests.approvals.factories import ApprovalFactory, ProlongationRequestFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
+from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, ContractFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.employee_record.factories import EmployeeRecordFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory, LaborInspectorFactory
@@ -43,7 +43,13 @@ from tests.siae_evaluations.factories import (
     EvaluatedSiaeFactory,
     EvaluationCampaignFactory,
 )
-from tests.users.factories import EmployerFactory, ItouStaffFactory, JobSeekerFactory, PrescriberFactory
+from tests.users.factories import (
+    EmployerFactory,
+    ItouStaffFactory,
+    JobSeekerAssignmentFactory,
+    JobSeekerFactory,
+    PrescriberFactory,
+)
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
@@ -191,6 +197,42 @@ class TestDashboardView:
         response = client.get(url)
         assert response.status_code == 200
         assert response.context["num_rejected_employee_records"] == 0
+
+    @freeze_time("2026-01-15")
+    def test_dashboard_contracts_ending_soon_count(self, client):
+        company = CompanyFactory(with_membership=True, subject_to_iae_rules=True)
+        employer = company.members.first()
+        client.force_login(employer)
+        today = date(2026, 1, 15)
+        url = reverse("dashboard:index")
+
+        # No contract ending soon yet: the entry is shown without a badge.
+        response = client.get(url)
+        assertContains(response, "Fins de contrats")
+        assert response.context["contracts_ending_soon_count"] == 0
+
+        # A job seeker assigned to the SIAE with a contract with this SIAE ending in 20 days is counted.
+        job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+        ContractFactory(
+            job_seeker=job_seeker,
+            company=company,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=20),
+        )
+        # A contract with another SIAE must not be counted.
+        other_job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+        ContractFactory(
+            job_seeker=other_job_seeker,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=20),
+        )
+
+        response = client.get(url)
+        assert response.context["contracts_ending_soon_count"] == 1
+
+        # The dashboard counter matches the filtered "Accompagnements" list results.
+        list_response = client.get(reverse("job_seekers_views:list_organization"), {"contract_ending_soon": "on"})
+        assert list(list_response.context["page_obj"].object_list) == [job_seeker]
 
     def test_dashboard_applications_to_process(self, client):
         non_geiq_url = reverse("apply:list_for_siae") + "?states=new&amp;states=processing"

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -207,6 +207,38 @@
       <hr/>
       <fieldset>
           <legend>
+              <button aria-controls="collapseEndOfJourney" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapseEndOfJourney" data-bs-toggle="collapse" type="button">
+                  Fin de parcours IAE à venir
+              </button>
+          </legend>
+          <div class="my-3 collapse" id="collapseEndOfJourney">
+              <ul>
+                  <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-pass-iae">
+                      <div class="dropdown-item">
+                          <div class="form-check">
+                              <input class="form-check-input" data-emplois-sync-with="id_approval_ending_soon" id="id_approval_ending_soon-offcanvas" name="approval_ending_soon" type="checkbox"/>
+                              <label class="form-check-label" for="id_approval_ending_soon-offcanvas">
+                                  PASS IAE bientôt expiré
+                              </label>
+                          </div>
+                      </div>
+                  </li>
+                  <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-contrat-iae">
+                      <div class="dropdown-item">
+                          <div class="form-check">
+                              <input class="form-check-input" data-emplois-sync-with="id_contract_ending_soon" id="id_contract_ending_soon-offcanvas" name="contract_ending_soon" type="checkbox"/>
+                              <label class="form-check-label" for="id_contract_ending_soon-offcanvas">
+                                  Contrat IAE bientôt terminé
+                              </label>
+                          </div>
+                      </div>
+                  </li>
+              </ul>
+          </div>
+      </fieldset>
+      <hr/>
+      <fieldset>
+          <legend>
               <button aria-controls="collapseSenders" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapseSenders" data-bs-toggle="collapse" type="button">
                   Accompagnateurs de ma structure
               </button>
@@ -684,6 +716,39 @@
                   <a class="btn btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" rel="noopener" target="_blank">
                       Qu’est-ce qu’un usager sans solution
                   </a>
+              </li>
+          </ul>
+      </div>
+      <div class="dropdown">
+          <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown" type="button">
+              Fin de parcours IAE à venir
+          </button>
+          <ul class="dropdown-menu">
+              <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-pass-iae">
+                  <div class="dropdown-item">
+                      <div class="form-check">
+                          <input aria-describedby="id_approval_ending_soon_helptext" class="form-check-input is-valid" id="id_approval_ending_soon" name="approval_ending_soon" type="checkbox"/>
+                          <label class="form-check-label" for="id_approval_ending_soon">
+                              PASS IAE bientôt expiré
+                          </label>
+                          <div class="form-text" id="id_approval_ending_soon_helptext">
+                              Dans les 90 prochains jours
+                          </div>
+                      </div>
+                  </div>
+              </li>
+              <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-contrat-iae">
+                  <div class="dropdown-item">
+                      <div class="form-check">
+                          <input aria-describedby="id_contract_ending_soon_helptext" class="form-check-input is-valid" id="id_contract_ending_soon" name="contract_ending_soon" type="checkbox"/>
+                          <label class="form-check-label" for="id_contract_ending_soon">
+                              Contrat IAE bientôt terminé
+                          </label>
+                          <div class="form-text" id="id_contract_ending_soon_helptext">
+                              Dans les 30 prochains jours
+                          </div>
+                      </div>
+                  </div>
               </li>
           </ul>
       </div>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1267,6 +1267,94 @@ def test_end_of_iae_journey_filter_for_siae(client):
     assert response.context["page_obj"].object_list == [job_seeker_own]
 
 
+@freeze_time("2026-01-15")
+def test_end_of_contracts_banners_for_siae(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+
+    # No contract ending soon: neither banner.
+    response = client.get(url)
+    assertNotContains(response, "Afficher ce salarié")
+    assertNotContains(response, "Afficher ces salariés")
+    assertNotContains(response, "Suggérer une suite de parcours aux salariés")
+
+    # A job seeker with a contract ending soon: discovery banner on the unfiltered list.
+    job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    response = client.get(url)
+    assertContains(response, "Vous avez 1 salarié en fin de contrat")
+    assertContains(response, "Afficher ce salarié")
+    assertNotContains(response, "Suggérer une suite de parcours aux salariés")
+
+    # When the end-of-journey filter is active: pedagogic banner replaces the discovery banner.
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assertContains(response, "Suggérer une suite de parcours aux salariés")
+    assertNotContains(response, "Afficher ce salariés")
+    assertNotContains(response, "Afficher ces salariés")
+
+
+@freeze_time("2026-01-15")
+@override_settings(TALLY_URL="https://tally.example", TALLY_SUGGEST_NEXT_STEP_FORM_ID="wSUGGEST")
+def test_suggest_next_step_action_in_list(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+    ending_soon = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=ending_soon,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    # A job seeker with no contract ending soon: no action on their row.
+    JobSeekerAssignmentFactory(professional=employer, company=company)
+
+    # Unfiltered: the action is offered on the row of the job seeker ending soon (mirroring the card banner),
+    # exactly once, and it links to the Tally form pre-filled with the responding employer's identifiers.
+    tally_url = f"https://tally.example/r/wSUGGEST?iduser={employer.pk}&kindcompany={company.kind}"
+    response = client.get(url)
+    assertContains(response, "Suggérer une suite de parcours")
+    assertContains(response, tally_url, count=1)
+
+    # With the end-of-journey filter active, only the job seeker ending soon remains, still with the action.
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assertContains(response, tally_url, count=1)
+
+
+@freeze_time("2026-01-15")
+@override_settings(TALLY_URL="https://tally.example", TALLY_SUGGEST_NEXT_STEP_FORM_ID="wSUGGEST")
+def test_suggest_next_step_banner_on_job_seeker_card(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    today = datetime.date(2026, 1, 15)
+    job_seeker = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+
+    response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
+    assertContains(response, "Le contrat arrive bientôt à échéance")
+    assertContains(response, "04/02/2026")
+    assertContains(response, f"https://tally.example/r/wSUGGEST?iduser={employer.pk}&kindcompany={company.kind}")
+
+
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_suspended_approval_info_tooltip(client, url):
     organization = PrescriberOrganizationWith2MembershipFactory()

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -1233,6 +1233,40 @@ def test_end_of_iae_journey_filter_only_for_authorized_prescriber(client):
     assert response.context["page_obj"].object_list == [job_seeker]
 
 
+@freeze_time("2026-01-15")
+def test_end_of_iae_journey_filter_for_siae(client):
+    membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
+    company = membership.company
+    employer = membership.user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+
+    # The filter is now available for an IAE SIAE, like for authorized prescribers.
+    response = client.get(url)
+    assertContains(response, "Fin de parcours IAE à venir")
+    assertContains(response, "Contrat IAE bientôt terminé")
+
+    # A contract ending soon WITH this SIAE is in the cohort.
+    job_seeker_own = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_own,
+        company=company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    # A contract ending soon WITH ANOTHER SIAE must be ignored (scoping avoids the false positive).
+    job_seeker_other_company = JobSeekerAssignmentFactory(professional=employer, company=company).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker_other_company,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker_own]
+
+
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
 def test_suspended_approval_info_tooltip(client, url):
     organization = PrescriberOrganizationWith2MembershipFactory()
@@ -1651,7 +1685,7 @@ def test_pro_support_request_action_for_authorized_prescriber(client, view):
 
 
 @freeze_time("2026-01-15")
-def test_request_accompaniment_review_action_not_for_employer(client):
+def test_pro_support_request_not_for_employer(client):
     company = CompanyFactory(subject_to_iae_rules=True, email="siae@example.com")
     employer = CompanyMembershipFactory(company=company).user
     client.force_login(employer)
@@ -1677,9 +1711,7 @@ def test_request_accompaniment_review_action_not_for_employer(client):
         hiring_start_at=today - datetime.timedelta(days=200),
     )
 
-    # The filter should not be available, but user could try to tweak
-    # the request.
-    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    response = client.get(url, {"approval_ending_soon": "on"})
     assert response.context["page_obj"].object_list == [job_seeker]
     assert not hasattr(response.context["page_obj"].object_list[0], "pro_support_request_company_email")
     assertNotContains(response, "mailto:siae@example.com")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les SIAE ont besoin d'anticiper la fin de parcours IAE de leurs salariés pour préparer une suite adaptée (formation, emploi, accompagnement). Aujourd'hui, rien ne signale côté employeur qu'un contrat approche de son terme.

Cette PR s'appuie sur le filtre « Fin de parcours IAE à venir » introduit pour les prescripteurs habilités (#8500, désormais fusionné) et l'étend aux employeurs SIAE, avec les points d'entrée et les incitations pour repérer ces salariés et leur suggérer une suite de parcours.

## :cake: Comment ?

- **Filtre** : le filtre « Fin de parcours IAE à venir » est ouvert aux SIAE, avec la détection des contrats se terminant sous 30 jours **restreinte à la structure courante** (un contrat signé avec une autre structure, ou un contrat renouvelé, ne fausse pas la cohorte). Définition partagée par un seul helper (`annotate_last_contract_end_date`), réutilisé par le compteur, le filtre, l'encart et la fiche.
- **Tableau de bord** : une entrée « Fins de contrats » avec un compteur des salariés concernés.
- **Encarts** : un encart de découverte sur la liste non filtrée, remplacé par un encart pédagogique quand le filtre est actif.
- **Action « Suggérer une suite de parcours »** : proposée sur chaque salarié en fin de contrat, depuis le menu « ⋮ » de la liste comme depuis sa fiche, vers un formulaire Tally configurable par variable d'environnement (`TALLY_SUGGEST_NEXT_STEP_FORM_ID`). L'action reste masquée tant que le formulaire n'est pas configuré.
- **Identification des répondants** : le lien Tally transmet en champs cachés l'identifiant de l'employeur répondant (`iduser`) et le type de sa structure (`kindcompany`), pour l'analyse des réponses. On n'envoie **ni l'e-mail, ni aucune donnée du salarié** concerné.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ? Non, aucun changement cassant.
- [ ] Ajouter l'étiquette « Bug » ? Non, nouvelle fonctionnalité.

## :desert_island: Comment tester ?

En tant qu'employeur d'une SIAE (soumise aux règles IAE), avec un salarié rattaché dont un contrat se termine dans moins de 30 jours :

1. **Tableau de bord** → carte employeur : entrée « Fins de contrats » avec le compteur.
2. **Accompagnements** (liste de la structure) sans filtre → encart de découverte « Vous avez N salarié·s en fin de contrat » + bouton « Afficher ces salariés ».
3. Cocher **« Contrat IAE bientôt terminé »** → la liste se réduit aux salariés concernés, l'encart devient pédagogique.
4. Sur la ligne d'un salarié en fin de contrat → menu **⋮** → **« Suggérer une suite de parcours »** (visible aussi sans filtre).
5. Fiche du salarié → encart « Le contrat arrive bientôt à échéance le … » avec le même bouton.

L'action « Suggérer une suite de parcours » n'apparaît que si `TALLY_SUGGEST_NEXT_STEP_FORM_ID` est configuré. Pour activer la fonctionnalité, définir la variable d'environnement `TALLY_SUGGEST_NEXT_STEP_FORM_ID=zxBpVM` (formulaire https://tally.so/r/zxBpVM).
