### PR TITLE
Restreindre l'accès des prescripteurs habilités au détail d'un PASS IAE

### DIFF
--- a/itou/approvals/perms.py
+++ b/itou/approvals/perms.py
@@ -31,7 +31,9 @@ def can_view_approval_details(request, approval):
     elif request.from_prescriber:
         if (
             request.from_authorized_prescriber
-            and User.objects.assigned_job_seeker_ids(request.user, request.current_organization).exists()
+            and User.objects.assigned_job_seeker_ids(request.user, request.current_organization)
+            .filter(pk=approval.user_id)
+            .exists()
         ):
             return PERMS_READ
     elif request.user.is_job_seeker:

--- a/tests/approvals/test_perms.py
+++ b/tests/approvals/test_perms.py
@@ -3,7 +3,7 @@ from itou.job_applications.enums import JobApplicationState
 from tests.approvals.factories import ApprovalFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
-from tests.users.factories import EmployerFactory, JobSeekerFactory
+from tests.users.factories import EmployerFactory, JobSeekerAssignmentFactory, JobSeekerFactory
 from tests.utils.testing import get_request
 
 
@@ -31,9 +31,16 @@ def test_can_view_approval_details():
         request = get_request(user)
         assert can_view_approval_details(request, approval) == PERMS_READ
 
+    unrelated_membership = PrescriberMembershipFactory(organization__authorized=True)
+    JobSeekerAssignmentFactory(
+        professional=unrelated_membership.user,
+        prescriber_organization=unrelated_membership.organization,
+    )
+
     for bad_user in [
         JobSeekerFactory(),  # another job seeker
         PrescriberMembershipFactory(organization__authorized=True).user,  # a random authorized prescriber
+        unrelated_membership.user,  # authorized, but for another job seeker
         JobApplicationFactory(
             sent_by_prescriber_alone=True, job_seeker=approval.user, with_job_seeker_assignment=True
         ).sender,  # a non authorized prescriber linked to the job seeker

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -2189,17 +2189,18 @@
         'sql': '''
           SELECT %s AS "a"
           FROM "users_user"
-          WHERE EXISTS
-              (SELECT %s AS "a"
-               FROM "users_jobseekerassignment" U0
-               WHERE (((U0."company_id" IS NULL
-                        AND U0."prescriber_organization_id" IS NULL
-                        AND U0."professional_id" = %s)
-                       OR (U0."company_id" IS NULL
-                           AND U0."prescriber_organization_id" = %s
-                           AND U0."professional_id" = %s))
-                      AND U0."job_seeker_id" = ("users_user"."id"))
-               LIMIT 1)
+          WHERE (EXISTS
+                   (SELECT %s AS "a"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE (((U0."company_id" IS NULL
+                             AND U0."prescriber_organization_id" IS NULL
+                             AND U0."professional_id" = %s)
+                            OR (U0."company_id" IS NULL
+                                AND U0."prescriber_organization_id" = %s
+                                AND U0."professional_id" = %s))
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    LIMIT 1)
+                 AND "users_user"."id" = %s)
           LIMIT 1
         ''',
       }),
@@ -4747,17 +4748,18 @@
         'sql': '''
           SELECT %s AS "a"
           FROM "users_user"
-          WHERE EXISTS
-              (SELECT %s AS "a"
-               FROM "users_jobseekerassignment" U0
-               WHERE (((U0."company_id" IS NULL
-                        AND U0."prescriber_organization_id" IS NULL
-                        AND U0."professional_id" = %s)
-                       OR (U0."company_id" IS NULL
-                           AND U0."prescriber_organization_id" = %s
-                           AND U0."professional_id" = %s))
-                      AND U0."job_seeker_id" = ("users_user"."id"))
-               LIMIT 1)
+          WHERE (EXISTS
+                   (SELECT %s AS "a"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE (((U0."company_id" IS NULL
+                             AND U0."prescriber_organization_id" IS NULL
+                             AND U0."professional_id" = %s)
+                            OR (U0."company_id" IS NULL
+                                AND U0."prescriber_organization_id" = %s
+                                AND U0."professional_id" = %s))
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    LIMIT 1)
+                 AND "users_user"."id" = %s)
           LIMIT 1
         ''',
       }),

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -7208,17 +7208,18 @@
         'sql': '''
           SELECT %s AS "a"
           FROM "users_user"
-          WHERE EXISTS
-              (SELECT %s AS "a"
-               FROM "users_jobseekerassignment" U0
-               WHERE (((U0."company_id" IS NULL
-                        AND U0."prescriber_organization_id" IS NULL
-                        AND U0."professional_id" = %s)
-                       OR (U0."company_id" IS NULL
-                           AND U0."prescriber_organization_id" = %s
-                           AND U0."professional_id" = %s))
-                      AND U0."job_seeker_id" = ("users_user"."id"))
-               LIMIT 1)
+          WHERE (EXISTS
+                   (SELECT %s AS "a"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE (((U0."company_id" IS NULL
+                             AND U0."prescriber_organization_id" IS NULL
+                             AND U0."professional_id" = %s)
+                            OR (U0."company_id" IS NULL
+                                AND U0."prescriber_organization_id" = %s
+                                AND U0."professional_id" = %s))
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    LIMIT 1)
+                 AND "users_user"."id" = %s)
           LIMIT 1
         ''',
       }),
@@ -8624,17 +8625,18 @@
         'sql': '''
           SELECT %s AS "a"
           FROM "users_user"
-          WHERE EXISTS
-              (SELECT %s AS "a"
-               FROM "users_jobseekerassignment" U0
-               WHERE (((U0."company_id" IS NULL
-                        AND U0."prescriber_organization_id" IS NULL
-                        AND U0."professional_id" = %s)
-                       OR (U0."company_id" IS NULL
-                           AND U0."prescriber_organization_id" = %s
-                           AND U0."professional_id" = %s))
-                      AND U0."job_seeker_id" = ("users_user"."id"))
-               LIMIT 1)
+          WHERE (EXISTS
+                   (SELECT %s AS "a"
+                    FROM "users_jobseekerassignment" U0
+                    WHERE (((U0."company_id" IS NULL
+                             AND U0."prescriber_organization_id" IS NULL
+                             AND U0."professional_id" = %s)
+                            OR (U0."company_id" IS NULL
+                                AND U0."prescriber_organization_id" = %s
+                                AND U0."professional_id" = %s))
+                           AND U0."job_seeker_id" = ("users_user"."id"))
+                    LIMIT 1)
+                 AND "users_user"."id" = %s)
           LIMIT 1
         ''',
       }),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un prescripteur habilité qui a **au moins un** candidat dans sa liste pouvait consulter le détail de **n’importe quel** PASS IAE, dès lors qu’il en connaissait le `public_id`.

La fonction `can_view_approval_details` vérifiait seulement que la liste d’accompagnements n’était pas vide, et non que **le candidat du PASS** en faisait partie. C’est une IDOR (_Insecure Direct Object Reference_, [Vulnérabilité des références directes](https://fr.wikipedia.org/wiki/Vuln%C3%A9rabilit%C3%A9_des_r%C3%A9f%C3%A9rences_directes)) sur des données sensibles.

ADDENDUM: Faite par Grok 4.6 (je lui ai demandé: trouve une vulnérabilité, fait le fix, ouvre une PR). J'attends de la review moi-même pour la proposer pour de vrai (ou la fermer).

## :cake: Comment ?

Le filtre s’appuie désormais sur le candidat du PASS :

`assigned_job_seeker_ids(...).filter(pk=approval.user_id).exists()`

Un test de non-régression couvre le cas d’un prescripteur habilité accompagnant un *autre* candidat. Les snapshots SQL des pages de détail PASS IAE et fiche candidat ont été mis à jour.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

1. Se connecter en prescripteur habilité avec au moins un candidat dans « Mes candidats ».
2. Récupérer l’URL de détail d’un PASS IAE d’un candidat **non accompagné** par cet utilisateur (`/approvals/details/<public_id>`).
3. Accéder à cette URL : la page doit renvoyer **403**.
4. Contrôle positif : ouvrir le PASS d’un candidat **présent** dans la liste d’accompagnements : le détail reste accessible.