### PR TITLE
Pilotage : Ajout des uid pour les entreprises, organisations prescriptrices, candidats et pros

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -248,6 +248,7 @@ class Command(BaseCommand):
                 ),
             )
             .only(
+                "uid",
                 "convention",
                 "convention__asp_id",
                 "kind",
@@ -340,6 +341,7 @@ class Command(BaseCommand):
                 ),
             )
             .only(
+                "uid",
                 "siret",
                 "name",
                 "kind",
@@ -436,6 +438,7 @@ class Command(BaseCommand):
                 ),
             )
             .only(
+                "public_id",
                 "jobseeker_profile__nir",
                 "jobseeker_profile__birthdate",  # get_user_age_in_years
                 "date_joined",

--- a/itou/metabase/tables/companies.py
+++ b/itou/metabase/tables/companies.py
@@ -17,6 +17,7 @@ TABLE = MetabaseTable(name="structures_v0")
 TABLE.add_columns(
     [
         get_column_from_field(get_model_field(Company, "pk"), name="id"),
+        get_column_from_field(get_model_field(Company, "uid"), name="uid", comment="identifiant universel unique"),
         {
             "name": "id_asp",
             "type": "integer",

--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -182,6 +182,9 @@ def get_table():
     job_seekers_table.add_columns(
         [
             get_column_from_field(get_model_field(User, "pk"), name="id", comment="ID C1 du candidat"),
+            get_column_from_field(
+                get_model_field(User, "public_id"), name="uid", comment="identifiant universel unique du candidat"
+            ),
             {
                 "name": "hash_nir",
                 "type": "varchar",

--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -17,6 +17,9 @@ TABLE = MetabaseTable(name="organisations_v0")
 TABLE.add_columns(
     [
         get_column_from_field(get_model_field(PrescriberOrganization, "pk"), name="id"),
+        get_column_from_field(
+            get_model_field(PrescriberOrganization, "uid"), name="uid", comment="identifiant universel unique"
+        ),
         get_column_from_field(get_model_field(PrescriberOrganization, "siret"), name="siret"),
         {"name": "nom", "type": "varchar", "comment": "Nom organisation", "fn": attrgetter("display_name")},
         get_column_from_field(

--- a/itou/metabase/tables/users.py
+++ b/itou/metabase/tables/users.py
@@ -6,6 +6,9 @@ TABLE = MetabaseTable(name="utilisateurs_v0")
 TABLE.add_columns(
     [
         get_column_from_field(get_model_field(User, "pk"), name="id"),
+        get_column_from_field(
+            get_model_field(User, "public_id"), name="uid", comment="identifiant unique universel du professionnel"
+        ),
         get_column_from_field(get_model_field(User, "email"), name="email"),
         get_column_from_field(get_model_field(User, "kind"), name="type"),
         get_column_from_field(get_model_field(User, "first_name"), name="prenom"),

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
@@ -934,7 +934,7 @@
 # ---
 # name: test_populate_companies
   dict({
-    'num_queries': 61,
+    'num_queries': 62,
     'queries': list([
       dict({
         'origin': list([
@@ -1040,7 +1040,10 @@
           'Command.execute[itoutils/django/commands.py]',
           'Command.execute[itoutils/django/commands.py]',
         ]),
-        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_structures_v0" ("id" integer,"id_asp" integer,"nom" varchar,"nom_complet" varchar,"description" text,"type" varchar,"siret" varchar,"source" varchar,"code_naf" varchar,"email_public" varchar,"email_authentification" varchar,"convergence_france" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_ligne_1_c1" varchar,"adresse_ligne_2_c1" varchar,"code_postal_c1" varchar,"code_commune_c1" varchar,"ville_c1" varchar,"longitude_c1" double precision,"latitude_c1" double precision,"département_c1" varchar,"nom_département_c1" varchar,"région_c1" varchar,"date_inscription" date,"total_membres" integer,"total_candidatures" integer,"total_candidatures_30j" integer,"total_embauches" integer,"total_embauches_30j" integer,"taux_conversion_30j" double precision,"total_auto_prescriptions" integer,"total_candidatures_autonomes" integer,"total_candidatures_via_prescripteur" integer,"total_candidatures_non_traitées" integer,"total_candidatures_en_étude" integer,"date_dernière_connexion" date,"active" integer,"date_dernière_évolution_candidature" date,"total_fiches_de_poste_actives" integer,"total_fiches_de_poste_inactives" integer,"date_mise_à_jour_metabase" date)',
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_structures_v0" ("id" integer,"uid" UUID,
+                                                                               "id_asp" integer,"nom" varchar,"nom_complet" varchar,"description" text,"type" varchar,"siret" varchar,"source" varchar,"code_naf" varchar,"email_public" varchar,"email_authentification" varchar,"convergence_france" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_ligne_1_c1" varchar,"adresse_ligne_2_c1" varchar,"code_postal_c1" varchar,"code_commune_c1" varchar,"ville_c1" varchar,"longitude_c1" double precision,"latitude_c1" double precision,"département_c1" varchar,"nom_département_c1" varchar,"région_c1" varchar,"date_inscription" date,"total_membres" integer,"total_candidatures" integer,"total_candidatures_30j" integer,"total_embauches" integer,"total_embauches_30j" integer,"taux_conversion_30j" double precision,"total_auto_prescriptions" integer,"total_candidatures_autonomes" integer,"total_candidatures_via_prescripteur" integer,"total_candidatures_non_traitées" integer,"total_candidatures_en_étude" integer,"date_dernière_connexion" date,"active" integer,"date_dernière_évolution_candidature" date,"total_fiches_de_poste_actives" integer,"total_fiches_de_poste_inactives" integer,"date_mise_à_jour_metabase" date)
+        ''',
       }),
       dict({
         'origin': list([
@@ -1053,6 +1056,18 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."uid" IS \'identifiant universel unique\'',
       }),
       dict({
         'origin': list([
@@ -1662,6 +1677,7 @@
                  "companies_company"."coords",
                  "companies_company"."insee_city_id",
                  "companies_company"."name",
+                 "companies_company"."uid",
                  "companies_company"."siret",
                  "companies_company"."naf",
                  "companies_company"."kind",
@@ -1841,6 +1857,7 @@
         ]),
         'sql': '''
           COPY "z_new_structures_v0" ("id",
+                                      "uid",
                                       "id_asp",
                                       "nom",
                                       "nom_complet",
@@ -5770,7 +5787,7 @@
 # ---
 # name: test_populate_job_seekers
   dict({
-    'num_queries': 74,
+    'num_queries': 75,
     'queries': list([
       dict({
         'origin': list([
@@ -5850,15 +5867,16 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': '''
-          CREATE TABLE IF NOT EXISTS "z_new_candidats_v0" ("id" integer,"hash_nir" varchar,"sexe_selon_nir" varchar,"annee_naissance_selon_nir" integer,"mois_naissance_selon_nir" integer,"age" integer,"date_inscription" date,"type_inscription" varchar,"pe_connect" integer,"pe_inscrit" integer,"date_dernière_connexion" date,"date_premiere_connexion" date,"actif" integer,"code_postal" varchar,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_en_qpv" varchar,"total_candidatures" integer,"total_embauches" integer,"total_diagnostics" integer,"date_diagnostic" date,"date_expiration_diagnostic" date,"diagnostic_valide" integer,"id_auteur_diagnostic_prescripteur" integer,"id_auteur_diagnostic_employeur" integer,"type_auteur_diagnostic" varchar,"sous_type_auteur_diagnostic" varchar,"nom_auteur_diagnostic" varchar,"type_structure_dernière_embauche" varchar,"total_critères_niveau_1" integer,"total_critères_niveau_2" integer,"critère_n1_bénéficiaire_du_rsa" integer,"critère_n1_bénéficiaire_du_rsa_date_certification" timestamp WITH TIME ZONE,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        "critère_n1_bénéficiaire_du_rsa_période_certification" daterange,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        "critère_n1_allocataire_ass" integer,"critère_n1_allocataire_aah" integer,"critère_n1_allocataire_aah_date_certification" timestamp WITH TIME ZONE,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n1_allocataire_aah_période_certification" daterange,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n1_detld_plus_de_24_mois" integer,"critère_n2_niveau_d_étude_3_cap_bep_ou_infra" integer,"critère_n2_senior_plus_de_50_ans" integer,"critère_n2_jeune_moins_de_26_ans" integer,"critère_n2_sortant_de_l_ase" integer,"critère_n2_deld_12_à_24_mois" integer,"critère_n2_travailleur_handicapé" integer,"critère_n2_travailleur_handicapé_date_certification" timestamp WITH TIME ZONE,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                "critère_n2_travailleur_handicapé_période_certification" daterange,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                "critère_n2_parent_isolé" integer,"critère_n2_parent_isolé_date_certification" timestamp WITH TIME ZONE,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   "critère_n2_parent_isolé_période_certification" daterange,
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   "critère_n2_personne_sans_hébergement_ou_hébergée_ou_ayant_un_parcours_de_rue" integer,"critère_n2_réfugié_statutaire_bénéficiaire_d_une_protection_temporaire_protégé_subsidiaire_ou_demandeur_d_asile" integer,"critère_n2_résident_zrr" integer,"critère_n2_résident_qpv" integer,"critère_n2_sortant_de_détention_ou_personne_placée_sous_main_de_justice" integer,"critère_n2_maîtrise_de_la_langue_française_inférieure_au_niveau_a1" integer,"critère_n2_problème_de_mobilité" integer,"injection_ai" integer,"date_mise_à_jour_metabase" date)
+          CREATE TABLE IF NOT EXISTS "z_new_candidats_v0" ("id" integer,"uid" UUID,
+                                                                              "hash_nir" varchar,"sexe_selon_nir" varchar,"annee_naissance_selon_nir" integer,"mois_naissance_selon_nir" integer,"age" integer,"date_inscription" date,"type_inscription" varchar,"pe_connect" integer,"pe_inscrit" integer,"date_dernière_connexion" date,"date_premiere_connexion" date,"actif" integer,"code_postal" varchar,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_en_qpv" varchar,"total_candidatures" integer,"total_embauches" integer,"total_diagnostics" integer,"date_diagnostic" date,"date_expiration_diagnostic" date,"diagnostic_valide" integer,"id_auteur_diagnostic_prescripteur" integer,"id_auteur_diagnostic_employeur" integer,"type_auteur_diagnostic" varchar,"sous_type_auteur_diagnostic" varchar,"nom_auteur_diagnostic" varchar,"type_structure_dernière_embauche" varchar,"total_critères_niveau_1" integer,"total_critères_niveau_2" integer,"critère_n1_bénéficiaire_du_rsa" integer,"critère_n1_bénéficiaire_du_rsa_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              "critère_n1_bénéficiaire_du_rsa_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              "critère_n1_allocataire_ass" integer,"critère_n1_allocataire_aah" integer,"critère_n1_allocataire_aah_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            "critère_n1_allocataire_aah_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            "critère_n1_detld_plus_de_24_mois" integer,"critère_n2_niveau_d_étude_3_cap_bep_ou_infra" integer,"critère_n2_senior_plus_de_50_ans" integer,"critère_n2_jeune_moins_de_26_ans" integer,"critère_n2_sortant_de_l_ase" integer,"critère_n2_deld_12_à_24_mois" integer,"critère_n2_travailleur_handicapé" integer,"critère_n2_travailleur_handicapé_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n2_travailleur_handicapé_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n2_parent_isolé" integer,"critère_n2_parent_isolé_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         "critère_n2_parent_isolé_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         "critère_n2_personne_sans_hébergement_ou_hébergée_ou_ayant_un_parcours_de_rue" integer,"critère_n2_réfugié_statutaire_bénéficiaire_d_une_protection_temporaire_protégé_subsidiaire_ou_demandeur_d_asile" integer,"critère_n2_résident_zrr" integer,"critère_n2_résident_qpv" integer,"critère_n2_sortant_de_détention_ou_personne_placée_sous_main_de_justice" integer,"critère_n2_maîtrise_de_la_langue_française_inférieure_au_niveau_a1" integer,"critère_n2_problème_de_mobilité" integer,"injection_ai" integer,"date_mise_à_jour_metabase" date)
         ''',
       }),
       dict({
@@ -5872,6 +5890,18 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."id" IS \'ID C1 du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."uid" IS \'identifiant universel unique du candidat\'',
       }),
       dict({
         'origin': list([
@@ -6601,6 +6631,7 @@
                  "users_user"."geocoding_score",
                  "users_user"."identity_provider",
                  "users_user"."created_by_id",
+                 "users_user"."public_id",
                  "users_user"."first_login",
                  COUNT(DISTINCT "eligibility_eligibilitydiagnosis"."id") AS "eligibility_diagnoses_count",
                  COUNT(DISTINCT "job_applications_jobapplication"."id") AS "job_applications_count",
@@ -6781,6 +6812,7 @@
         ]),
         'sql': '''
           COPY "z_new_candidats_v0" ("id",
+                                     "uid",
                                      "hash_nir",
                                      "sexe_selon_nir",
                                      "annee_naissance_selon_nir",
@@ -7698,7 +7730,7 @@
 # ---
 # name: test_populate_organizations
   dict({
-    'num_queries': 36,
+    'num_queries': 37,
     'queries': list([
       dict({
         'origin': list([
@@ -7767,7 +7799,10 @@
           'Command.execute[itoutils/django/commands.py]',
           'Command.execute[itoutils/django/commands.py]',
         ]),
-        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_organisations_v0" ("id" integer,"siret" varchar,"nom" varchar,"type" varchar,"type_complet" varchar,"habilitée" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"date_inscription" date,"code_safir" varchar,"total_membres" integer,"total_candidatures" integer,"total_embauches" integer,"date_dernière_candidature" date,"date_dernière_connexion" date,"active" integer,"brsa" integer,"date_mise_à_jour_metabase" date)',
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_organisations_v0" ("id" integer,"uid" UUID,
+                                                                                  "siret" varchar,"nom" varchar,"type" varchar,"type_complet" varchar,"habilitée" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"date_inscription" date,"code_safir" varchar,"total_membres" integer,"total_candidatures" integer,"total_embauches" integer,"date_dernière_candidature" date,"date_dernière_connexion" date,"active" integer,"brsa" integer,"date_mise_à_jour_metabase" date)
+        ''',
       }),
       dict({
         'origin': list([
@@ -7780,6 +7815,18 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."uid" IS \'identifiant universel unique\'',
       }),
       dict({
         'origin': list([
@@ -8101,6 +8148,7 @@
                  "prescribers_prescriberorganization"."coords",
                  "prescribers_prescriberorganization"."insee_city_id",
                  "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."uid",
                  "prescribers_prescriberorganization"."siret",
                  "prescribers_prescriberorganization"."kind",
                  "prescribers_prescriberorganization"."is_brsa",
@@ -8232,6 +8280,7 @@
         ]),
         'sql': '''
           COPY "z_new_organisations_v0" ("id",
+                                         "uid",
                                          "siret",
                                          "nom",
                                          "type",
@@ -9777,7 +9826,7 @@
 # ---
 # name: test_populate_users
   dict({
-    'num_queries': 17,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -9821,8 +9870,9 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': '''
-          CREATE TABLE IF NOT EXISTS "z_new_utilisateurs_v0" ("id" integer,"email" varchar,"type" varchar,"prenom" varchar,"nom" varchar,"dernière_connexion" timestamp WITH TIME ZONE,
-                                                                                                                                                                                  "date_inscription" date,"date_mise_à_jour_metabase" date)
+          CREATE TABLE IF NOT EXISTS "z_new_utilisateurs_v0" ("id" integer,"uid" UUID,
+                                                                                 "email" varchar,"type" varchar,"prenom" varchar,"nom" varchar,"dernière_connexion" timestamp WITH TIME ZONE,
+                                                                                                                                                                                        "date_inscription" date,"date_mise_à_jour_metabase" date)
         ''',
       }),
       dict({
@@ -9836,6 +9886,18 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."uid" IS \'identifiant unique universel du professionnel\'',
       }),
       dict({
         'origin': list([
@@ -9988,6 +10050,7 @@
         ]),
         'sql': '''
           COPY "z_new_utilisateurs_v0" ("id",
+                                        "uid",
                                         "email",
                                         "type",
                                         "prenom",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -294,6 +294,7 @@ def test_populate_job_seekers(snapshot):
     assert rows == [
         {
             "id": user_1.pk,
+            "uid": user_1.public_id,
             "hash_nir": "28e41a0abf44151d54b9006aa6308d71d15284f7cc83a200b8fc6a9ffdf58352",
             "sexe_selon_nir": "Homme",
             "annee_naissance_selon_nir": 79,
@@ -356,6 +357,7 @@ def test_populate_job_seekers(snapshot):
         },
         {
             "id": user_2.pk,
+            "uid": user_2.public_id,
             "hash_nir": "d4d74522c83e8371e4ccafa994a70bb802b59d8e143177cf048e71c9b9d2e34a",
             "sexe_selon_nir": "Femme",
             "annee_naissance_selon_nir": 71,
@@ -418,6 +420,7 @@ def test_populate_job_seekers(snapshot):
         },
         {
             "id": user_3.pk,
+            "uid": user_3.public_id,
             "hash_nir": "2eb53772722d3026b539173c62ba7adc1756e5ab1f03b95ce4026c27d177bd34",
             "sexe_selon_nir": "Femme",
             "annee_naissance_selon_nir": 97,
@@ -874,6 +877,7 @@ def test_populate_users(snapshot):
         assert rows == [
             (
                 pro_user.id,
+                pro_user.public_id,
                 pro_user.email,
                 "professional",
                 pro_user.first_name,
@@ -1067,6 +1071,7 @@ def test_populate_companies(snapshot):
         assert rows == [
             (
                 company.pk,
+                company.uid,
                 company.convention.asp_id,
                 "ACME Inc.",
                 f"EI - ID {company.pk} - ACME Inc.",
@@ -1220,6 +1225,7 @@ def test_populate_organizations(snapshot):
     assert rows == [
         {
             "id": first_organisation.pk,
+            "uid": first_organisation.uid,
             "siret": first_organisation.siret,
             "nom": first_organisation.name,
             "type": first_organisation.kind,
@@ -1248,6 +1254,7 @@ def test_populate_organizations(snapshot):
         },
         {
             "id": second_organisation.pk,
+            "uid": second_organisation.uid,
             "siret": second_organisation.siret,
             "nom": second_organisation.name,
             "type": second_organisation.kind,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certaines données (par exemple, des orientations) sont échangées entre les produits et utilisent des identifiants publics (UID).
Nous souhaitons (enfin l’équipe data) désormais joindre des tables entre les produits et avons besoin de cet identifiant commun.

