### PR TITLE
Suppression du filtre EATT, devenu inutile, dans la recherche d'offres d'emplois

### DIFF
--- a/itou/companies/enums.py
+++ b/itou/companies/enums.py
@@ -15,6 +15,20 @@ class CompanyKind(models.TextChoices):
     OPCS = "OPCS", "Organisation porteuse de la clause sociale"
 
     @classmethod
+    def for_job_description_filter(cls):
+        """EA/EATT companies support has been dropped on 11/05/2026.
+
+        Jobs descriptions from France Travail API can be EA (marked as
+        `entrepriseAdaptee` in their API), but they cannot be EATT
+        (the FT API has no way to distinguish between EA and EATT).
+
+        So as of 2026 no job description can be EATT.
+
+        That's why we're removing it from the filter interface.
+        """
+        return [(k, f"{k} - {v}") for k, v in CompanyKind.choices if k != "EATT"]
+
+    @classmethod
     def siae_choices(cls):
         """Returns a list of CompanyKinds which are SIAEs."""
         return [(k, v) for k, v in cls.choices if k in cls.siae_kinds()]

--- a/itou/www/search_views/forms.py
+++ b/itou/www/search_views/forms.py
@@ -117,8 +117,7 @@ class SiaeSearchForm(forms.Form):
 
 
 class JobDescriptionSearchForm(SiaeSearchForm):
-    KIND_CHOICES = [(k, f"{k} - {v}") for k, v in CompanyKind.choices]
-
+    KIND_CHOICES = CompanyKind.for_job_description_filter()
     CONTRACT_TYPE_CHOICES = sorted(
         [(k, v) for k, v in ContractType.choices if k not in (ContractType.OTHER, ContractType.BUSINESS_CREATION)],
         key=lambda d: d[1],


### PR DESCRIPTION
## :thinking: Pourquoi ?

[carte notion](https://app.notion.com/p/gip-inclusion/Moteur-de-recherche-Nouveau-filtre-handicap-pour-afficher-les-offres-EA-EATT-et-offres-des-emplo-33c5f321b60480338f5feb28e71a5aa9)

## :cake: Comment ? <!-- optionnel -->

Je pensais que la suppression du champ EATT impliquerai un grand nettoyage de la notion d'EATT dans le code.

Mais pour le moment nous souhaitons conserver les données en base, et dans `import_ea_eatt.py` donc une bonne partie du code ne peut pas bouger pour le moment.

cf. le commentaire dans `import_ea_eatt.py` :

    As of 11/05/2026, EA and EATT should not be accessible anymore on our platform.
    However, Le Marché & Data Inclusion still use these data.

donc finalement j'ai juste supprimé le filtre dans l'interface graphique, en posant un commentaire explicatif.

<!--

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
