### PR TITLE
Prescripteur : Permettre de demander un bilan d'accompagnement à la SIAE

### DIFF
--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -23,7 +23,7 @@
                         {% if request.from_iae_actor %}<th scope="col">Situation IAE</th>{% endif %}
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.LAST_ACTION_AT_ASC name="Dernière action" only %}
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.JOB_APPLICATIONS_NB_ASC name="Nbr de candidatures" only %}
-                        {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.ADVISORS_NB_ASC name="Nbr d'accompagnateurs" only %}
+                        {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.ADVISORS_NB_ASC name="Nbr d’accompagnateurs" only %}
                         <th scope="col">Dernier accompagnateur connu</th>
                         <th scope="col" class="text-end {% if request.current_organization.is_authorized or can_orient_towards_insertion_service %}w-100px{% else %}w-50px{% endif %}">
                             <span class="visually-hidden">Actions possibles sur les usagers</span>
@@ -71,7 +71,7 @@
                                     <i class="ri-draft-line" aria-label="Postuler pour {{ job_seeker.get_inverted_full_name|mask_unless:job_seeker.user_can_view_personal_information }}"></i>
                                 </a>
                                 {% if job_seeker.show_more_actions %}
-                                    <button id="dropdown_{{ forloop.counter }}_action_menu" class="btn btn-sm btn-link btn-ico-only" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Plus d'actions">
+                                    <button id="dropdown_{{ forloop.counter }}_action_menu" class="btn btn-sm btn-link btn-ico-only" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Plus d’actions">
                                         <i class="ri-more-2-fill" aria-hidden="true"></i>
                                     </button>
                                     <div class="dropdown-menu" aria-labelledby="dropdown_{{ forloop.counter }}_action_menu">
@@ -90,9 +90,9 @@
                                                     {% csrf_token %}
                                                     <input type="hidden" name="is_not_stalled_anymore" value="{{ job_seeker.jobseeker_profile.is_not_stalled_anymore|yesno:"0,1" }}">
                                                     {% if job_seeker.jobseeker_profile.is_not_stalled_anymore %}
-                                                        <button type="submit" class="dropdown-item">L'usager est sans solution</button>
+                                                        <button type="submit" class="dropdown-item">L’usager est sans solution</button>
                                                     {% else %}
-                                                        <button type="submit" class="dropdown-item">L'usager n'est plus sans solution</button>
+                                                        <button type="submit" class="dropdown-item">L’usager n’est plus sans solution</button>
                                                     {% endif %}
                                                 </form>
                                             {% endif %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -112,6 +112,9 @@
                                                 <button type="submit" class="dropdown-item">Ajouter mon intervention</button>
                                             </form>
                                         {% endif %}
+                                        {% if job_seeker.pro_support_request_mailto %}
+                                            <a href="{{ job_seeker.pro_support_request_mailto }}" class="dropdown-item" {% matomo_event "candidat" "clic" "demande_bilan_accompagnement" %}>Demander un bilan d’accompagnement à la SIAE</a>
+                                        {% endif %}
                                     </div>
                                 {% endif %}
                             </td>

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 from functools import cached_property
 
 from django.conf import settings
@@ -7,7 +8,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import Count, DateTimeField, Exists, IntegerField, OuterRef, Subquery, Value
+from django.db.models import Count, DateTimeField, Exists, F, IntegerField, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce, Concat, Lower
 from django.db.models.query import Prefetch
 from django.forms import ValidationError
@@ -397,6 +398,34 @@ def assign_oneself_as_last_advisor(request, public_id):
     return HttpResponseRedirect(get_safe_url(request, "back_url", fallback_url=reverse("job_seekers_views:list")))
 
 
+PRO_SUPPORT_REQUEST_EMAIL_SUBJECT = "Demande de bilan d’accompagnement en fin de parcours IAE"
+# Use non-breaking spaces to avoid mail user agent to trim leading spaces.
+PRO_SUPPORT_REQUEST_EMAIL_BODY = """\
+    Bonjour,
+
+{job_seeker_full_name} arrive bientôt en fin de parcours IAE
+
+Pour préparer la suite de son accompagnement, pouvez-vous me partager les éléments utiles : ce qui a été travaillé, les freins encore présents et votre préconisation pour la suite ?
+
+On peut aussi s'appeler si c'est plus simple.
+
+Merci.
+"""  # noqa: E501 # Line too long
+
+
+def _build_pro_support_request_mailto(to_email, job_seeker_full_name):
+    # V1 opens a pre-filled mailto to the employing SIAE: no email is
+    # sent nor stored server-side.
+    query = urllib.parse.urlencode(
+        {
+            "subject": PRO_SUPPORT_REQUEST_EMAIL_SUBJECT,
+            "body": PRO_SUPPORT_REQUEST_EMAIL_BODY.format(job_seeker_full_name=job_seeker_full_name),
+        },
+        quote_via=urllib.parse.quote,
+    )
+    return f"mailto:{to_email}?{query}"
+
+
 @readonly_view
 @check_request(lambda request: request.from_prescriber or request.from_employer)
 def list_job_seekers(request, template_name="job_seekers_views/list.html", list_organization=False):
@@ -452,9 +481,34 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     )
 
     filters_counter = 0
+    end_of_journey_filter_active = False
     if form.is_valid():
         queryset = form.filter(queryset)
         filters_counter = form.get_filters_counter()
+        # The upcoming-end-of-IAE-journey filter is reserved for authorized prescribers (see FilterForm).
+        end_of_journey_filter_active = request.from_authorized_prescriber and bool(
+            form.cleaned_data.get("approval_ending_soon") or form.cleaned_data.get("contract_ending_soon")
+        )
+        if end_of_journey_filter_active:
+            # Contracts are the most precise, but they are delayed.
+            # Fallback to job applications if needs be.
+            queryset = queryset.annotate(
+                pro_support_request_company_email=Coalesce(
+                    Subquery(
+                        Contract.objects.filter(job_seeker=OuterRef("pk"), company__isnull=False)
+                        .exclude(company__email="")
+                        .order_by(F("start_date").desc())
+                        .values("company__email")[:1]
+                    ),
+                    Subquery(
+                        JobApplication.objects.accepted()
+                        .filter(job_seeker=OuterRef("pk"))
+                        .exclude(to_company__email="")
+                        .order_by(F("hiring_start_at").desc(nulls_last=True))
+                        .values("to_company__email")[:1]
+                    ),
+                )
+            )
 
     queryset = (
         queryset.annotate(
@@ -484,10 +538,23 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_LARGE)
     for job_seeker in page_obj:
         job_seeker.user_can_view_personal_information = can_view_personal_information(request, job_seeker)
+        job_seeker.pro_support_request_mailto = None
+        if (
+            end_of_journey_filter_active
+            and job_seeker.pro_support_request_company_email
+            # This last condition avoid the job seeker's name to leak
+            # to unauthorized users.
+            and job_seeker.user_can_view_personal_information
+        ):
+            job_seeker.pro_support_request_mailto = _build_pro_support_request_mailto(
+                job_seeker.pro_support_request_company_email,
+                job_seeker.get_full_name(),
+            )
         job_seeker.show_more_actions = (
             not job_seeker.has_valid_approval
             or job_seeker.jobseeker_profile.is_stalled
             or can_orient_towards_insertion_service(request)
+            or bool(job_seeker.pro_support_request_mailto)
         )
         job_seeker.services_search_url = build_services_search_url(request, job_seeker)
         professional, organization = request.user, request.current_organization

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -1703,6 +1703,23 @@
                        AND U0."job_seeker_id" = ("users_user"."id"))
                 ORDER BY 1 DESC
                 LIMIT 1) AS "last_contract_end_date",
+                    COALESCE(
+                               (SELECT U1."email" AS "company__email"
+                                FROM "companies_contract" U0
+                                INNER JOIN "companies_company" U1 ON (U0."company_id" = U1."id")
+                                WHERE (U0."company_id" IS NOT NULL
+                                       AND U0."job_seeker_id" = ("users_user"."id")
+                                       AND NOT (U1."email" = %s))
+                                ORDER BY U0."start_date" DESC
+                                LIMIT 1),
+                               (SELECT U2."email" AS "to_company__email"
+                                FROM "job_applications_jobapplication" U0
+                                INNER JOIN "companies_company" U2 ON (U0."to_company_id" = U2."id")
+                                WHERE (U0."state" = %s
+                                       AND U0."job_seeker_id" = ("users_user"."id")
+                                       AND NOT (U2."email" = %s))
+                                ORDER BY U0."hiring_start_at" DESC NULLS LAST
+                                LIMIT 1)) AS "pro_support_request_company_email",
                     (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
                     COALESCE(
                                (SELECT COUNT(U0."id") AS "count"
@@ -1758,7 +1775,8 @@
              GROUP BY "users_user"."id",
                       3,
                       4,
-                      6) subquery
+                      5,
+                      7) subquery
         ''',
       }),
       dict({
@@ -1819,6 +1837,23 @@
                     AND U0."job_seeker_id" = ("users_user"."id"))
              ORDER BY 1 DESC
              LIMIT 1) AS "last_contract_end_date",
+                 COALESCE(
+                            (SELECT U1."email" AS "company__email"
+                             FROM "companies_contract" U0
+                             INNER JOIN "companies_company" U1 ON (U0."company_id" = U1."id")
+                             WHERE (U0."company_id" IS NOT NULL
+                                    AND U0."job_seeker_id" = ("users_user"."id")
+                                    AND NOT (U1."email" = %s))
+                             ORDER BY U0."start_date" DESC
+                             LIMIT 1),
+                            (SELECT U2."email" AS "to_company__email"
+                             FROM "job_applications_jobapplication" U0
+                             INNER JOIN "companies_company" U2 ON (U0."to_company_id" = U2."id")
+                             WHERE (U0."state" = %s
+                                    AND U0."job_seeker_id" = ("users_user"."id")
+                                    AND NOT (U2."email" = %s))
+                             ORDER BY U0."hiring_start_at" DESC NULLS LAST
+                             LIMIT 1)) AS "pro_support_request_company_email",
                  (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
                  COALESCE(
                             (SELECT COUNT(U0."id") AS "count"
@@ -1921,9 +1956,10 @@
           GROUP BY "users_user"."id",
                    41,
                    42,
-                   44,
+                   43,
+                   45,
                    "users_jobseekerprofile"."user_id"
-          ORDER BY 43 DESC,
+          ORDER BY 44 DESC,
                    "users_user"."id" DESC
           LIMIT 1
         ''',
@@ -2519,6 +2555,23 @@
                        AND U0."job_seeker_id" = ("users_user"."id"))
                 ORDER BY 1 DESC
                 LIMIT 1) AS "last_contract_end_date",
+                    COALESCE(
+                               (SELECT U1."email" AS "company__email"
+                                FROM "companies_contract" U0
+                                INNER JOIN "companies_company" U1 ON (U0."company_id" = U1."id")
+                                WHERE (U0."company_id" IS NOT NULL
+                                       AND U0."job_seeker_id" = ("users_user"."id")
+                                       AND NOT (U1."email" = %s))
+                                ORDER BY U0."start_date" DESC
+                                LIMIT 1),
+                               (SELECT U2."email" AS "to_company__email"
+                                FROM "job_applications_jobapplication" U0
+                                INNER JOIN "companies_company" U2 ON (U0."to_company_id" = U2."id")
+                                WHERE (U0."state" = %s
+                                       AND U0."job_seeker_id" = ("users_user"."id")
+                                       AND NOT (U2."email" = %s))
+                                ORDER BY U0."hiring_start_at" DESC NULLS LAST
+                                LIMIT 1)) AS "pro_support_request_company_email",
                     (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
                     COALESCE(
                                (SELECT COUNT(U0."id") AS "count"
@@ -2576,7 +2629,8 @@
              GROUP BY "users_user"."id",
                       3,
                       4,
-                      6) subquery
+                      5,
+                      7) subquery
         ''',
       }),
       dict({
@@ -2637,6 +2691,23 @@
                     AND U0."job_seeker_id" = ("users_user"."id"))
              ORDER BY 1 DESC
              LIMIT 1) AS "last_contract_end_date",
+                 COALESCE(
+                            (SELECT U1."email" AS "company__email"
+                             FROM "companies_contract" U0
+                             INNER JOIN "companies_company" U1 ON (U0."company_id" = U1."id")
+                             WHERE (U0."company_id" IS NOT NULL
+                                    AND U0."job_seeker_id" = ("users_user"."id")
+                                    AND NOT (U1."email" = %s))
+                             ORDER BY U0."start_date" DESC
+                             LIMIT 1),
+                            (SELECT U2."email" AS "to_company__email"
+                             FROM "job_applications_jobapplication" U0
+                             INNER JOIN "companies_company" U2 ON (U0."to_company_id" = U2."id")
+                             WHERE (U0."state" = %s
+                                    AND U0."job_seeker_id" = ("users_user"."id")
+                                    AND NOT (U2."email" = %s))
+                             ORDER BY U0."hiring_start_at" DESC NULLS LAST
+                             LIMIT 1)) AS "pro_support_request_company_email",
                  (COALESCE(LOWER("users_user"."last_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."first_name"), %s)), %s)) AS "full_name",
                  COALESCE(
                             (SELECT COUNT(U0."id") AS "count"
@@ -2741,9 +2812,10 @@
           GROUP BY "users_user"."id",
                    41,
                    42,
-                   44,
+                   43,
+                   45,
                    "users_jobseekerprofile"."user_id"
-          ORDER BY 43 DESC,
+          ORDER BY 44 DESC,
                    "users_user"."id" DESC
           LIMIT 1
         ''',
@@ -3782,7 +3854,7 @@
               </th>
               <th aria-sort="none" scope="col">
                   <button data-emplois-setter-target="#id_order" data-emplois-setter-value="advisors__len" type="button">
-                      Nbr d'accompagnateurs
+                      Nbr d’accompagnateurs
                   </button>
               </th>
               <th scope="col">
@@ -3828,7 +3900,7 @@
                       <i aria-label="Postuler pour WATERFORD David" class="ri-draft-line">
                       </i>
                   </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
                       <i aria-hidden="true" class="ri-more-2-fill">
                       </i>
                   </button>
@@ -3878,7 +3950,7 @@
                       <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                       </i>
                   </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
                       <i aria-hidden="true" class="ri-more-2-fill">
                       </i>
                   </button>
@@ -3890,7 +3962,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="1"/>
                           <button class="dropdown-item" type="submit">
-                              L'usager n'est plus sans solution
+                              L’usager n’est plus sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -3931,7 +4003,7 @@
                       <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
                       </i>
                   </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
                       <i aria-hidden="true" class="ri-more-2-fill">
                       </i>
                   </button>
@@ -3940,7 +4012,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="0"/>
                           <button class="dropdown-item" type="submit">
-                              L'usager est sans solution
+                              L’usager est sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -3991,7 +4063,7 @@
                       <i aria-label="Postuler pour ZORRO Alain" class="ri-draft-line">
                       </i>
                   </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_4_action_menu" type="button">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_4_action_menu" type="button">
                       <i aria-hidden="true" class="ri-more-2-fill">
                       </i>
                   </button>
@@ -4003,7 +4075,7 @@
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <input name="is_not_stalled_anymore" type="hidden" value="1"/>
                           <button class="dropdown-item" type="submit">
-                              L'usager n'est plus sans solution
+                              L’usager n’est plus sans solution
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&back_url=%2Fjob-seekers%2Flist&city=brest-29">
@@ -4827,7 +4899,7 @@
                   <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                   </i>
               </a>
-              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
+              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
                   <i aria-hidden="true" class="ri-more-2-fill">
                   </i>
               </button>
@@ -4879,7 +4951,7 @@
                   <i aria-label="Postuler pour ZORRO Alain" class="ri-draft-line">
                   </i>
               </a>
-              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
+              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
                   <i aria-hidden="true" class="ri-more-2-fill">
                   </i>
               </button>
@@ -4925,7 +4997,7 @@
                   <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
                   </i>
               </a>
-              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
+              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d’actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
                   <i aria-hidden="true" class="ri-more-2-fill">
                   </i>
               </button>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -14,6 +14,7 @@ from pytest_django.asserts import assertContains, assertNotContains, assertRedir
 
 from itou.asp.models import Commune
 from itou.companies.models import Company
+from itou.job_applications.enums import JobApplicationState
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
@@ -1594,3 +1595,138 @@ def test_last_action_at(client):
 
     response = client.get(url)
     assertContains(response, now.strftime("%d/%m/%Y"))
+
+
+ACCOMPANIMENT_REVIEW_ACTION_LABEL = ""
+
+
+@freeze_time("2026-01-15")
+@pytest.mark.parametrize("view", ("job_seekers_views:list", "job_seekers_views:list_organization"))
+def test_pro_support_request_action_for_authorized_prescriber(client, view):
+    organization = PrescriberOrganizationFactory(with_membership=True, authorized=True)
+    user = organization.members.first()
+    client.force_login(user)
+    today = datetime.date(2026, 1, 15)
+
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=user,
+        author_prescriber_organization=organization,
+        job_seeker__first_name="Jean",
+        job_seeker__last_name="Dupont",
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=30),
+    )
+    job_application = JobApplicationFactory(
+        job_seeker=job_seeker,
+        sent_by_job_seeker=True,
+        to_company__email="",
+        state=JobApplicationState.ACCEPTED,
+        hiring_start_at=today - datetime.timedelta(days=200),
+    )
+
+    # Without the end-of-journey filter, the action is hidden.
+    mailto_label = "Demander un bilan d’accompagnement à la SIAE"
+    url = reverse(view)
+    response = client.get(url)
+    assertNotContains(response, mailto_label)
+
+    # With the filter active, the action should be displayed, unless
+    # the company does not have any email.
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assertNotContains(response, mailto_label)
+
+    # Now with a company that has an e-mail.
+    company = job_application.to_company
+    company.email = "siae@example.com"
+    company.save()
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assertContains(response, mailto_label)
+    assertContains(response, "mailto:siae@example.com?subject=Demande%20de%20bilan%20d%E2%80%99accompagnement")
+    assertContains(response, "Jean%20DUPONT%20arrive")
+
+
+@freeze_time("2026-01-15")
+def test_request_accompaniment_review_action_not_for_employer(client):
+    company = CompanyFactory(subject_to_iae_rules=True, email="siae@example.com")
+    employer = CompanyMembershipFactory(company=company).user
+    client.force_login(employer)
+    url = reverse("job_seekers_views:list_organization")
+    today = datetime.date(2026, 1, 15)
+
+    job_seeker = JobSeekerFactory()
+    JobSeekerAssignmentFactory(
+        job_seeker=job_seeker,
+        professional=employer,
+        company=company,
+    )
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=30),
+    )
+    JobApplicationFactory(
+        job_seeker=job_seeker,
+        sent_by_job_seeker=True,
+        to_company=company,
+        state=JobApplicationState.ACCEPTED,
+        hiring_start_at=today - datetime.timedelta(days=200),
+    )
+
+    # The filter should not be available, but user could try to tweak
+    # the request.
+    response = client.get(url, {"approval_ending_soon": "on", "contract_ending_soon": "on"})
+    assert response.context["page_obj"].object_list == [job_seeker]
+    assert not hasattr(response.context["page_obj"].object_list[0], "pro_support_request_company_email")
+    assertNotContains(response, "mailto:siae@example.com")
+
+
+@freeze_time("2026-01-15")
+def test_request_accompaniment_review_recipient_priority(client):
+    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
+    user = organization.members.first()
+    client.force_login(user)
+    url = reverse("job_seekers_views:list")
+    today = datetime.date(2026, 1, 15)
+
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=user,
+        author_prescriber_organization=organization,
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    ApprovalFactory(
+        user=job_seeker,
+        start_at=today - datetime.timedelta(days=600),
+        end_at=today + datetime.timedelta(days=30),
+    )
+    # Fallback source: the last accepted job application SIAE.
+    JobApplicationFactory(
+        job_seeker=job_seeker,
+        sent_by_job_seeker=True,
+        to_company__email="candidature@example.com",
+        state=JobApplicationState.ACCEPTED,
+        hiring_start_at=today - datetime.timedelta(days=200),
+    )
+    # Priority source: the ASP contract SIAE ending the latest wins over an older contract and the
+    # accepted job application.
+    ContractFactory(
+        job_seeker=job_seeker,
+        company__email="vieux-contrat@example.com",
+        start_date=today - datetime.timedelta(days=800),
+        end_date=today - datetime.timedelta(days=400),
+    )
+    ContractFactory(
+        job_seeker=job_seeker,
+        company__email="contrat-asp@example.com",
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+
+    response = client.get(url, {"approval_ending_soon": "on"})
+    assertContains(response, "mailto:contrat-asp@example.com")
+    assertNotContains(response, "mailto:candidature@example.com")

--- a/tests/www/job_seekers_views/test_search_services.py
+++ b/tests/www/job_seekers_views/test_search_services.py
@@ -106,7 +106,7 @@ def assert_has_more_actions(response, list_url, job_seeker):
         query["city"] = job_seeker.city_slug
     expected_url = reverse("search:services_results", query=query)
     assertContains(response, list_markup(expected_url), html=True)
-    assertContains(response, 'aria-label="Plus d\'actions"')
+    assertContains(response, 'aria-label="Plus d’actions"')
 
 
 def test_search_services_from_list_as_authorized_prescriber(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand un prescripteur habilité constate qu'un de ses candidats arrive en fin de parcours IAE, il n'a aujourd'hui aucun moyen simple de solliciter la SIAE employeuse pour préparer la suite. Cette PR ajoute un raccourci pour lui demander un bilan d'accompagnement.

## :cake: Comment ?

Sur la liste « Accompagnements », quand le filtre « Fin de parcours IAE à venir » est actif (réservé aux prescripteurs habilités), chaque salarié concerné propose une action « ⋮ » **« Demander un bilan d'accompagnement à la SIAE »**.

- L'action ouvre un **`mailto:` pré-rempli** (objet + corps) vers l'e-mail de la SIAE employeuse. **V1** : rien n'est envoyé côté serveur, rien n'est stocké.
- **Destinataire** trouvé par priorité, en ignorant les structures sans e-mail : (1) la SIAE du contrat ASP (la plus récente), (2) sinon la SIAE de la dernière candidature acceptée. La donnée ASP est la plus précise mais partielle et différée, d'où le repli.
- **Vie privée** : le nom du salarié n'est mis dans le corps que si le prescripteur a le droit de le voir ; aucun envoi automatique.
- L'annotation qui récupère l'e-mail n'est calculée que lorsque le filtre est actif (aucune requête supplémentaire sur la liste courante).

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ? Non, aucun changement cassant.
- [ ] Ajouter l'étiquette « Bug » ? Non, nouvelle fonctionnalité.

## :desert_island: Comment tester ?

En tant que **prescripteur habilité**, sur « Accompagnements », avec un candidat dont le PASS IAE expire bientôt (ou le contrat se termine bientôt) et une SIAE employeuse ayant un e-mail :

1. Cocher **« PASS IAE bientôt expiré »** (ou « Contrat IAE bientôt terminé »).
2. Sur la ligne du candidat, ouvrir le menu **« ⋮ »** → **« Demander un bilan d'accompagnement à la SIAE »**.
3. Le clic ouvre un brouillon d'e-mail pré-rempli vers la SIAE (aucun envoi automatique).
