### PR TITLE
Tech: Correction automatique des incohérences des PASS IAE

### DIFF
--- a/itou/approvals/management/commands/fix_incoherences.py
+++ b/itou/approvals/management/commands/fix_incoherences.py
@@ -1,0 +1,73 @@
+import pgtrigger
+from django.db.models import F
+from django.utils import timezone
+from itoutils.django.commands import dry_runnable
+
+from itou.approvals.models import Prolongation, Suspension
+from itou.utils.admin import add_support_remark_to_obj
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
+    def add_arguments(self, parser):
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    def fix_prolongations_ending_after(self):
+        for prolongation in Prolongation.objects.filter(end_at__gt=F("approval__end_at")):
+            approval = prolongation.approval
+            old_end_at = approval.end_at
+            approval.end_at = prolongation.end_at
+            approval.save(update_fields=["end_at", "updated_at"])
+            log_string = (
+                "allongement d'un PASS finissant avant la dernière prologation"
+                f" pass_iae={approval.number} old_end_at={old_end_at}"
+                f" new_end_at={approval.end_at}"
+            )
+            add_support_remark_to_obj(
+                approval,
+                f"------------------------\n{timezone.localtime().replace(microsecond=0)} (automatique): {log_string}",
+            )
+            self.stdout.write(log_string)
+
+    def fix_suspensions_starting_after(self):
+        for suspension in Suspension.objects.filter(start_at__gt=F("approval__end_at")):
+            approval = suspension.approval
+            s_data = {k: str(v) for k, v in suspension.__dict__.items() if k != "_state"}
+            with pgtrigger.ignore("approvals.Suspension:update_approval_end_at"):
+                suspension.delete()
+            log_string = (
+                "suppression d'une suspension commençant après la fin du PASS"
+                f" (sans modifier la date de fin du PASS): {s_data}"
+            )
+            add_support_remark_to_obj(
+                approval,
+                f"------------------------\n{timezone.localtime().replace(microsecond=0)} (automatique): {log_string}",
+            )
+            self.stdout.write(log_string)
+
+    def fix_suspensions_ending_after(self):
+        for suspension in Suspension.objects.filter(end_at__gt=F("approval__end_at")):
+            approval = suspension.approval
+            old_end_at = suspension.end_at
+            with pgtrigger.ignore("approvals.Suspension:update_approval_end_at"):
+                suspension.end_at = approval.end_at
+                suspension.updated_by = None
+                suspension.save(update_fields=["end_at", "updated_at", "updated_by"])
+            log_string = (
+                "raccourcissement d'une suspension finissant après la fin du PASS"
+                f" (sans modifier la date de fin du PASS): suspension={suspension.pk} old_end_at={old_end_at}"
+                f" new_end_at={suspension.end_at}"
+            )
+            add_support_remark_to_obj(
+                approval,
+                f"------------------------\n{timezone.localtime().replace(microsecond=0)} (automatique): {log_string}",
+            )
+            self.stdout.write(log_string)
+
+    @dry_runnable
+    def handle(self, *args, **options):
+        self.fix_prolongations_ending_after()
+        self.fix_suspensions_starting_after()
+        self.fix_suspensions_ending_after()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Au lieu de nous en informer tous les jours et de les traiter occasionnellement en batch, autant le faire au fil de l'eau.

L'alternative est de le faire automatiquement lors de la modification d'un PASS IAE ou d'une prolongation/suspension dans l'admin.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
