### PR TITLE
Afficher la landing plateforme-accueil sur la page d'accueil

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -520,6 +520,12 @@ PRO_CONNECT_MFA_IDENTITY_PROVIDER_ALLOWLIST = [
 
 TALLY_URL = os.getenv("TALLY_URL")
 
+# Landing page embedded on the home page, served by the plateforme-accueil app.
+# Overridable per environment so a review app can embed its own deployment.
+PLATEFORME_ACCUEIL_URL = os.getenv(
+    "PLATEFORME_ACCUEIL_URL", "https://novarw2u9ckv-plateforme-accueil.functions.fnc.fr-par.scw.cloud"
+)
+
 # Embedding signed Metabase dashboard
 METABASE_SITE_URL = os.getenv("METABASE_SITE_URL")
 METABASE_SECRET_KEY = os.getenv("METABASE_SECRET_KEY")
@@ -752,6 +758,8 @@ SECURE_CSP = {
         "https://pilotage.inclusion.beta.gouv.fr",
         "https://inclusion.beta.gouv.fr",
         "https://api.data.inclusion.gouv.fr",
+        # Landing page embedded on the home page
+        PLATEFORME_ACCUEIL_URL,
         "blob:",  # For downloading Metabase questions as CSV/XSLX/JSON on Firefox etc
         "data:",  # For downloading Metabase questions as PNG on Firefox etc
     ],

--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -460,3 +460,12 @@ table.table td > .modal .modal-content {
         aspect-ratio: 1 / 1;
     }
 }
+
+/* Home page: the landing page from the plateforme-accueil app is embedded full
+   width. It carries no scrollbar of its own; its height is applied from the
+   message it posts (see search/siaes_search_home.html). */
+#iframe-plateforme-accueil {
+    display: block;
+    width: 100%;
+    border: 0;
+}

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -1,60 +1,46 @@
 {% extends "layout/base.html" %}
-{% load static %}
 
 {% block title %}Les emplois de l'inclusion{% endblock %}
 
 {% block body_class %}p-home{% endblock %}
 
 {% block content %}
+    {% comment %}
+        The home page is the landing page served by the plateforme-accueil app,
+        embedded here so it is maintained in one place. Only the header and the
+        footer of this site are kept around it. Without PLATEFORME_ACCUEIL_URL
+        (an environment that does not embed it), the local search form is shown.
+    {% endcomment %}
+    {% if PLATEFORME_ACCUEIL_URL %}
+        <iframe id="iframe-plateforme-accueil"
+                title="La plateforme de l'inclusion"
+                src="{{ PLATEFORME_ACCUEIL_URL }}"
+                sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation"></iframe>
+    {% else %}
+        {% include "search/includes/generic_search_home.html" with form=siae_search_form title="Rechercher un emploi inclusif" url_search="search:employers_results" template_form_name="search/includes/siaes_search_form.html" %}
+    {% endif %}
+{% endblock %}
 
-    {% include "search/includes/generic_search_home.html" with form=siae_search_form title="Rechercher un emploi inclusif" url_search="search:employers_results" template_form_name="search/includes/siaes_search_form.html" %}
-
-    <section class="s-article-figure-01 s-article-figure-01--ltr">
-        <div class="s-article-figure-01__container container container-max-lg">
-            <div class="s-article-figure-01__row row">
-                <div class="s-article-figure-01__col s-article-figure-01__col--figure col-12 col-md-3 col-lg-4 d-flex align-items-center justify-content-center">
-                    <figure class="w-50 w-md-100">
-                        <img src="{% static "img/home/illustration-01.png" %}" class="img-fluid img-fitcover" width="411" height="291" alt="">
-                    </figure>
-                </div>
-                <div class="s-article-figure-01__col s-article-figure-01__col--article col-12 col-md-9 col-lg-8 d-flex align-items-center">
-                    <article>
-                        <h2 class="h1 text-tertiary">
-                            Qu’est-ce que l’inclusion
-                            <br class="d-none d-lg-inline">
-                            dans l’emploi&nbsp;?
-                        </h2>
-                        <p>
-                            L’inclusion dans l'emploi est un projet de société gouvernemental qui permet aux personnes les plus fragiles de bénéficier de l’accès à l’emploi et à la formation pour s’insérer dans la société par le travail.
-                        </p>
-                        <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" class="btn btn-outline-primary w-100 w-md-auto mb-3 mt-4 has-external-link" target="_blank">En savoir plus</a>
-                    </article>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <section class="s-article-figure-01">
-        <div class="s-article-figure-01__container container container-max-lg">
-            <div class="s-article-figure-01__row row">
-                <div class="s-article-figure-01__col s-article-figure-01__col--figure col-12 col-md-3 col-lg-4 d-flex align-items-center justify-content-center">
-                    <figure class="w-50 w-md-100">
-                        <img src="{% static "img/home/illustration-02.png" %}" loading="lazy" class="img-fluid img-fitcover" width="411" height="291" alt="">
-                    </figure>
-                </div>
-                <div class="s-article-figure-01__col s-article-figure-01__col--article col-12 col-md-9 col-lg-8 d-flex align-items-center">
-                    <article>
-                        <h2 class="h1 text-tertiary">Nos missions</h2>
-                        <p>
-                            Ce service facilite la mise en relation des personnes les plus éloignées de l'emploi avec les employeurs inclusifs (SIAE, GEIQ et facilitateurs de clauses sociales) et les accompagnants (orienteurs et prescripteurs habilités).
-                        </p>
-                        <p>
-                            Il offre aux utilisateurs un outil numérique mutualisé pour simplifier les procédures, fluidifier les parcours d'insertion entre professionnels et renforcer la qualité de l'accompagnement des personnes.
-                        </p>
-                    </article>
-                </div>
-            </div>
-        </div>
-    </section>
-
+{% block script %}
+    {{ block.super }}
+    {% if PLATEFORME_ACCUEIL_URL %}
+        <script nonce="{{ csp_nonce }}">
+            (function() {
+                "use strict";
+                const frame = document.getElementById("iframe-plateforme-accueil");
+                // The embedded page has no scrollbar of its own: it publishes its
+                // height and we resize the iframe to match. See the plateforme-accueil
+                // README for the protocol.
+                window.addEventListener("message", function(event) {
+                    var data = event.data;
+                    if (!data || data.source !== "plateforme-accueil" || frame.contentWindow !== event.source) {
+                        return;
+                    }
+                    if (data.type === "resize") {
+                        frame.style.height = data.height + "px";
+                    }
+                });
+            })();
+        </script>
+    {% endif %}
 {% endblock %}

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -31,6 +31,7 @@ def expose_settings(request):
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MON_RECAP_WWW_BASE_URL": settings.MON_RECAP_WWW_BASE_URL,
+        "PLATEFORME_ACCUEIL_URL": settings.PLATEFORME_ACCUEIL_URL,
         "SHOW_DEMO_ACCOUNTS_BANNER": settings.SHOW_DEMO_ACCOUNTS_BANNER,
         "TALLY_URL": settings.TALLY_URL,
     }

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -1,6 +1,7 @@
 from urllib.parse import quote
 
 import pytest
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.template.defaultfilters import capfirst, urlencode as urlencode_filter
 from django.templatetags.static import static
@@ -55,8 +56,19 @@ class TestSearchCompany:
     applications_open_str = "Cette structure vous intéresse ?"
 
     def test_home_anonymous(self, client):
+        # The home page is the landing page from the plateforme-accueil app,
+        # embedded between our header and our footer.
         response = client.get(reverse("search:employers_home"))
-        assertContains(response, "Rechercher un emploi inclusif")
+        assertContains(response, 'id="iframe-plateforme-accueil"')
+        assertContains(response, settings.PLATEFORME_ACCUEIL_URL)
+        assertNotContains(response, "s-home-search")
+
+    @override_settings(PLATEFORME_ACCUEIL_URL="")
+    def test_home_anonymous_without_the_landing_page(self, client):
+        # Environments that do not embed it keep the local search form.
+        response = client.get(reverse("search:employers_home"))
+        assertNotContains(response, 'id="iframe-plateforme-accueil"')
+        assertContains(response, "s-home-search")
 
     def test_home_connected(self, client):
         client.force_login(random_user_kind_factory())


### PR DESCRIPTION
La page d'accueil (celle sur laquelle atterrissent les visiteurs anonymes, `search:employers_home`) affiche désormais la **landing servie par l'app plateforme-accueil**, embarquée en iframe, avec **uniquement le header et le footer** de ce site autour.

## Changements
- `search/siaes_search_home.html` : le contenu de la page est remplacé par l'iframe. Le script de redimensionnement applique la hauteur publiée par la page embarquée (elle n'a pas de barre de défilement propre).
- `config/settings/base.py` : nouveau réglage **`PLATEFORME_ACCUEIL_URL`**, lu depuis l'environnement, et ajouté à la directive CSP `frame-src`.
- `itou/utils/settings_context_processors.py` : réglage exposé aux gabarits.
- `itou/static/css/itou.css` : l'iframe s'affiche pleine largeur, sans bordure.

## Repli
Si `PLATEFORME_ACCUEIL_URL` est vide, la page conserve le formulaire de recherche actuel : les environnements qui n'embarquent pas la landing ne sont pas cassés. Le réglage étant par environnement, une review app peut pointer vers son propre déploiement.

## Tests
- `test_home_anonymous` vérifie la présence de l'iframe et l'absence du bloc de recherche local.
- `test_home_anonymous_without_the_landing_page` couvre le repli.

⚠️ Non exécutés localement : la suite demande PostgreSQL/PostGIS. Syntaxe Python validée.

## À noter
Les liens de recherche de la landing pointent en dur vers `emplois.inclusion.beta.gouv.fr`. Sur une review app, une recherche fait donc **sortir vers la production** — à traiter côté plateforme-accueil pour tester le parcours de bout en bout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)