### PR TITLE
Ajout du tracking sur les filtres handicap dans la recherche

### DIFF
--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -1,3 +1,4 @@
+{% load matomo %}
 {% load theme_inclusion %}
 {% comment %}
 Arguments:
@@ -5,6 +6,7 @@ Arguments:
 - label: (defaults to the field label)
 - id_suffix: When the field is present multiple times on the page, use the
     suffix to make its input id unique.
+- matomo_category: When given, a matomo click event is set for each choice of this field.
 {% endcomment %}
 <div class="dropdown">
     <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="outside" aria-expanded="false">
@@ -25,7 +27,8 @@ Arguments:
                            type="checkbox"
                            value="{{ choice.data.value }}"
                            {% if id_suffix|default:"" %}data-emplois-sync-with="{{ choice.id_for_label }}"{% endif %}
-                           {% if choice.data.selected %}checked{% endif %}>
+                           {% if choice.data.selected %}checked{% endif %}
+                           {% if matomo_category|default:False %}{% matomo_event matomo_category "clic" choice.data.name|add:"_"|add:choice.data.value %}{% endif %}>
                     <label for="{{ choice.id_for_label }}{{ id_suffix|default:'' }}" class="form-check-label">
                         {{ choice.choice_label }}
                     </label>

--- a/itou/templates/includes/field_collapse_checkbox.html
+++ b/itou/templates/includes/field_collapse_checkbox.html
@@ -1,7 +1,9 @@
+{% load matomo %}
 {% load theme_inclusion %}
 {% comment %}
 Arguments:
 - field
+- matomo_category: When given, a matomo click event is set for each choice of this field.
 {% endcomment %}
 <fieldset>
     <legend>
@@ -26,7 +28,13 @@ Arguments:
             {% for choice in field %}
                 <li>
                     <div class="form-check">
-                        <input id="{{ choice.id_for_label }}" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}"{% if choice.data.selected %} checked{% endif %}>
+                        <input id="{{ choice.id_for_label }}"
+                               class="form-check-input"
+                               name="{{ choice.data.name }}"
+                               type="checkbox"
+                               value="{{ choice.data.value }}"
+                               {% if choice.data.selected %} checked{% endif %}
+                               {% if matomo_category|default:False %}{% matomo_event matomo_category "clic" choice.data.name|add:"_"|add:choice.data.value %}{% endif %}>
                         <label for="{{ choice.id_for_label }}" class="form-check-label">{{ choice.choice_label }}</label>
                     </div>
                 </li>

--- a/itou/templates/search/includes/filters/offcanvas_body.html
+++ b/itou/templates/search/includes/filters/offcanvas_body.html
@@ -9,6 +9,6 @@
     {% endif %}
     {% include "search/includes/filters/departments.html" %}
     {% if form.handicap %}
-        {% include "search/includes/filters/handicap.html" with nouveau=True %}
+        {% include "search/includes/filters/handicap.html" with nouveau=True matomo_category="recherche" %}
     {% endif %}
 </div>

--- a/itou/templates/search/includes/siaes_search_content.html
+++ b/itou/templates/search/includes/siaes_search_content.html
@@ -12,7 +12,7 @@
                                     {% include "search/includes/filters/distance.html" with btn_dropdown_filter=True %}
                                     {% include "search/includes/filters/structure_kind.html" with btn_dropdown_filter=True %}
                                     {% if form.handicap %}
-                                        {% include "search/includes/filters/handicap.html" with btn_dropdown_filter=True nouveau=True %}
+                                        {% include "search/includes/filters/handicap.html" with btn_dropdown_filter=True nouveau=True matomo_category="recherche" %}
                                     {% endif %}
                                     <button type="button" class="btn btn-ico btn-dropdown-filter" data-bs-toggle="offcanvas" data-bs-target="#offcanvasApplyFilters" aria-controls="offcanvasApplyFilters">
                                         <i class="ri-sound-module-fill fw-medium" aria-hidden="true"></i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

[carte notion](https://app.notion.com/p/gip-inclusion/Moteur-de-recherche-Nouveau-filtre-handicap-pour-afficher-les-offres-EA-EATT-et-offres-des-emplo-33c5f321b60480338f5feb28e71a5aa9?d=ec15f321b604831e9fca8395183ffe4a)

## :cake: Comment ? <!-- optionnel -->

J'ai fait en sorte que `includes/field_collapse_checkbox.html` et `btn_dropdown_filter/checkboxes.html` acceptent un paramètre `matomo_category`. Le paramètre me semble suffire: `matomo_action` est toujours "click" et `matomo_name` est déduit du field.

Attention c'est la première fois que je touche à matomo !

<!--
## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
