### PR TITLE
Tech : Tracking Matomo du filtre « Fin de parcours IAE à venir »

### DIFF
--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/end_of_journey.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load matomo %}
 
 {% if btn_dropdown_filter|default:False %}
     <div class="dropdown">
@@ -6,8 +7,8 @@
             Fin de parcours IAE à venir
         </button>
         <ul class="dropdown-menu">
-            <li>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
-            <li>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-pass-iae" %}>{% bootstrap_field filters_form.approval_ending_soon wrapper_class="dropdown-item" %}</li>
+            <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-contrat-iae" %}>{% bootstrap_field filters_form.contract_ending_soon wrapper_class="dropdown-item" %}</li>
         </ul>
     </div>
 {% else %}
@@ -22,10 +23,10 @@
         </legend>
         <div class="my-3 collapse" id="collapseEndOfJourney">
             <ul>
-                <li>
+                <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-pass-iae" %}>
                     {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.approval_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
-                <li>
+                <li {% matomo_event "candidat" "clic" "filtre-fin-de-parcours-contrat-iae" %}>
                     {% include "job_seekers_views/includes/job_seekers_filters/single_checkbox.html" with field=filters_form.contract_ending_soon wrapper_class="dropdown-item" id_suffix="-offcanvas" only %}
                 </li>
             </ul>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -84,7 +84,7 @@
           </legend>
           <div class="my-3 collapse" id="collapseEndOfJourney">
               <ul>
-                  <li>
+                  <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-pass-iae">
                       <div class="dropdown-item">
                           <div class="form-check">
                               <input class="form-check-input" data-emplois-sync-with="id_approval_ending_soon" id="id_approval_ending_soon-offcanvas" name="approval_ending_soon" type="checkbox"/>
@@ -94,7 +94,7 @@
                           </div>
                       </div>
                   </li>
-                  <li>
+                  <li data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="filtre-fin-de-parcours-contrat-iae">
                       <div class="dropdown-item">
                           <div class="form-check">
                               <input class="form-check-input" data-emplois-sync-with="id_contract_ending_soon" id="id_contract_ending_soon-offcanvas" name="contract_ending_soon" type="checkbox"/>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mesurer l'adoption du filtre « Fin de parcours IAE à venir » (introduit en #8500) en suivant les clics sur ses deux cases, pour éclairer les décisions produit.

Recréation de #8574, fermée automatiquement au merge de #8500. Les tests ont été retirés (non nécessaires ici, comme convenu).

## :cake: Comment ?

Un événement Matomo (`candidat` / `clic`) sur chaque case du filtre, en version menu déroulant comme en version « Tous les filtres » :
- `filtre-fin-de-parcours-pass-iae`
- `filtre-fin-de-parcours-contrat-iae`

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ? Non, aucun changement cassant.
- [ ] Ajouter l'étiquette « Bug » ? Non.

## :desert_island: Comment tester ?

Sur la page « Accompagnements » (prescripteur habilité ou employeur SIAE), ouvrir le filtre « Fin de parcours IAE à venir » et cocher une case : un événement Matomo `candidat / clic / filtre-fin-de-parcours-*` est émis.
