### PR TITLE
PASS IAE : générer un lien de demande de prolongation depuis l'admin

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -11,6 +11,7 @@ from itou.approvals.admin_forms import ApprovalAdminForm
 from itou.approvals.admin_views import (
     manually_add_approval,
     manually_refuse_approval,
+    prolongation_derogation,
     send_approvals_to_pe_stats,
     terminate_approval,
 )
@@ -370,6 +371,12 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
     def terminate_approval(self, request, approval_id):
         return terminate_approval(request, self, approval_id)
 
+    def prolongation_derogation(self, request, approval_id):
+        """
+        Custom admin view to issue an out-of-time-limits prolongation link.
+        """
+        return prolongation_derogation(request, self, approval_id)
+
     def get_urls(self):
         additional_urls = [
             path(
@@ -386,6 +393,11 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
                 "<int:approval_id>/terminate",
                 self.admin_site.admin_view(self.terminate_approval),
                 name="approvals_approval_terminate_approval",
+            ),
+            path(
+                "<int:approval_id>/prolongation-derogation",
+                self.admin_site.admin_view(self.prolongation_derogation),
+                name="approvals_approval_prolongation_derogation",
             ),
             path(
                 "sent-to-pe-stats",

--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -1,8 +1,13 @@
 from django import forms
+from django.contrib.admin import widgets
 from django.core.exceptions import ValidationError
 
 from itou.approvals.models import Approval
-from itou.job_applications.enums import Origin
+from itou.companies.enums import CompanyKind
+from itou.companies.models import Company
+from itou.job_applications.enums import JobApplicationState, Origin
+from itou.job_applications.models import JobApplication
+from itou.utils.admin import FakeRelForRawIdWidget
 
 
 class ApprovalFormMixin:
@@ -86,3 +91,35 @@ class ManuallyAddApprovalFromJobApplicationForm(ApprovalFormMixin, forms.ModelFo
     class Meta:
         model = Approval
         fields = ["start_at", "end_at", "number"]
+
+
+class ProlongationDerogationForm(forms.Form):
+    """Select the company to which a derogation link for an out-of-deadline prolongation is issued."""
+
+    company = forms.ModelChoiceField(
+        Company.objects.filter(kind__in=CompanyKind.siae_kinds()),
+        required=True,
+        label="SIAE autorisée à déclarer la prolongation",
+        help_text="Saisissez l’ID de la SIAE, ou recherchez-la avec la loupe.",
+        error_messages={
+            "invalid_choice": (
+                "Cette entreprise n’existe pas ou n’est pas une SIAE, elle ne peut pas déclarer de prolongation."
+            )
+        },
+    )
+
+    def __init__(self, *args, approval, admin_site, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["company"].widget = widgets.ForeignKeyRawIdWidget(
+            FakeRelForRawIdWidget(Company, limit_choices_to={"kind__in": CompanyKind.siae_kinds()}), admin_site
+        )
+        self.approval = approval
+
+    def clean_company(self):
+        """Mirrors checks performed by `declare_prolongation` to never hand out a link leading to a 404/403."""
+        company = self.cleaned_data["company"]
+        if not JobApplication.objects.filter(
+            approval=self.approval, to_company=company, state=JobApplicationState.ACCEPTED
+        ).exists():
+            raise ValidationError("Cette entreprise n’a pas de candidature acceptée liée à ce PASS IAE.")
+        return company

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -7,6 +7,7 @@ https://docs.djangoproject.com/en/dev/ref/contrib/admin/#adding-views-to-admin-s
 https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/change_form.html
 """
 
+import datetime
 import logging
 from collections import defaultdict
 
@@ -20,7 +21,7 @@ from django.urls import reverse
 from django.utils import timezone
 from itoutils.urls import add_url_params
 
-from itou.approvals.admin_forms import ManuallyAddApprovalFromJobApplicationForm
+from itou.approvals.admin_forms import ManuallyAddApprovalFromJobApplicationForm, ProlongationDerogationForm
 from itou.approvals.enums import Origin
 from itou.approvals.models import Approval, CancelledApproval, Prolongation, Suspension
 from itou.job_applications.enums import JobApplicationState
@@ -28,6 +29,7 @@ from itou.job_applications.models import JobApplication
 from itou.utils.admin import add_support_remark_to_obj
 from itou.utils.apis import enums as api_enums
 from itou.utils.emails import get_email_text_template
+from itou.utils.tokens import prolongation_derogation_token_generator
 from itou.utils.urls import get_absolute_url
 
 
@@ -235,6 +237,76 @@ def terminate_approval(request, model_admin, approval_id):
     approval.save(update_fields=["end_at", "updated_at"])
     add_support_remark_to_obj(approval, f"{new_end} : PASS IAE clôturé par {request.user.get_full_name()}.")
     return HttpResponseRedirect(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
+
+
+def prolongation_derogation(
+    request, model_admin, approval_id, template_name="admin/approvals/prolongation_derogation.html"
+):
+    """Admin view to issue a link that allows an employer to declare an out-of-time-limits prolongation.
+
+    Only the prolongation deadline is waived, see `Approval.needs_prolongation_derogation`.
+    """
+
+    opts = model_admin.model._meta
+    codename = get_permission_codename("change", opts)
+    if not request.user.has_perm(f"{opts.app_label}.{codename}"):
+        raise PermissionDenied
+
+    approval = get_object_or_404(Approval.objects.select_related("user").with_assigned_company(), pk=approval_id)
+
+    if not approval.needs_prolongation_derogation:
+        PROLONGATION_STILL_POSSIBLE = (
+            "Ce PASS IAE est dans les délais, l’employeur peut déclarer la prolongation sans lien de dérogation."
+        )
+        blocker = approval.prolongation_blocker
+        messages.error(request, blocker.label if blocker else PROLONGATION_STILL_POSSIBLE)
+        return HttpResponseRedirect(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
+
+    form = ProlongationDerogationForm(
+        approval=approval,
+        admin_site=model_admin.admin_site,
+        data=request.POST or None,
+        # The company handling the PASS IAE is the expected one in the
+        # majority of cases, but the support can still pick another one
+        initial={"company": approval.assigned_company},
+    )
+    derogation_link = None
+    if request.method == "POST" and form.is_valid():
+        company = form.cleaned_data["company"]
+        token = prolongation_derogation_token_generator.make_token(approval=approval, company=company)
+        derogation_link = get_absolute_url(
+            reverse("approvals:prolongation_derogation", kwargs={"approval_id": approval.pk, "token": token})
+        )
+        add_support_remark_to_obj(
+            approval,
+            f"{timezone.localdate()} : lien de demande de prolongation hors délais généré par "
+            f"{request.user.get_full_name()} pour l’entreprise {company.pk} — {company.display_name}.",
+        )
+        logger.info(
+            "staff user=%(user_id)d issued a prolongation derogation link "
+            "for approval=%(approval_id)d company=%(company_id)d.",
+            {"user_id": request.user.pk, "approval_id": approval.pk, "company_id": company.pk},
+        )
+        messages.success(request, "Le lien de demande de prolongation a bien été généré.")
+    timeout = datetime.timedelta(seconds=prolongation_derogation_token_generator.timeout)
+    context = _admin_context(
+        request,
+        model_admin,
+        title=(
+            f"Générer un lien de demande de prolongation pour "
+            f"le PASS IAE {approval.number} ({approval.user.get_full_name()})"
+        ),
+        approval=approval,
+        # `add` and `original` drive the last breadcrumb of admin/change_form.html,
+        # `errors` its “Error:” page <title> prefix.
+        add=False,
+        original=approval,
+        errors=admin.helpers.AdminErrorList(form, {}),
+        derogation_link=derogation_link,
+        expires_at=timezone.localdate() + timeout if derogation_link else None,
+        form=form,
+    )
+    return render(request, template_name, context)
 
 
 def _compute_send_approvals_to_pe_stats(model, list_url):

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -34,6 +34,22 @@ from itou.utils.urls import get_absolute_url
 logger = logging.getLogger("itou.approvals.admin")
 
 
+def _admin_context(request, model_admin, *, title, **extra):
+    """Build the context every custom admin view needs to render an admin template."""
+    admin_site = model_admin.admin_site
+    opts = model_admin.model._meta
+    return admin_site.each_context(request) | {
+        "admin_site": admin_site.name,
+        "app_label": opts.app_label,
+        "has_view_permission": model_admin.has_view_permission(request),
+        "media": model_admin.media,
+        "opts": opts,
+        "subtitle": None,
+        "title": title,
+        **extra,
+    }
+
+
 def manually_add_approval(
     request, model_admin, job_application_id, template_name="admin/approvals/manually_add_approval.html"
 ):
@@ -41,9 +57,7 @@ def manually_add_approval(
     Custom admin view to manually add an approval.
     """
 
-    admin_site = model_admin.admin_site
-    opts = model_admin.model._meta
-    app_label = opts.app_label
+    app_label = model_admin.model._meta.app_label
     has_perm = request.user.has_perm(f"{app_label}.handle_manual_approval_requests")
 
     if not has_perm:
@@ -92,21 +106,16 @@ def manually_add_approval(
         messages.success(request, f"Le PASS IAE {approval.number_with_spaces} a bien été créé et envoyé par e-mail.")
         return HttpResponseRedirect(reverse("admin:approvals_approval_changelist"))
 
-    context = {
-        "add": True,
-        "adminform": adminForm,
-        "admin_site": admin_site.name,
-        "app_label": app_label,
-        "errors": admin.helpers.AdminErrorList(form, {}),
-        "form": form,
-        "job_application": job_application,
-        "media": model_admin.media,
-        "opts": opts,
-        "title": "Ajout manuel d'un numéro d'agrément",
-        "subtitle": None,
-        "has_view_permission": model_admin.has_view_permission(request),
-        **admin_site.each_context(request),
-    }
+    context = _admin_context(
+        request,
+        model_admin,
+        title="Ajout manuel d'un numéro d'agrément",
+        add=True,
+        adminform=adminForm,
+        errors=admin.helpers.AdminErrorList(form, {}),
+        form=form,
+        job_application=job_application,
+    )
     return render(request, template_name, context)
 
 
@@ -117,9 +126,7 @@ def manually_refuse_approval(
     Custom admin view to manually refuse an approval (in the case of a job seeker in waiting period).
     """
 
-    admin_site = model_admin.admin_site
-    opts = model_admin.model._meta
-    app_label = opts.app_label
+    app_label = model_admin.model._meta.app_label
     has_perm = request.user.has_perm(f"{app_label}.handle_manual_approval_requests")
 
     if not has_perm:
@@ -160,20 +167,15 @@ def manually_refuse_approval(
         },
     )
 
-    context = {
-        "add": True,
-        "admin_site": admin_site.name,
-        "app_label": app_label,
-        "email_body_template": email_body_template,
-        "email_subject_template": email_subject_template,
-        "job_application": job_application,
-        "media": model_admin.media,
-        "opts": opts,
-        "title": "Confirmer le refus manuel d'un numéro d'agrément",
-        "subtitle": None,
-        "has_view_permission": model_admin.has_view_permission(request),
-        **admin_site.each_context(request),
-    }
+    context = _admin_context(
+        request,
+        model_admin,
+        title="Confirmer le refus manuel d'un numéro d'agrément",
+        add=True,
+        email_body_template=email_body_template,
+        email_subject_template=email_subject_template,
+        job_application=job_application,
+    )
     return render(request, template_name, context)
 
 

--- a/itou/approvals/enums.py
+++ b/itou/approvals/enums.py
@@ -47,6 +47,31 @@ class ProlongationReason(models.TextChoices):
         return empty + [(enum.value, enum.label) for enum in enums]
 
 
+class ProlongationBlocker(models.TextChoices):
+    """Why a PASS IAE cannot be prolonged.
+
+    Only `DEADLINE_PASSED` can be waived, by a derogation link issued by the support.
+    """
+
+    SUSPENDED = "SUSPENDED", "Ce PASS IAE est suspendu, il ne peut pas être prolongé."
+    PENDING_REQUEST = (
+        "PENDING_REQUEST",
+        "Une demande de prolongation est déjà en attente pour ce PASS IAE.",
+    )
+    NOT_LATEST_APPROVAL = (
+        "NOT_LATEST_APPROVAL",
+        "Ce PASS IAE n’est pas le PASS IAE le plus récent du candidat, il ne peut donc pas être prolongé.",
+    )
+    TOO_EARLY = (
+        "TOO_EARLY",
+        "Ce PASS IAE se termine dans plus de 12 mois, il est trop tôt pour le prolonger.",
+    )
+    DEADLINE_PASSED = (
+        "DEADLINE_PASSED",
+        "Ce PASS IAE est arrivé à échéance il y a plus de 6 mois, le délai de prolongation est dépassé.",
+    )
+
+
 class ProlongationRequestStatus(models.TextChoices):
     PENDING = "PENDING", "À traiter"
     GRANTED = "GRANTED", "Acceptée"

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -398,6 +398,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     ASP_ITOU_PREFIX = settings.ASP_ITOU_PREFIX
 
     # The period of time during which it is possible to prolong a PASS IAE.
+    # The support can waive the closing date by issuing a derogation link, never the opening one.
     PROLONGATION_OPENS_MONTHS_BEFORE_END = 12
     PROLONGATION_CLOSES_MONTHS_AFTER_END = 6
 
@@ -825,25 +826,69 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     def pending_prolongation_request(self):
         return self.prolongationrequest_set.filter(status=enums.ProlongationRequestStatus.PENDING).first()
 
+    def count_declarations(self):
+        """How many times a prolongation was declared for this PASS IAE, whatever its outcome.
+
+        Rows are not supposed to be deleted (a denied request keeps its `DENIED` status), so this
+        only ever grows. `ProlongationDerogationTokenGenerator` folds it into its hash to make
+        a support derogation link single-use.
+        """
+        return self.prolongation_set.count() + self.prolongationrequest_set.count()
+
+    @property
+    def prolongation_period_has_started(self):
+        """Prolongations open 12 months before the end of a PASS IAE. Nothing waives this."""
+        return timezone.localdate() >= self.end_at - relativedelta(months=self.PROLONGATION_OPENS_MONTHS_BEFORE_END)
+
+    @property
+    def prolongation_period_has_ended(self):
+        """Prolongations close 6 months after the end of a PASS IAE.
+
+        The support can waive this deadline, and only this one, by issuing a derogation link.
+        """
+        return timezone.localdate() > self.end_at + relativedelta(months=self.PROLONGATION_CLOSES_MONTHS_AFTER_END)
+
     @property
     def is_open_to_prolongation(self):
-        now = timezone.localdate()
-        lower_bound = self.end_at - relativedelta(months=self.PROLONGATION_OPENS_MONTHS_BEFORE_END)
-        upper_bound = self.end_at + relativedelta(months=self.PROLONGATION_CLOSES_MONTHS_AFTER_END)
-        return lower_bound <= now <= upper_bound
+        return self.prolongation_period_has_started and not self.prolongation_period_has_ended
 
     @cached_property
-    def can_be_prolonged(self):
+    def prolongation_blocker(self):
+        """Why this PASS IAE cannot be prolonged. `None` when it can.
+
+        Checked from the most definitive to the most waivable: `DEADLINE_PASSED` comes last
+        because it is the only blocker a support derogation link can waive.
+        """
+        if self.is_suspended:
+            return enums.ProlongationBlocker.SUSPENDED
+        if self.pending_prolongation_request():
+            return enums.ProlongationBlocker.PENDING_REQUEST
         # Since it is possible to prolong even a few months after the end of a PASS IAE,
         # it is possible that another one has been issued in the meantime. Thus we
         # have to ensure that the current PASS IAE is the most recent for the user
         # before allowing a prolongation.
-        return (
-            self.is_open_to_prolongation
-            and self == self.user.latest_approval
-            and not self.is_suspended
-            and not self.pending_prolongation_request()
-        )
+        if self != self.user.latest_approval:
+            return enums.ProlongationBlocker.NOT_LATEST_APPROVAL
+        if not self.prolongation_period_has_started:
+            return enums.ProlongationBlocker.TOO_EARLY
+        if self.prolongation_period_has_ended:
+            return enums.ProlongationBlocker.DEADLINE_PASSED
+        return None
+
+    @cached_property
+    def can_be_prolonged(self):
+        # `is_open_to_prolongation` first: it short-circuits the queries of `prolongation_blocker`
+        # for the many PASS IAE simply out of the prolongation period.
+        return self.is_open_to_prolongation and self.prolongation_blocker is None
+
+    @cached_property
+    def needs_prolongation_derogation(self):
+        """The passed deadline is the only obstacle to a prolongation.
+
+        Only then may the support issue a derogation link: it waives that deadline, and
+        nothing else. See `ProlongationDerogationTokenGenerator`.
+        """
+        return self.prolongation_blocker == enums.ProlongationBlocker.DEADLINE_PASSED
 
     @staticmethod
     def get_origin_kwargs(origin_job_application):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -398,8 +398,8 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     ASP_ITOU_PREFIX = settings.ASP_ITOU_PREFIX
 
     # The period of time during which it is possible to prolong a PASS IAE.
-    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END = 12
-    IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END = 6
+    PROLONGATION_OPENS_MONTHS_BEFORE_END = 12
+    PROLONGATION_CLOSES_MONTHS_AFTER_END = 6
 
     # Error messages.
     ERROR_PASS_IAE_SUSPENDED_FOR_USER = (
@@ -828,8 +828,8 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     @property
     def is_open_to_prolongation(self):
         now = timezone.localdate()
-        lower_bound = self.end_at - relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END)
-        upper_bound = self.end_at + relativedelta(months=self.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_AFTER_END)
+        lower_bound = self.end_at - relativedelta(months=self.PROLONGATION_OPENS_MONTHS_BEFORE_END)
+        upper_bound = self.end_at + relativedelta(months=self.PROLONGATION_CLOSES_MONTHS_AFTER_END)
         return lower_bound <= now <= upper_bound
 
     @cached_property

--- a/itou/approvals/perms.py
+++ b/itou/approvals/perms.py
@@ -2,6 +2,7 @@ import logging
 
 from itou.job_applications.enums import JobApplicationState
 from itou.users.models import User
+from itou.utils.tokens import prolongation_derogation_token_generator
 
 
 logger = logging.getLogger(__name__)
@@ -40,3 +41,34 @@ def can_view_approval_details(request, approval):
     else:
         logger.exception("This should never happen")
     return None
+
+
+def prolongation_derogation_session_key(*, approval, company):
+    """Where the token of a derogation link is kept for the duration of the declaration flow."""
+    return f"prolongation_derogation:{company.pk}:{approval.pk}"
+
+
+def can_declare_prolongation(request, *, approval, company):
+    """Whether `company` may open the prolongation form for `approval`.
+
+    A derogation link issued by the support for this exact (approval, company) pair waives the
+    prolongation deadline (`Approval.prolongation_period_has_ended`), and only this limit: an
+    approval that is suspended, that is not the latest one of the job seeker, that already has a
+    pending prolongation request or that ends in more than 12 months still cannot be prolonged.
+
+    Following such a link stores its token in the session, see the `prolongation_derogation`
+    view. The token is checked again here on every step of the flow, and remains single-use:
+    declaring a prolongation consumes it, see `ProlongationDerogationTokenGenerator`.
+    """
+    if not company.is_subject_to_iae_rules:
+        return False
+    if approval.can_be_prolonged:
+        return True
+    session_key = prolongation_derogation_session_key(approval=approval, company=company)
+    if approval.needs_prolongation_derogation and prolongation_derogation_token_generator.check_token(
+        request.session.get(session_key), approval=approval, company=company
+    ):
+        return True
+    # The derogation link cannot be used anymore, don’t keep its token around
+    request.session.pop(session_key, None)
+    return False

--- a/itou/companies/admin_forms.py
+++ b/itou/companies/admin_forms.py
@@ -1,23 +1,9 @@
-from collections import namedtuple
-
 from django import forms
 from django.contrib.admin import widgets
 from django.core.exceptions import ValidationError
 
 from itou.companies.models import Company
-from itou.utils.admin import ChooseFieldsToTransfer
-
-
-FakeField = namedtuple("FakeField", ("name",))
-
-
-class FakeRelForToCompanyRawIdWidget:
-    model = Company
-    limit_choices_to = {}
-
-    def get_related_field(self):
-        # This must return something that has the name of an existing field
-        return FakeField("id")
+from itou.utils.admin import ChooseFieldsToTransfer, FakeRelForRawIdWidget
 
 
 class SelectTargetCompanyForm(forms.Form):
@@ -25,7 +11,7 @@ class SelectTargetCompanyForm(forms.Form):
 
     def __init__(self, *args, from_company, admin_site, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["to_company"].widget = widgets.ForeignKeyRawIdWidget(FakeRelForToCompanyRawIdWidget(), admin_site)
+        self.fields["to_company"].widget = widgets.ForeignKeyRawIdWidget(FakeRelForRawIdWidget(Company), admin_site)
         self.from_company = from_company
 
     def clean_to_company(self):

--- a/itou/templates/admin/approvals/change_approval_form.html
+++ b/itou/templates/admin/approvals/change_approval_form.html
@@ -1,5 +1,10 @@
 {% extends 'admin/change_form.html' %}
 {% block object-tools-items %}
+    {% if has_change_permission and original.needs_prolongation_derogation %}
+        <li>
+            <a href="{% url "admin:approvals_approval_prolongation_derogation" original.pk %}">Générer un lien de demande de prolongation</a>
+        </li>
+    {% endif %}
     {% if original.is_valid %}
         <li>
             <form method="post" action="{% url "admin:approvals_approval_terminate_approval" original.pk %}" class="js-with-confirm">

--- a/itou/templates/admin/approvals/prolongation_derogation.html
+++ b/itou/templates/admin/approvals/prolongation_derogation.html
@@ -1,0 +1,27 @@
+{% extends "admin/change_form.html" %}
+
+{% block content %}
+    <p>
+        Ce lien permet à l’entreprise choisie de déclarer une prolongation de ce PASS IAE alors que
+        le délai de prolongation, six mois après son échéance, est dépassé. Il ne fonctionne que pour
+        cette entreprise, et uniquement pour un utilisateur connecté sur son espace de travail. Il ne
+        peut être utilisé qu’une seule fois.
+    </p>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+        <div class="form-row">{{ form }}</div>
+        <div class="submit-row">
+            <input class="default" type="submit" value="Générer le lien">
+        </div>
+    </form>
+
+    {% if derogation_link %}
+        <h2>Lien à transmettre à l’employeur</h2>
+        <div class="form-row">
+            <label for="derogation-link">Lien de demande de prolongation :</label>
+            <input id="derogation-link" type="text" class="vLargeTextField" readonly value="{{ derogation_link }}">
+            <p class="help">Lien à usage unique, valable 90 jours, jusqu’au {{ expires_at }}. À transmettre par e-mail à l’employeur.</p>
+        </div>
+    {% endif %}
+{% endblock content %}

--- a/itou/templates/approvals/details.html
+++ b/itou/templates/approvals/details.html
@@ -138,7 +138,7 @@
                                                 disabled
                                                 data-bs-toggle="tooltip"
                                                 data-bs-placement="top"
-                                                {% if prolongation_request_pending %} data-bs-title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." {% elif not approval.is_valid %} data-bs-title="Il est impossible de faire une prolongation de PASS IAE expiré." {% else %} data-bs-title="Les prolongations sont possibles à partir du {{ approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END }}ème mois avant la fin d’un PASS IAE." {% endif %}>
+                                                {% if prolongation_request_pending %} data-bs-title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." {% elif not approval.is_valid %} data-bs-title="Il est impossible de faire une prolongation de PASS IAE expiré." {% else %} data-bs-title="Les prolongations sont possibles à partir du {{ approval.PROLONGATION_OPENS_MONTHS_BEFORE_END }}ème mois avant la fin d’un PASS IAE." {% endif %}>
                                             <i class="ri-refresh-line fw-medium" aria-hidden="true"></i>
                                             <span>Prolonger</span>
                                         </button>

--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -2,7 +2,7 @@
 {% load components %}
 {% load django_bootstrap5 %}
 
-<form id="mainForm" method="post" class="js-prevent-multiple-submit"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form id="new-prolongation-form" method="post" class="js-prevent-multiple-submit"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
     {% csrf_token %}
 
     {% bootstrap_form_errors form type="non_fields" %}

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -1,5 +1,4 @@
 import logging
-from collections import namedtuple
 
 from django import forms
 from django.contrib.admin import widgets
@@ -9,6 +8,7 @@ from django.core.exceptions import ValidationError
 from itou.geo.utils import coords_to_geometry
 from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
+from itou.utils.admin import FakeRelForRawIdWidget
 from itou.utils.apis import geocoding as api_geocoding
 
 
@@ -83,25 +83,6 @@ class JobSeekerProfileAdminForm(forms.ModelForm):
         return asp_uid.lower()
 
 
-FakeField = namedtuple("FakeField", ("name",))
-
-
-class FakeRelForToUserRawIdWidget:
-    model = User
-    limit_choices_to = {
-        "kind": UserKind.JOB_SEEKER,
-    }
-
-    def get_related_field(self):
-        # This must return something that has the name of an existing field
-        return FakeField("id")
-
-
-class ToUserRawIdWidget(widgets.ForeignKeyRawIdWidget):
-    def __init__(self, admin_site, attrs=None, using=None):
-        super().__init__(FakeRelForToUserRawIdWidget(), admin_site, attrs, using)
-
-
 class SelectTargetUserForm(forms.Form):
     to_user = forms.ModelChoiceField(
         User.objects.filter(kind=UserKind.JOB_SEEKER), required=True, label="Choisissez l'utilisateur cible"
@@ -109,7 +90,9 @@ class SelectTargetUserForm(forms.Form):
 
     def __init__(self, *args, from_user, admin_site, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["to_user"].widget = ToUserRawIdWidget(admin_site)
+        self.fields["to_user"].widget = widgets.ForeignKeyRawIdWidget(
+            FakeRelForRawIdWidget(User, {"kind": UserKind.JOB_SEEKER}), admin_site
+        )
         self.from_user = from_user
 
     def clean_to_user(self):

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from functools import partial
 
 from django import forms
@@ -348,6 +349,24 @@ class CreatedOrUpdatedByMixin:
         if hasattr(obj, attr):
             setattr(obj, attr, request.user)
         super().save_model(request, obj, form, change)
+
+
+FakeField = namedtuple("FakeField", ("name",))
+
+
+class FakeRelForRawIdWidget:
+    """Minimal stand-in for a relation, to use `ForeignKeyRawIdWidget` on a plain form field.
+
+    Indeed, ForeignKeyRawIdWidget is designed to be used in a ModelAdmin form by default.
+    """
+
+    def __init__(self, model, limit_choices_to=None):
+        self.model = model
+        self.limit_choices_to = limit_choices_to or {}
+
+    def get_related_field(self):
+        # This must return something that has the name of an existing field
+        return FakeField("id")
 
 
 class ChooseFieldsToTransfer(forms.Form):

--- a/itou/utils/tokens.py
+++ b/itou/utils/tokens.py
@@ -103,3 +103,26 @@ class AdminRequestTokenGenerator(TokenGenerator):
 
 
 admin_request_token_generator = AdminRequestTokenGenerator()
+
+
+class ProlongationDerogationTokenGenerator(TokenGenerator):
+    """Token generator for out-of-time-limits prolongation links.
+
+    Support staff issues a link for an (approval, company) pair when the employer cannot
+    declare the prolongation themselves because the prolongation deadline has passed
+    (`Approval.needs_prolongation_derogation`). The link is single-use: the hash value
+    holds `Approval.count_declarations()`, so declaring a prolongation (or a prolongation
+    request) invalidates every link issued before it.
+    """
+
+    key_salt = "itou.utils.tokens.ProlongationDerogationTokenGenerator"
+    timeout = 3 * 30 * 24 * 3600  # arbitrary time interval of 3 months
+
+    def make_token(self, approval, company):
+        return super().make_token(approval=approval, company=company)
+
+    def _make_hash_value(self, timestamp, approval, company):
+        return f"{approval.pk}-{company.pk}-{approval.count_declarations()}-{timestamp}"
+
+
+prolongation_derogation_token_generator = ProlongationDerogationTokenGenerator()

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -223,8 +223,8 @@ class CreateProlongationForm(forms.ModelForm):
                 ),
                 "hx-params": "not end_at",  # Clear "end_at" when switching reason
                 "hx-swap": "outerHTML",
-                "hx-target": "#mainForm",
-                "hx-indicator": "#mainForm",  # Add a spinner to another element, here the main form instead of a field
+                "hx-target": "#new-prolongation-form",
+                "hx-indicator": "#new-prolongation-form",  # Add a spinner to another element, here the main form
             }
         )
 

--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
     path("list", views.ApprovalListView.as_view(), name="list"),
     path("declare_prolongation/<int:approval_id>", views.declare_prolongation, name="declare_prolongation"),
     path(
+        "declare_prolongation/<int:approval_id>/derogation/<str:token>",
+        views.prolongation_derogation,
+        name="prolongation_derogation",
+    ),
+    path(
         "declare_prolongation/<int:approval_id>/check_prescriber_email",
         views.CheckPrescriberEmailView.as_view(),
         name="check_prescriber_email",

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -27,7 +27,12 @@ from itou.approvals.models import (
     ProlongationRequestDenyInformation,
     Suspension,
 )
-from itou.approvals.perms import PERMS_READ_AND_WRITE, can_view_approval_details
+from itou.approvals.perms import (
+    PERMS_READ_AND_WRITE,
+    can_declare_prolongation,
+    can_view_approval_details,
+    prolongation_derogation_session_key,
+)
 from itou.approvals.utils import get_contracts
 from itou.companies.models import Contract
 from itou.employee_record.enums import Status
@@ -49,6 +54,7 @@ from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.perms.utils import can_view_personal_information
 from itou.utils.readonly import ReadonlyViewMixin, http_methods, readonly_view
 from itou.utils.storage.s3 import TEMPORARY_STORAGE_PREFIX
+from itou.utils.tokens import prolongation_derogation_token_generator
 from itou.utils.urls import get_safe_url
 from itou.www.approvals_views.forms import (
     ApprovalForm,
@@ -357,17 +363,44 @@ def prolongation_back_url(request):
     return get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
 
-def get_prolongable_approval_or_404(siae, approval_id):
+def prolongable_approvals(siae):
     """The approvals `siae` may declare a prolongation for: those of an employee it hired."""
-    return get_object_or_404(
-        Approval.objects.filter(
-            Exists(
-                JobApplication.objects.filter(
-                    approval=OuterRef("pk"), to_company=siae, state=JobApplicationState.ACCEPTED
-                )
-            )
-        ),
-        pk=approval_id,
+    return Approval.objects.filter(
+        Exists(
+            JobApplication.objects.filter(approval=OuterRef("pk"), to_company=siae, state=JobApplicationState.ACCEPTED)
+        )
+    )
+
+
+def get_prolongable_approval_or_404(siae, approval_id):
+    return get_object_or_404(prolongable_approvals(siae), pk=approval_id)
+
+
+@http_methods(db_readonly=["GET", "HEAD"])
+def prolongation_derogation(request, approval_id, token):
+    """Open the prolongation form from a derogation link issued by the support.
+
+    The token is stored in the session so that the whole declaration flow (the form page, its
+    HTMX fragments and the final POST) keeps the deadline waiver without having to carry the
+    token in every URL. It is checked again on each step, see `can_declare_prolongation`.
+    """
+    siae = get_current_company_or_404(request)
+    approval = prolongable_approvals(siae).filter(pk=approval_id).first()
+    if (
+        approval is None
+        or not siae.is_subject_to_iae_rules
+        or not (approval.can_be_prolonged or approval.needs_prolongation_derogation)
+        or not prolongation_derogation_token_generator.check_token(token, approval=approval, company=siae)
+    ):
+        messages.error(
+            request,
+            "Le token n’est peut-être plus valable ou concerne une autre structure "
+            f"que celle actuellement active ({siae.display_name}).",
+        )
+        return HttpResponseRedirect(reverse("dashboard:index"))
+    request.session[prolongation_derogation_session_key(approval=approval, company=siae)] = token
+    return HttpResponseRedirect(
+        reverse("approvals:declare_prolongation", kwargs={"approval_id": approval.pk}, query=request.GET or None)
     )
 
 
@@ -380,7 +413,7 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
     siae = get_current_company_or_404(request)
     approval = get_prolongable_approval_or_404(siae, approval_id)
 
-    if not siae.is_subject_to_iae_rules or not approval.can_be_prolonged:
+    if not can_declare_prolongation(request, approval=approval, company=siae):
         raise PermissionDenied()
 
     back_url = prolongation_back_url(request)
@@ -432,6 +465,8 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
                     default_storage.delete(tmpfile_key)
             prolongation.save()
             prolongation.notify_authorized_prescriber()
+            # A derogation link is single-use
+            request.session.pop(prolongation_derogation_session_key(approval=approval, company=siae), None)
             messages.success(request, "Déclaration de prolongation enregistrée.", extra_tags="toast")
             return HttpResponseRedirect(back_url)
 
@@ -464,10 +499,9 @@ class DeclareProlongationHTMXFragmentView(ReadonlyViewMixin, TemplateView):
         super().setup(request, *args, **kwargs)
 
         self.siae = get_current_company_or_404(request)
-        if not self.siae.is_subject_to_iae_rules:
-            raise PermissionDenied()
         self.approval = get_prolongable_approval_or_404(self.siae, approval_id)
-        if not self.approval.can_be_prolonged:
+
+        if not can_declare_prolongation(request, approval=self.approval, company=self.siae):
             raise PermissionDenied()
 
         self.form = get_prolongation_form(

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -357,14 +357,9 @@ def prolongation_back_url(request):
     return get_safe_url(request, "back_url", fallback_url=reverse("dashboard:index"))
 
 
-@http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
-def declare_prolongation(request, approval_id, template_name="approvals/declare_prolongation.html"):
-    """
-    Declare a prolongation for the given approval.
-    """
-
-    siae = get_current_company_or_404(request)
-    approval = get_object_or_404(
+def get_prolongable_approval_or_404(siae, approval_id):
+    """The approvals `siae` may declare a prolongation for: those of an employee it hired."""
+    return get_object_or_404(
         Approval.objects.filter(
             Exists(
                 JobApplication.objects.filter(
@@ -374,6 +369,16 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
         ),
         pk=approval_id,
     )
+
+
+@http_methods(db_readonly=["GET", "HEAD"], db_write=["POST"])
+def declare_prolongation(request, approval_id, template_name="approvals/declare_prolongation.html"):
+    """
+    Declare a prolongation for the given approval.
+    """
+
+    siae = get_current_company_or_404(request)
+    approval = get_prolongable_approval_or_404(siae, approval_id)
 
     if not siae.is_subject_to_iae_rules or not approval.can_be_prolonged:
         raise PermissionDenied()
@@ -461,17 +466,7 @@ class DeclareProlongationHTMXFragmentView(ReadonlyViewMixin, TemplateView):
         self.siae = get_current_company_or_404(request)
         if not self.siae.is_subject_to_iae_rules:
             raise PermissionDenied()
-        self.approval = get_object_or_404(
-            Approval.objects.filter(
-                Exists(
-                    JobApplication.objects.filter(
-                        approval=OuterRef("pk"), to_company=self.siae, state=JobApplicationState.ACCEPTED
-                    )
-                )
-            ),
-            pk=approval_id,
-        )
-
+        self.approval = get_prolongable_approval_or_404(self.siae, approval_id)
         if not self.approval.can_be_prolonged:
             raise PermissionDenied()
 

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -31,10 +31,13 @@ from itou.users.enums import LackOfPoleEmploiId
 from itou.users.models import User
 from itou.utils.admin import get_admin_view_link
 from itou.utils.models import PkSupportRemark
+from itou.utils.tokens import prolongation_derogation_token_generator
+from itou.utils.urls import get_absolute_url
 from tests.approvals.factories import (
     ApprovalFactory,
     CancelledApprovalFactory,
     ProlongationFactory,
+    ProlongationRequestFactory,
     SuspensionFactory,
 )
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
@@ -1093,6 +1096,189 @@ class TestCustomApprovalAdminViews:
         )
         msg = inline.employee_record_status(job_application)
         assert msg == "Une fiche salarié existe déjà pour ce candidat"
+
+
+class TestProlongationDerogation:
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        with freeze_time("2025-08-21"):
+            today = timezone.localdate()
+            # A PASS IAE whose prolongation deadline has passed: its employer cannot prolong it alone
+            self.job_application = JobApplicationFactory(
+                sent_by_prescriber_alone=True,
+                with_approval=True,
+                approval__start_at=today - relativedelta(months=32),
+                approval__end_at=today - relativedelta(months=8),
+                to_company__subject_to_iae_rules=True,
+            )
+            self.approval = self.job_application.approval
+            self.company = self.job_application.to_company
+            self.url = reverse("admin:approvals_approval_prolongation_derogation", args=(self.approval.pk,))
+            assert self.approval.needs_prolongation_derogation
+            yield
+
+    def test_visible_button(self, client):
+        staff_user = ItouStaffFactory()
+        staff_user.user_permissions.add(*Permission.objects.filter(codename="view_approval"))
+        client.force_login(staff_user)
+        change_url = reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk})
+        response = client.get(change_url)
+        assertNotContains(response, self.url)
+        staff_user.user_permissions.add(*Permission.objects.filter(codename="change_approval"))
+        response = client.get(change_url)
+        assertContains(response, f'<a href="{self.url}">Générer un lien de demande de prolongation</a>', html=True)
+
+    def test_hidden_button_when_prolongation_is_impossible(self, client):
+        # A pending prolongation request is one of the blockers of the derogation view
+        ProlongationRequestFactory(approval=self.approval, declared_by_siae=self.company)
+        staff_user = ItouStaffFactory()
+        staff_user.user_permissions.add(*Permission.objects.filter(codename__in=["view_approval", "change_approval"]))
+        client.force_login(staff_user)
+        response = client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertNotContains(response, self.url)
+
+    def test_without_change_permission(self, client):
+        staff_user = ItouStaffFactory()
+        staff_user.user_permissions.add(*Permission.objects.filter(codename="view_approval"))
+        client.force_login(staff_user)
+        assert client.get(self.url).status_code == 403
+
+    def test_generate_link(self, admin_client, caplog):
+        response = admin_client.get(self.url)
+        assertContains(response, "Générer le lien")
+        assertNotContains(response, "Lien à usage unique")
+        assert not PkSupportRemark.objects.exists()
+        response = admin_client.post(self.url, data={"company": self.company.pk})
+        token = prolongation_derogation_token_generator.make_token(approval=self.approval, company=self.company)
+        expected_link = get_absolute_url(
+            reverse("approvals:prolongation_derogation", kwargs={"approval_id": self.approval.pk, "token": token})
+        )
+        assertContains(response, f'value="{expected_link}"')
+        assertContains(response, "Lien à usage unique, valable 90 jours, jusqu’au 19 novembre 2025.")
+        support_remark = PkSupportRemark.objects.get(
+            content_type=ContentType.objects.get_for_model(Approval), object_id=self.approval.pk
+        )
+        user = User.objects.get(pk=get_user(admin_client).pk)
+        assert support_remark.remark == (
+            f"2025-08-21 : lien de demande de prolongation hors délais généré par {user.get_full_name()} "
+            f"pour l’entreprise {self.company.pk} — {self.company.display_name}."
+        )
+        assert (
+            f"staff user={user.pk} issued a prolongation derogation link "
+            f"for approval={self.approval.pk} company={self.company.pk}." in caplog.messages
+        )
+
+    def test_company_defaults_to_the_latest_company(self, admin_client):
+        response = admin_client.get(self.url)
+        assertContains(response, f'value="{self.company.pk}"')
+        # The job seeker was hired by another SIAE more recently
+        new_company = CompanyFactory(subject_to_iae_rules=True)
+        with freeze_time("2025-08-22"):
+            JobApplicationFactory(
+                sent_by_prescriber_alone=True,
+                approval=self.approval,
+                job_seeker=self.approval.user,
+                to_company=new_company,
+                state=JobApplicationState.ACCEPTED,
+            )
+        response = admin_client.get(self.url)
+        assertContains(response, f'value="{new_company.pk}"')
+
+    def test_company_without_accepted_job_application(self, admin_client):
+        other_company = CompanyFactory(subject_to_iae_rules=True)
+        response = admin_client.post(self.url, data={"company": other_company.pk})
+        assertContains(response, "Cette entreprise n’a pas de candidature acceptée liée à ce PASS IAE.")
+        assert not PkSupportRemark.objects.exists()
+
+    def test_company_not_subject_to_iae_rules(self, admin_client):
+        geiq = CompanyFactory(kind=CompanyKind.GEIQ)
+        JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            approval=self.approval,
+            job_seeker=self.approval.user,
+            to_company=geiq,
+            state=JobApplicationState.ACCEPTED,
+        )
+        response = admin_client.post(self.url, data={"company": geiq.pk})
+        assertContains(
+            response,
+            "Cette entreprise n’existe pas ou n’est pas une SIAE, elle ne peut pas déclarer de prolongation.",
+        )
+        assert not PkSupportRemark.objects.exists()
+
+    def test_suspended_approval(self, admin_client):
+        SuspensionFactory(
+            approval=self.approval,
+            siae=self.company,
+            start_at=timezone.localdate() - relativedelta(days=1),
+            end_at=timezone.localdate() + relativedelta(days=1),
+        )
+        response = admin_client.get(self.url)
+        assertRedirects(response, reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertMessages(
+            response,
+            [messages.Message(messages.ERROR, "Ce PASS IAE est suspendu, il ne peut pas être prolongé.")],
+        )
+
+    def test_pending_prolongation_request(self, admin_client):
+        ProlongationRequestFactory(approval=self.approval, declared_by_siae=self.company)
+        response = admin_client.get(self.url)
+        assertRedirects(response, reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertMessages(
+            response,
+            [messages.Message(messages.ERROR, "Une demande de prolongation est déjà en attente pour ce PASS IAE.")],
+        )
+
+    def test_not_the_latest_approval(self, admin_client):
+        ApprovalFactory(user=self.approval.user)
+        response = admin_client.get(self.url)
+        assertRedirects(response, reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "Ce PASS IAE n’est pas le PASS IAE le plus récent du candidat, il ne peut donc pas être prolongé.",
+                )
+            ],
+        )
+
+    def test_approval_ending_in_more_than_12_months(self, admin_client):
+        # Only the deadline is waivable: it is still too early to prolong this PASS IAE
+        self.approval.end_at = timezone.localdate() + relativedelta(months=18)
+        self.approval.save(update_fields=["end_at", "updated_at"])
+
+        response = admin_client.get(self.url)
+        assertRedirects(response, reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "Ce PASS IAE se termine dans plus de 12 mois, il est trop tôt pour le prolonger.",
+                )
+            ],
+        )
+        assertNotContains(admin_client.get(response.url), self.url)
+
+    def test_approval_still_within_the_prolongation_window(self, admin_client):
+        # The employer can declare the prolongation on their own, generating a link would be pointless & confusing
+        self.approval.end_at = timezone.localdate() - relativedelta(months=2)
+        self.approval.save(update_fields=["end_at", "updated_at"])
+
+        response = admin_client.get(self.url)
+        assertRedirects(response, reverse("admin:approvals_approval_change", kwargs={"object_id": self.approval.pk}))
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "Ce PASS IAE est dans les délais, l’employeur peut déclarer la prolongation "
+                    "sans lien de dérogation.",
+                )
+            ],
+        )
+        assertNotContains(admin_client.get(response.url), self.url)
 
 
 def test_prolongation_inconsistency_check(admin_client):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertNumQueries, assertQuerySetEqual
 
 from itou.approvals.constants import PROLONGATION_REPORT_FILE_REASONS
-from itou.approvals.enums import ApprovalStatus, Origin, ProlongationReason
+from itou.approvals.enums import ApprovalStatus, Origin, ProlongationBlocker, ProlongationReason
 from itou.approvals.models import Approval, CancelledApproval, Prolongation, Suspension
 from itou.approvals.utils import get_user_last_accepted_siae_job_application, last_hire_was_made_by_siae
 from itou.archive.constants import EXPIRATION_DAYS
@@ -299,6 +299,46 @@ class TestApprovalModel:
         approval = ApprovalFactory(start_at=datetime.date(2021, 11, 17))
         with freeze_time(approval.end_at + end_at_delta):
             assert approval.is_open_to_prolongation is expected
+
+    def test_prolongation_blocker_time_limits(self):
+        approval = ApprovalFactory(start_at=datetime.date(2021, 11, 17))
+
+        def blocker_at(delta):
+            with freeze_time(approval.end_at + delta):
+                # Reset the cached properties
+                return Approval.objects.get(pk=approval.pk).prolongation_blocker
+
+        assert blocker_at(relativedelta(months=-12, days=-1)) == ProlongationBlocker.TOO_EARLY
+        assert blocker_at(relativedelta(months=-12)) is None
+        assert blocker_at(relativedelta(months=6)) is None
+        assert blocker_at(relativedelta(months=6, days=1)) == ProlongationBlocker.DEADLINE_PASSED
+
+    def test_suspension_takes_precedence_over_the_time_limits(self):
+        approval = ApprovalFactory(start_at=datetime.date(2021, 11, 17))
+        past_the_deadline = approval.end_at + relativedelta(months=6, days=1)
+        with freeze_time(past_the_deadline):
+            assert Approval.objects.get(pk=approval.pk).prolongation_blocker == ProlongationBlocker.DEADLINE_PASSED
+            SuspensionFactory(
+                approval=approval,
+                start_at=past_the_deadline - relativedelta(days=1),
+                end_at=past_the_deadline + relativedelta(days=1),
+            )
+            assert Approval.objects.get(pk=approval.pk).prolongation_blocker == ProlongationBlocker.SUSPENDED
+
+    def test_needs_prolongation_derogation(self):
+        approval = ApprovalFactory(start_at=datetime.date(2021, 11, 17))
+
+        def needs_derogation_at(delta):
+            with freeze_time(approval.end_at + delta):
+                # Reset the cached properties
+                return Approval.objects.get(pk=approval.pk).needs_prolongation_derogation
+
+        # Too early or still in time: the employer does not need any link from the support
+        assert needs_derogation_at(relativedelta(months=-12, days=-1)) is False
+        assert needs_derogation_at(relativedelta(months=-12)) is False
+        assert needs_derogation_at(relativedelta(months=6)) is False
+        # Past the deadline: only the support can enable the prolongation form
+        assert needs_derogation_at(relativedelta(months=6, days=1)) is True
 
     def test_cannot_be_prolonged_when_a_newer_approval_exists(self):
         initial_approval = ApprovalFactory(start_at=timezone.localdate() - relativedelta(years=2, months=3))

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -179,7 +179,7 @@
       <label class="form-label">
           Motif
       </label>
-      <div class="" hx-indicator="#mainForm" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+      <div class="" hx-indicator="#new-prolongation-form" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#new-prolongation-form" hx-trigger="change" id="id_reason" required="">
           <div class="form-check">
               <input class="form-check-input" id="id_reason_0" name="reason" type="radio" value="SENIOR_CDI"/>
               <label class="form-check-label" for="id_reason_0">
@@ -215,7 +215,7 @@
       <label class="form-label">
           Motif
       </label>
-      <div class="" hx-indicator="#mainForm" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+      <div class="" hx-indicator="#new-prolongation-form" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#new-prolongation-form" hx-trigger="change" id="id_reason" required="">
           <div class="form-check">
               <input class="form-check-input" id="id_reason_0" name="reason" type="radio" value="SENIOR_CDI"/>
               <label class="form-check-label" for="id_reason_0">

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -1,20 +1,35 @@
 import uuid
-from datetime import timedelta
+from datetime import date, timedelta
 
 import pytest
 from dateutil.relativedelta import relativedelta
+from django.contrib import messages
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
 from django.utils.http import urlencode
 from freezegun import freeze_time
-from pytest_django.asserts import assertContains, assertNotContains, assertQuerySetEqual, assertRedirects
+from pytest_django.asserts import (
+    assertContains,
+    assertMessages,
+    assertNotContains,
+    assertQuerySetEqual,
+    assertRedirects,
+)
 
-from itou.approvals.enums import ProlongationReason
+from itou.approvals.enums import ProlongationReason, ProlongationRequestStatus
 from itou.approvals.models import Prolongation
+from itou.approvals.perms import prolongation_derogation_session_key
 from itou.companies.enums import CompanyKind
+from itou.job_applications.enums import JobApplicationState
+from itou.utils.tokens import prolongation_derogation_token_generator
 from itou.utils.widgets import DuetDatePickerWidget
-from tests.approvals.factories import ProlongationFactory
+from tests.approvals.factories import (
+    ApprovalFactory,
+    ProlongationFactory,
+    ProlongationRequestFactory,
+    SuspensionFactory,
+)
 from tests.companies.factories import CompanyFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationFactory
@@ -139,6 +154,24 @@ class TestApprovalProlongation:
         url = reverse("approvals:declare_prolongation", kwargs={"approval_id": self.approval.pk})
         response = client.get(url)
         assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "view_name",
+        [
+            "declare_prolongation",
+            "prolongation_form_for_reason",
+            "check_prescriber_email",
+            "check_contact_details",
+        ],
+    )
+    def test_approval_prolongation_with_company_not_subject_to_iae_rules(self, client, view_name):
+        """Only a company subject to IAE rules may declare a prolongation."""
+        self._setup_with_company_kind(CompanyKind.GEIQ)
+        assert not self.siae.is_subject_to_iae_rules
+        client.force_login(self.employer)
+        url = reverse(f"approvals:{view_name}", kwargs={"approval_id": self.approval.pk})
+        response = client.post(url, {"reason": ProlongationReason.SENIOR})
+        assert response.status_code == 403
 
     @pytest.mark.parametrize(
         "view_name",
@@ -627,3 +660,308 @@ def test_prolongation_report_file(client, mocker, faker, xlsx_file, mailoutbox):
         in email.body
     )
     assert TestApprovalProlongation.PROLONGATION_EMAIL_REPORT_TEXT in email.body
+
+
+class TestProlongationDerogationLink:
+    """The support can hand out a link waiving the prolongation deadline, and only this limit."""
+
+    HTMX_VIEW_NAMES = ["prolongation_form_for_reason", "check_prescriber_email", "check_contact_details"]
+
+    NEW_PROLONGATION_MARKUP = '<form id="new-prolongation-form"'
+
+    def _setup_approval(self, end_at):
+        self.job_application = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            with_approval=True,
+            approval__start_at=end_at - relativedelta(months=24),
+            approval__end_at=end_at,
+            # An AI company would add the report file field,
+            # whose HTMX and full page renderings differ
+            to_company__kind=CompanyKind.EI,
+        )
+        self.siae = self.job_application.to_company
+        self.employer = self.siae.members.first()
+        self.approval = self.job_application.approval
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        # A PASS IAE that expired more than 6 months ago: the employer cannot prolong it alone
+        self._setup_approval(end_at=timezone.localdate() - relativedelta(months=8))
+        assert not self.approval.is_open_to_prolongation
+
+    def _derogation_url(self, token, **kwargs):
+        """The link the support hands out: it opens the declaration form."""
+        return reverse(
+            "approvals:prolongation_derogation", kwargs={"approval_id": self.approval.pk, "token": token}, **kwargs
+        )
+
+    def _url(self, **kwargs):
+        return reverse("approvals:declare_prolongation", kwargs={"approval_id": self.approval.pk}, **kwargs)
+
+    def _token(self, company=None):
+        return prolongation_derogation_token_generator.make_token(approval=self.approval, company=company or self.siae)
+
+    def _follow_derogation_link(self, client, token=None, **kwargs):
+        """Follow the derogation link and return the declaration form page."""
+        response = client.get(self._derogation_url(token or self._token(), **kwargs))
+        assertRedirects(response, self._url(**kwargs))
+        return client.get(response.url)
+
+    def _assert_link_refused(self, response, company=None):
+        """The derogation link led nowhere: the employer is sent back with an explicit message."""
+        assertRedirects(response, reverse("dashboard:index"))
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "Le token n’est peut-être plus valable ou concerne une autre structure "
+                    f"que celle actuellement active ({(company or self.siae).display_name}).",
+                )
+            ],
+        )
+
+    def _session_token(self, client, company=None):
+        session_key = prolongation_derogation_session_key(approval=self.approval, company=company or self.siae)
+        return client.session.get(session_key)
+
+    def test_with_token(self, client):
+        client.force_login(self.employer)
+        response = self._follow_derogation_link(client)
+        assertContains(response, self.NEW_PROLONGATION_MARKUP)
+
+    def test_declare_prolongation(self, client, mailoutbox):
+        client.force_login(self.employer)
+        back_url = reverse("dashboard:index")
+        query = {"back_url": back_url}
+        url = self._url(query=query)
+
+        response = self._follow_derogation_link(client, query=query)
+        assert response.context["preview"] is False
+
+        post_data = {
+            "end_at": (self.approval.end_at + relativedelta(days=30)).strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
+            "reason": ProlongationReason.COMPLETE_TRAINING,
+            "preview": "1",
+        }
+        response = client.post(url, data=post_data)
+        assert response.context["preview"] is True
+
+        del post_data["preview"]
+        post_data["save"] = 1
+        response = client.post(url, data=post_data)
+        assertRedirects(response, back_url)
+
+        prolongation = self.approval.prolongation_set.get()
+        assert prolongation.declared_by == self.employer
+        assert prolongation.declared_by_siae == self.siae
+        assert prolongation.start_at == self.approval.end_at
+        assert prolongation.reason == ProlongationReason.COMPLETE_TRAINING
+        assert not mailoutbox
+
+    def test_without_token(self, client):
+        client.force_login(self.employer)
+        response = client.get(self._url())
+        assert response.status_code == 403
+
+    def test_the_bypass_is_scoped_to_one_approval(self, client):
+        # The company hired two job seekers, both PASS IAE are out of the prolongation window
+        # but the support only issued a link for one of them
+        other_end_at = timezone.localdate() - relativedelta(months=8)
+        other_approval = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            with_approval=True,
+            approval__start_at=other_end_at - relativedelta(months=24),
+            approval__end_at=other_end_at,
+            to_company=self.siae,
+        ).approval
+        client.force_login(self.employer)
+        self._follow_derogation_link(client)
+        other_url = reverse("approvals:declare_prolongation", kwargs={"approval_id": other_approval.pk})
+        assert client.get(other_url).status_code == 403
+
+    def test_before_the_prolongation_window(self, client):
+        # A PASS IAE ending in more than 12 months is out of the window too,
+        # but no link can rescue it: only the deadline is waivable
+        self._setup_approval(end_at=timezone.localdate() + relativedelta(months=18))
+        assert not self.approval.is_open_to_prolongation
+        assert not self.approval.needs_prolongation_derogation
+        client.force_login(self.employer)
+
+        assert client.get(self._url()).status_code == 403
+        self._assert_link_refused(client.get(self._derogation_url(self._token())))
+
+    def test_link_is_consumed_by_a_first_prolongation(self, client):
+        token = self._token()
+        ProlongationFactory(
+            approval=self.approval,
+            declared_by_siae=self.siae,
+            declared_by=self.employer,
+            start_at=self.approval.end_at,
+            end_at=self.approval.end_at + relativedelta(days=30),
+        )
+        self.approval.refresh_from_db()
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(token)))
+
+    def test_link_is_consumed_by_a_first_prolongation_request(self, client):
+        # A prolongation request is denied:
+        # the PASS IAE is still extendable, but with another link
+        token = self._token()
+        ProlongationRequestFactory(
+            approval=self.approval,
+            declared_by_siae=self.siae,
+            declared_by=self.employer,
+            status=ProlongationRequestStatus.DENIED,
+        )
+        client.force_login(self.employer)
+        assert self.approval.needs_prolongation_derogation
+        self._assert_link_refused(client.get(self._derogation_url(token)))
+
+    def test_a_new_link_can_be_issued_after_a_prolongation(self, client):
+        # The PASS IAE is still out of the prolongation window after a first prolongation:
+        # the consumed link cannot be reused, but the support can issue another one
+        ProlongationFactory(
+            approval=self.approval,
+            declared_by_siae=self.siae,
+            declared_by=self.employer,
+            start_at=self.approval.end_at,
+            end_at=self.approval.end_at + relativedelta(days=30),
+        )
+        self.approval.refresh_from_db()
+        assert self.approval.needs_prolongation_derogation
+        client.force_login(self.employer)
+        assertContains(self._follow_derogation_link(client, self._token()), self.NEW_PROLONGATION_MARKUP)
+
+    def test_invalid_token(self, client):
+        invalid_token = "ddt9as-f88cd08908264f2e9de6"
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(invalid_token)))
+
+    def test_invalid_token_inside_the_prolongation_window(self, client):
+        # The approval could be prolonged without any token:
+        # a bogus one must not be accepted anyway
+        invalid_token = "ddt9as-f88cd08908264f2e9de6"
+        self._setup_approval(end_at=timezone.localdate() + relativedelta(months=1))
+        assert self.approval.is_open_to_prolongation
+        client.force_login(self.employer)
+        assertContains(client.get(self._url()), self.NEW_PROLONGATION_MARKUP)
+        self._assert_link_refused(client.get(self._derogation_url(invalid_token)))
+
+    def test_token_issued_for_another_company(self, client):
+        other_company = CompanyFactory(subject_to_iae_rules=True, with_membership=True)
+        derogation_url = self._derogation_url(self._token(company=other_company))
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(derogation_url))
+        # The company the token was issued for never hired this job seeker
+        client.force_login(other_company.members.first())
+        self._assert_link_refused(client.get(derogation_url), company=other_company)
+
+    def test_current_company_not_subject_to_iae_rules(self, client):
+        geiq = CompanyFactory(kind=CompanyKind.GEIQ, with_membership=True)
+        JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            approval=self.approval,
+            job_seeker=self.approval.user,
+            to_company=geiq,
+            state=JobApplicationState.ACCEPTED,
+        )
+        client.force_login(geiq.members.first())
+        self._assert_link_refused(client.get(self._derogation_url(self._token(company=geiq))), company=geiq)
+
+    def test_expired_token(self, client, settings):
+        # Moving through time brings a new version of the "CGU" into force
+        settings.BYPASS_TERMS_ACCEPTANCE = True
+        with freeze_time("2025-08-21") as frozen_time:
+            # Fixed dates, so that the PASS IAE stays out of the prolongation window
+            # and out of the waiting period for the whole test
+            self._setup_approval(end_at=date(2024, 6, 30))
+            assert not self.approval.is_open_to_prolongation
+            token = self._token()
+            frozen_time.move_to("2025-11-18")  # 89 days later
+            client.force_login(self.employer)
+            assertContains(self._follow_derogation_link(client, token), self.NEW_PROLONGATION_MARKUP)
+            frozen_time.move_to("2025-11-20")  # 91 days later
+            client.force_login(self.employer)
+            self._assert_link_refused(client.get(self._derogation_url(token)))
+
+    def test_suspended_approval(self, client):
+        SuspensionFactory(
+            approval=self.approval,
+            siae=self.siae,
+            start_at=timezone.localdate() - relativedelta(days=1),
+            end_at=timezone.localdate() + relativedelta(days=1),
+        )
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(self._token())))
+
+    def test_pending_prolongation_request(self, client):
+        ProlongationRequestFactory(approval=self.approval, declared_by_siae=self.siae)
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(self._token())))
+
+    def test_not_the_latest_approval(self, client):
+        ApprovalFactory(user=self.approval.user)
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(self._token())))
+
+    def test_waiting_period_has_elapsed(self, client):
+        # Beyond the 2 years waiting period the job seeker has no latest approval anymore
+        self._setup_approval(end_at=timezone.localdate() - relativedelta(months=30))
+        client.force_login(self.employer)
+        self._assert_link_refused(client.get(self._derogation_url(self._token())))
+
+    def test_stale_token_is_removed_from_the_session(self, client):
+        client.force_login(self.employer)
+        token = self._token()
+        self._follow_derogation_link(client, token)
+        assert self._session_token(client) == token
+
+        # Another declaration consumes the link
+        ProlongationFactory(
+            approval=self.approval,
+            declared_by_siae=self.siae,
+            declared_by=self.employer,
+            start_at=self.approval.end_at,
+            end_at=self.approval.end_at + relativedelta(days=30),
+        )
+        assert client.get(self._url()).status_code == 403
+        assert self._session_token(client) is None
+
+    def test_valid_token_is_kept_in_the_session(self, client):
+        client.force_login(self.employer)
+        token = self._token()
+        assertContains(self._follow_derogation_link(client, token), self.NEW_PROLONGATION_MARKUP)
+        assertContains(client.get(self._url()), self.NEW_PROLONGATION_MARKUP)
+        assert self._session_token(client) == token
+
+    @pytest.mark.parametrize("view_name", HTMX_VIEW_NAMES)
+    def test_htmx_fragments(self, client, view_name):
+        client.force_login(self.employer)
+        data = {"reason": ProlongationReason.SENIOR}
+        url = reverse(f"approvals:{view_name}", kwargs={"approval_id": self.approval.pk})
+        assert client.post(url, data).status_code == 403
+        self._follow_derogation_link(client)
+        assert client.post(url, data).status_code == 200
+        ProlongationFactory(
+            approval=self.approval,
+            declared_by_siae=self.siae,
+            declared_by=self.employer,
+            start_at=self.approval.end_at,
+            end_at=self.approval.end_at + relativedelta(days=30),
+        )
+        assert client.post(url, data).status_code == 403
+
+    def test_check_prescriber_email_button(self, client):
+        client.force_login(self.employer)
+        page = parse_response_to_soup(self._follow_derogation_link(client), selector="#main")
+        [reason] = page.select("#id_reason")
+        data = {
+            "reason": ProlongationReason.RQTH,
+            # Workaround the validation of the initial page by providing enough data
+            "end_at": self.approval.end_at + relativedelta(days=30),
+            "email": PrescriberOrganizationFactory(authorized=True, with_membership=True).members.first().email,
+        }
+        update_page_with_htmx(page, "#id_reason", client.post(reason["hx-post"], data))
+        [button] = page.select("#check_prescriber_email button")
+        assert client.post(button["hx-post"], data).status_code == 200


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte Notion](https://app.notion.com/p/gip-inclusion/ETQ-agent-du-support-je-peux-g-n-rer-un-lien-qui-permettra-l-employeur-d-effectuer-une-demande-de-3a55f321b6048052a883d3e3be28fd74). Un employeur ne peut demander une prolongation de PASS IAE que dans une fenêtre de temps précise (`Approval.is_open_to_prolongation`). Passé ce délai (plus de 6 mois après l'échéance du PASS), il doit contacter le support, qui devait jusqu'ici saisir la prolongation à la main dans l'admin Django, une opération chronophage nécessitant de retrouver plusieurs PK.

## :cake: Comment ? <!-- optionnel -->

- Commits préalables : refactoring de quelques fonctions et classes très similaires en termes de logique (DRY).
- Ajout d'un bouton **"Générer un lien de demande de prolongation"** sur la fiche PASS IAE de l'admin, visible uniquement quand le seul blocage est le délai dépassé (`Approval.needs_prolongation_derogation`).
- Ce bouton ouvre un formulaire où l'agent support saisit la SIAE concernée, la soumission génère un lien de dérogation signé, valable 90 jours et à usage unique pour le couple (PASS IAE, SIAE).
- Le lien pointe vers une nouvelle vue `prolongation_derogation`, qui vérifie le token et le stocke en session avant de rediriger vers le formulaire habituel de `declare_prolongation`. Le token est revérifié à chaque étape du parcours (`can_declare_prolongation` dans `perms.py`) et ne lève que la contrainte de délai.
- Refactor de `Approval.can_be_prolonged` en `prolongation_blocker`, qui expose la raison précise de blocage (`ProlongationBlocker`), utilisée à la fois par le formulaire admin et par les futurs messages d'erreur.
- Le token (`ProlongationDerogationTokenGenerator`) intègre `Approval.count_declarations()` dans son hash : toute déclaration de prolongation invalide automatiquement les liens émis précédemment. Une alternative pourrait être d'utiliser `Approval.updated_at`. Il faudrait alors `touch` le PASS pour que `updated_at` soit mis à jour quand `ProlongationRequest.save()` s'exécute, ce qui ne me semble pas nettement mieux que cette solution que j'ai retenue.

## :desert_island: Comment tester ?

D'un côté, se connecter en tant qu'employeur par exemple `EI`. De l'autre, en tant qu'admin. Avec les données de démo on peut par exemple regarder le PASS IAE de Maël MALANT : `/approvals/details/b2aa1138-8140-4818-b48f-2a82f45e09d0` et `/admin/approvals/approval/1/prolongation-derogation` respectivement

## :computer: Captures d'écran

**_Côté admin_**

<img width="2233" height="1230" alt="image" src="https://github.com/user-attachments/assets/879bebe6-14b7-43ec-9d54-244b96126bfa" />
     
<img width="2233" height="1230" alt="Screenshot from 2026-08-24 15-45-00" src="https://github.com/user-attachments/assets/896c0147-19f5-49d3-9c66-3f7145543c1d" />
     
<img width="2224" height="1342" alt="Screenshot from 2026-08-24 15-46-30" src="https://github.com/user-attachments/assets/dd8575d2-214e-4d4c-9a87-631eb33898b0" />
     
<img width="2373" height="716" alt="Screenshot from 2026-08-21 11-47-38" src="https://github.com/user-attachments/assets/07251c14-b9b9-4af4-98aa-8510bd42a8a1" />
     
**_Côté employeur_**

Rien ne change en fait :

<img width="913" height="431" alt="Screenshot from 2026-08-24 15-46-21" src="https://github.com/user-attachments/assets/3d710fc9-0458-49df-bd7a-e0d2db3c49c7" />

