### PR TITLE
Tech : permettre le déclenchement manuel de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: ./.github/actions/setup
-    - name: 🤹 Django tests
-      run: make test TARGET="--ignore=tests/www"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - name: 🤹 Django tests
+        run: make test TARGET="--ignore=tests/www"
 
   test_www:
     runs-on: ubuntu-latest
@@ -54,10 +54,10 @@ jobs:
       cancel-in-progress: true
     services: *test_services
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: ./.github/actions/setup
-    - name: 🤹 Django tests
-      run: make test TARGET="tests/www --ignore=tests/www/apply"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - name: 🤹 Django tests
+        run: make test TARGET="tests/www --ignore=tests/www/apply"
 
   test_www_apply:
     runs-on: ubuntu-latest
@@ -68,35 +68,35 @@ jobs:
       cancel-in-progress: true
     services: *test_services
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: ./.github/actions/setup
-    - name: 🤹 Django tests
-      run: make test TARGET="tests/www/apply"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - name: 🤹 Django tests
+        run: make test TARGET="tests/www/apply"
 
   quality:
-      runs-on: ubuntu-latest
-      permissions: {}
-      env:
-        DJANGO_SETTINGS_MODULE: config.settings.test
-        REQUIREMENTS_PATH: requirements/test.txt
-      concurrency:
-        group: ${{ github.workflow }}-quality-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
-        cancel-in-progress: true
-      services:
-        postgres:
-          # Docker Hub image
-          image: postgis/postgis:17-master
-          env:
-            POSTGRES_PASSWORD: password
-          volumes:
-            - /var/run/postgresql:/var/run/postgresql
-          # Set health checks to wait until postgres has started
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
-      steps:
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings.test
+      REQUIREMENTS_PATH: requirements/test.txt
+    concurrency:
+      group: ${{ github.workflow }}-quality-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
+    services:
+      postgres:
+        # Docker Hub image
+        image: postgis/postgis:17-master
+        env:
+          POSTGRES_PASSWORD: password
+        volumes:
+          - /var/run/postgresql:/var/run/postgresql
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - name: ✨ Verify quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
   merge_group:
+  # Allow this workflow to be triggered manually:
+  # gh workflow run ci.yml --ref <branche>
+  workflow_dispatch:
 
 jobs:
   test_core:

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -8,10 +8,10 @@ jobs:
     permissions: {}
 
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Detect fixup commits & complain if found
-      run: >
-        ! gh pr view ${{ github.event.pull_request.number }} --json commits  --jq ".commits[].messageHeadline"
-        | grep --regexp '^(amend|fixup|squash)!' --extended-regexp
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Detect fixup commits & complain if found
+        run: >
+          ! gh pr view ${{ github.event.pull_request.number }} --json commits  --jq ".commits[].messageHeadline"
+          | grep --regexp '^(amend|fixup|squash)!' --extended-regexp
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il arrive que GitHub ne démarre pas les workflows sur un push, sans qu'on puisse rien y faire de notre côté. Exemple sur cette branche : le run [32985981257](https://github.com/gip-inclusion/les-emplois/actions/runs/32985981257) ("Git Checks" sur `b8645b04a`) s'est terminé en `startup_failure` sans créer un seul job, et la CI n'a tout simplement jamais démarré sur ce commit.

Dans cette situation on est bloqué : un run en `startup_failure` ne se rejoue pas et les seuls déclencheurs de `ci.yml` étaient `push` sur `main`, `pull_request` et `merge_group`. La seule solution était de re-provoquer un événement `pull_request` (commit vide) ou fermeture/réouverture de la PR (ce que j'ai fait).

## :cake: Comment ? <!-- optionnel -->

Ajout de `workflow_dispatch` à `ci.yml`, ce qui permet de relancer la CI à la demande.

L'autre commit ne fait que réindenter les blocs `steps:` de `ci.yml` et `git.yml` pour homogénéiser le style (le job `quality` avait deux niveaux d'indentation en trop). Aucun changement de comportement.
