### PR TITLE
Dans les notifications de mise à jour de fiche salarié : toujours utiliser un SIRET à jour

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -347,7 +347,7 @@ class EmployeeRecordUpdateNotificationSerializer(serializers.Serializer):
     numLigne = serializers.IntegerField(source="asp_batch_line_number")  # Required
     typeMouvement = serializers.CharField(source="ASP_MOVEMENT_TYPE")  # Required
     mesure = serializers.CharField(source="employee_record.asp_measure")  # Required
-    siret = serializers.CharField(source="employee_record.siret")  # Required
+    siret = serializers.SerializerMethodField()  # Required
 
     personnePhysique = serializers.SerializerMethodField()  # Required
     adresse = serializers.SerializerMethodField()  # Required
@@ -356,6 +356,26 @@ class EmployeeRecordUpdateNotificationSerializer(serializers.Serializer):
     # These fields are null at the beginning of the ASP processing
     codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True, allow_null=True)
     libelleTraitement = serializers.CharField(source="asp_processing_label", allow_blank=True, allow_null=True)
+
+    def get_siret(self, obj: EmployeeRecordUpdateNotification):
+        """We don't trust the SIRET we have in the ER:
+
+        - siret_from_asp_source and obj.siret can be equal, so this
+          does not change anything.
+        - siret_from_asp_source and obj.siret can differ in which case:
+            The ER have an old SIRET, the ASP have a new SIRET: using
+            siret_from_asp_source fix the situation as we're giving the
+            SIRET expected by the ASP.
+
+        Giving the old SIRET leads the ASP to refuse the update (Error
+        3435).
+
+        This probably just bypasses a filter ASP side: the goal of a
+        Notification is just to update the end date of a pass linked
+        to an existing ER.
+
+        """
+        return obj.employee_record.job_application.to_company.siret_from_asp_source()
 
     def get_personnePhysique(self, obj: EmployeeRecordUpdateNotification):
         is_missing_required_fields = not all(

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -209,6 +209,16 @@ class TestEmployeeRecordUpdateNotificationSerializer:
         assert personal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
         assert personal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")
 
+    def test_different_siret_between_er_and_asp(self):
+        # Do not trust denormalized SIRET: it can be out of date.
+        employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED, siret="OLD_SIRET")
+        notification = EmployeeRecordUpdateNotification(employee_record=employee_record)
+        serializer = EmployeeRecordUpdateNotificationSerializer(notification)
+        data = serializer.data
+
+        assert data["siret"] != "OLD_SIRET"
+        assert data["siret"] == employee_record.job_application.to_company.siret_from_asp_source()
+
     def test_batch_serializer(self, subtests):
         # This is the same serializer used for employee record batches.
         # Previously not tested, killing 2 birds with 1 stone.


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte notion](https://app.notion.com/p/gip-inclusion/Fiches-salari-En-cas-de-changement-de-siret-utiliser-le-SIRET-actuel-de-la-SIAE-plut-t-que-le-SI-3a65f321b6048025b94ece57eb3a70fc)

## :cake: Comment ? <!-- optionnel -->

En modifiant juste le Serializer pour prendre le SIRET de l'entreprise plutôt que le SIRET dénormalisé.

Dans un second commit je fais en sort qu'il soit très simple de tester sur une machine de dev:

    ./manage.py transfer_employee_records_updates --upload

fonctionne sans variable d'environnement puisqu'il n'établit plus de connexion SFTP en l'absence de `--wet-run`.

<!--

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran


# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
