### PR TITLE
Tech : Gérer les cas où l'API de Sentry ne renvoie aucune donnée (pour la commande "collect_analytics_data")

### DIFF
--- a/itou/analytics/tech.py
+++ b/itou/analytics/tech.py
@@ -14,11 +14,13 @@ def collect_analytics_data(before):
     updown_metrics = UpdownApiClient().get_metrics(start=start, end=end)
     github_metrics = GithubApiClient().get_metrics(start=start)
     data = {
-        models.DatumCode.TECH_SENTRY_APDEX: round(sentry_metrics["apdex"] * 10000),
-        models.DatumCode.TECH_SENTRY_FAILURE_RATE: round(sentry_metrics["failure_rate"] * 10000),
         models.DatumCode.TECH_UPDOWN_UPTIME: round(updown_metrics["uptime"]),
         models.DatumCode.TECH_GH_TOTAL_BUGS: github_metrics["total_pr_bugs"],
     }
+    if "apdex" in sentry_metrics:
+        data[models.DatumCode.TECH_SENTRY_APDEX] = round(sentry_metrics["apdex"] * 10000)
+    if "failure_rate" in sentry_metrics:
+        data[models.DatumCode.TECH_SENTRY_FAILURE_RATE] = round(sentry_metrics["failure_rate"] * 10000)
     if updown_metrics.get("apdex"):
         data[models.DatumCode.TECH_UPDOWN_APDEX] = round(updown_metrics["apdex"] * 10000)
 

--- a/itou/utils/apis/sentry.py
+++ b/itou/utils/apis/sentry.py
@@ -33,7 +33,15 @@ class SentryApiClient:
     def get_metrics(self, start, end):
         response = self._request(start=start, end=end)
 
-        data_received = response.json()["data"][0]
+        try:
+            data_received = response.json()["data"][0]
+        except IndexError:  # `data` key may be empty
+            logger.info(
+                "Sentry returned no metrics for period %s - %s",
+                start.isoformat(),
+                end.isoformat(),
+            )
+            return {}
         return {
             "failure_rate": data_received["failure_rate()"],
             "apdex": data_received["apdex()"],


### PR DESCRIPTION
Parfois, Sentry ne renvoie aucune donnée ([cas ici dans Sentry](https://inclusion.sentry.io/issues/142439991/events/0f5fe11421df4f2aa4a2c365509db910/)) :

    >>> client = sentry.SentryApiClient()
    >>> start = datetime.datetime(2026, 8, 23)
    >>> end = datetime.datetime(2026, 8, 24)
    >>> response = client._request(start, end)
    >>> response.json()["data"]
    []

Le cas passant (avec des données) est déjà testé, pas besoin de rajouter des tests pour ce cas particulier (et probablement rare).
