### PR TITLE
Connexion : Ne pas rediriger vers le nouveau domain depuis la page de vérification OTP

### DIFF
--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -158,6 +158,11 @@ def _get_redirect_url(request):
         # some time before redirecting (or maybe never redirect
         # them if we still see calls to the old domain in logs).
         return None
+    if request.path.startswith(reverse("otp_views:verify_otp")):
+        # Don't redirect to the new domain, otherwise the user will
+        # end up at "new.domain/otp/verify" and it will look like the
+        # user has been disconnected (which they are not).
+        return None
     if request.method != "GET":
         # Don't redirect POST, DELETE, etc.: if the user visits the
         # old domain _before_ we enable the redirection for them, then

--- a/tests/www/middleware/tests.py
+++ b/tests/www/middleware/tests.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from tests.companies.factories import CompanyFactory
+from tests.otp.factories import ItouTOTPDeviceFactory
 from tests.users.factories import ItouStaffFactory, PrescriberFactory
 
 
@@ -48,4 +49,21 @@ class TestRedirectToNewDomainMiddleware:
         user = CompanyFactory(with_membership=True).members.first()
         api_client.force_authenticate(user)
         response = api_client.get(reverse("v1:applicants-list"), HTTP_HOST="old.domain")
-        assert response.status_code == 200
+        assert response.status_code == 200  # no redirect
+
+    def test_do_not_redirect_otp_verify_form(self, settings, client):
+        settings.NEW_DOMAIN = "new.domain"
+        settings.ALLOWED_HOSTS = ["old.domain", settings.NEW_DOMAIN]
+        settings.REDIRECT_TO_NEW_DOMAIN = True
+        settings.REQUIRE_OTP_FOR_STAFF = True
+
+        user = ItouStaffFactory()
+        ItouTOTPDeviceFactory(user=user)
+        client.force_login(user)
+        response = client.get(
+            "/otp/verify",
+            query_params={"next": "/some/restricted/page"},
+            HTTP_HOST="old.domain",
+            follow=False,
+        )
+        assert response.status_code == 200  # no rediect


### PR DESCRIPTION
La redirection vers le nouveau domaine n'est pour l'instant appliquée qu'aux utilisateurs staff, mais c'est assez embêtant pour l'équipe support, qui clique sur des liens vers l'_ancien_ nom de domaine depuis les tickets Zendesk (et est donc affectée par le problème).

---

Use case:

1. User is authenticated (and verified their OTP) on new domain.
2. User goes to old domain.
3. User authenticates (password only, no OTP) on old domain.
3. They are redirected (by `ItouCurrentOrganizationMiddleware`) to "/otp/verify?next=/something" on the old domain.
4. They are redirected (this time by `RedirectToNewDomainMiddleware`) to the same URL on the _new_ domain.
5. User is requested to enter an OTP on the new domain, even when they already did and are already fully authenticated there.
6. User is angry and throws keyboard to developers.

We do not want that (keyboards and developers are fragile). Instead, do not redirect to new domain on step 4: redirect to next page on _old_ domain, and only then redirect to the _new_ domain.
