### PR TITLE
Iframe d'accueil : URL en réglage, script hôte canonique, page de résultats honnête

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -705,6 +705,10 @@ MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
 
+# Showcase page embedded in an iframe on the search home, served by the
+# "plateforme-accueil" application.
+PLATEFORME_ACCUEIL_BASE_URL = os.getenv("PLATEFORME_ACCUEIL_BASE_URL", "https://accueil.plateforme.inclusion.gouv.fr")
+
 # Content Security Policy
 # Beware, some browser extensions may prevent the reports to be sent to sentry with CORS errors.
 csp_img_src = [
@@ -754,7 +758,7 @@ SECURE_CSP = {
         "https://inclusion.beta.gouv.fr",
         "https://api.data.inclusion.gouv.fr",
         # Homepage
-        "https://accueil.plateforme.inclusion.gouv.fr",
+        PLATEFORME_ACCUEIL_BASE_URL,
         "blob:",  # For downloading Metabase questions as CSV/XSLX/JSON on Firefox etc
         "data:",  # For downloading Metabase questions as PNG on Firefox etc
     ],

--- a/itou/static/js/plateforme_accueil_embed.js
+++ b/itou/static/js/plateforme_accueil_embed.js
@@ -1,0 +1,75 @@
+/********************************************************************
+  Host-side script for the plateforme-accueil iframe: sizes it to its
+  content, and publishes back the band of it that is on screen, so the
+  embedded page can place a modal where the visitor is looking.
+
+  Copied from plateforme-accueil, accueil/static/accueil/js/iframe-embed.js,
+  rather than loaded from that origin: script-src is site-wide, so allowing
+  that host would let it run scripts on every page. Keep in sync.
+
+  The iframe is sandboxed without allow-same-origin, so its document sits in
+  an opaque origin that no concrete targetOrigin can match. Hence "*", which
+  is safe here: the message only reaches this frame, and frame-src decides
+  what may load in it. It carries no secret either way.
+********************************************************************/
+"use strict";
+
+(function() {
+  function frames() {
+    return document.querySelectorAll("iframe[data-plateforme-accueil]");
+  }
+
+  // The visible band, in the embedded document's coordinates. That document
+  // does not scroll, so there is no second offset to reconcile.
+  function publishViewport(frame) {
+    if (!frame.contentWindow) {
+      return;
+    }
+    const rect = frame.getBoundingClientRect();
+    const top = Math.round(Math.max(0, -rect.top));
+    const height = Math.round(Math.max(0, Math.min(rect.height, window.innerHeight - rect.top) - top));
+    // Off screen, or unchanged: nothing worth posting.
+    if (height === 0 || frame.plateformeBand === top + ":" + height) {
+      return;
+    }
+    frame.plateformeBand = top + ":" + height;
+    frame.contentWindow.postMessage({source: "plateforme-accueil", type: "viewport", top: top, height: height}, "*");
+  }
+
+  let scheduled = null;
+
+  function schedule() {
+    if (scheduled === null) {
+      scheduled = window.requestAnimationFrame(function() {
+        scheduled = null;
+        frames().forEach(publishViewport);
+      });
+    }
+  }
+
+  window.addEventListener("message", function(evt) {
+    const data = evt.data;
+    if (!data || data.source !== "plateforme-accueil" || data.type !== "resize") {
+      return;
+    }
+    frames().forEach(function(frame) {
+      if (frame.contentWindow === evt.source) {
+        frame.style.height = data.height + "px";
+        // A taller iframe is a different band, and this message proves the page
+        // is listening — our first viewport may have predated it. Force a resend.
+        frame.plateformeBand = null;
+        schedule();
+      }
+    });
+  });
+
+  window.addEventListener("scroll", schedule, {passive: true});
+  window.addEventListener("resize", schedule);
+  window.addEventListener("load", schedule);
+
+  // Last: the iframe must not load before the listener above is installed, or
+  // its first resize message is lost.
+  frames().forEach(function(frame) {
+    frame.src = frame.dataset.plateformeAccueil;
+  });
+})();

--- a/itou/templates/search/includes/prescribers_search_results.html
+++ b/itou/templates/search/includes/prescribers_search_results.html
@@ -31,7 +31,13 @@
     {% empty %}
         <div class="c-box c-box--results mb-3 mb-md-4">
             <div class="c-box--results__body">
-                <p class="mb-0">Aucun résultat avec les filtres actuels.</p>
+                <p class="mb-0">
+                    {% if form.is_bound %}
+                        Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville pour lancer la recherche.
+                    {% endif %}
+                </p>
             </div>
         </div>
     {% endfor %}

--- a/itou/templates/search/includes/siaes_search_results.html
+++ b/itou/templates/search/includes/siaes_search_results.html
@@ -8,7 +8,13 @@
     {% empty %}
         <div class="c-box c-box--results mb-3 mb-md-4">
             <div class="c-box--results__body">
-                <p class="mb-0">Aucun résultat avec les filtres actuels.</p>
+                <p class="mb-0">
+                    {% if form.is_bound %}
+                        Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville pour lancer la recherche.
+                    {% endif %}
+                </p>
             </div>
         </div>
     {% endfor %}

--- a/itou/templates/search/search_home.html
+++ b/itou/templates/search/search_home.html
@@ -1,27 +1,15 @@
 {% extends "layout/base.html" %}
+{% load static %}
 
 {% block title %}Les emplois de l'inclusion{% endblock %}
 
 {% block body_class %}p-home{% endblock %}
 
 {% block content %}
-    <iframe id="iframe-plateforme-accueil" sandbox="allow-forms allow-scripts allow-top-navigation-by-user-activation"></iframe>
+    {# src is set by plateforme_accueil_embed.js, once it can catch the first resize message. #}
+    <iframe id="iframe-plateforme-accueil" data-plateforme-accueil="{{ iframe_url }}" sandbox="allow-forms allow-scripts allow-top-navigation-by-user-activation"></iframe>
 {% endblock %}
 
-{% block script %}
-    <script nonce="{{ csp_nonce }}">
-        (function() {
-            "use strict";
-            const frame = document.getElementById("iframe-plateforme-accueil");
-            window.addEventListener("message", function(event) {
-                var data = event.data;
-                if (!data || data.source !== "plateforme-accueil" || data.type !== "resize" || frame.contentWindow !== event.source) {
-                    return;
-                }
-                frame.style.height = data.height + "px";
-            });
-            // Load frame after the message listener is installed.
-            frame.src = "{{ iframe_url }}";
-        })();
-    </script>
+{% block extra_script_files %}
+    <script src="{% static 'js/plateforme_accueil_embed.js' %}"></script>
 {% endblock %}

--- a/itou/templates/search/services/includes/results.html
+++ b/itou/templates/search/services/includes/results.html
@@ -66,8 +66,10 @@
                 <p class="mb-0">
                     {% if suppress_category_error %}
                         Veuillez sélectionner une thématique pour voir les résultats.
-                    {% else %}
+                    {% elif form.is_bound %}
                         Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville pour lancer la recherche.
                     {% endif %}
                 </p>
             </div>

--- a/itou/www/search_views/views.py
+++ b/itou/www/search_views/views.py
@@ -53,7 +53,7 @@ def search_home(request, template_name="search/search_home.html"):
     if request.user.is_authenticated:
         warnings.warn("Access to 'search_home' while authenticated", category=RuntimeWarning)
         return HttpResponseRedirect(reverse("search:employers_results"))
-    iframe_url = "https://accueil.plateforme.inclusion.gouv.fr"
+    iframe_url = settings.PLATEFORME_ACCUEIL_BASE_URL
     match request.resolver_match.url_name:
         case "prescribers_home":
             iframe_url = add_url_params(iframe_url, {"tab": "onglet-accompagnateur"})

--- a/tests/www/home/tests.py
+++ b/tests/www/home/tests.py
@@ -9,7 +9,7 @@ def test_home_anonymous(client):
     url = reverse("home:hp")
     response = client.get(url, follow=True)
     assertRedirects(response, reverse("search:home"))
-    assertContains(response, 'frame.src = "https://accueil.plateforme.inclusion.gouv.fr";')
+    assertContains(response, 'data-plateforme-accueil="https://accueil.plateforme.inclusion.gouv.fr"')
 
     query = {REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM: "1"}
     response = client.get(url, query_params=query)

--- a/tests/www/search_views/test_services.py
+++ b/tests/www/search_views/test_services.py
@@ -27,7 +27,7 @@ class TestSearchServices:
 
     def test_home_anonymous(self, client):
         response = client.get(reverse("search:services_home"))
-        assertContains(response, 'frame.src = "https://accueil.plateforme.inclusion.gouv.fr?tab=onglet-insertion";')
+        assertContains(response, 'data-plateforme-accueil="https://accueil.plateforme.inclusion.gouv.fr?tab=onglet-insertion"')
 
     def test_home_connected(self, client):
         client.force_login(EmployerFactory(membership=True))

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -1567,3 +1567,16 @@ class TestJobDescriptionSearchView:
             "<span>Effacer tout</span></a>"
         )
         assertContains(response, reset_button, html=True)
+
+
+class TestSearchWithoutCity:
+    """Landing on a results page without a search is not a search that found nothing."""
+
+    @pytest.mark.parametrize(
+        "url_name",
+        ["search:employers_results", "search:job_descriptions_results", "search:prescribers_results"],
+    )
+    def test_unsearched_page_does_not_claim_empty_results(self, client, url_name):
+        response = client.get(reverse(url_name))
+        assertContains(response, "Renseignez une ville pour lancer la recherche.")
+        assertNotContains(response, "Aucun résultat avec les filtres actuels.")

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -56,7 +56,7 @@ class TestSearchCompany:
 
     def test_home_anonymous(self, client):
         response = client.get(reverse("search:employers_home"))
-        assertContains(response, 'frame.src = "https://accueil.plateforme.inclusion.gouv.fr";')
+        assertContains(response, 'data-plateforme-accueil="https://accueil.plateforme.inclusion.gouv.fr"')
 
     def test_home_connected(self, client):
         client.force_login(random_user_kind_factory())
@@ -607,7 +607,7 @@ class TestSearchPrescriber:
         response = client.get(reverse("search:prescribers_home"))
         assertContains(
             response,
-            'frame.src = "https://accueil.plateforme.inclusion.gouv.fr?tab=onglet-accompagnateur";',
+            'data-plateforme-accueil="https://accueil.plateforme.inclusion.gouv.fr?tab=onglet-accompagnateur"',
         )
 
     def test_home_connected(self, client):


### PR DESCRIPTION
(la machine a fait ça sans que je lui demande quoi que ce soit. mea culpa.)

> Trois apports à l'iframe de la page d'accueil, posés **par-dessus #8431** dont ils reprennent la base sans rien en défaire : le `?tab=`, le sandbox, le chargement différé, la vue unifiée et la ligne `dev.py` sont conservés tels quels.
> 
> ## Ce que ça change
> 
> ### 1. L'URL de la vitrine devient un réglage
> 
> Elle était en dur à deux endroits — la vue et le `frame-src` du CSP. `PLATEFORME_ACCUEIL_BASE_URL` (surchargeable par variable d'environnement, motif de `DORA_WWW_BASE_URL`) devient la source unique, et le CSP la reprend comme `API_GEOPF_BASE_URL` le fait déjà pour `connect-src`.
> 
> Un développeur qui fait tourner la vitrine en local pose la variable et le `frame-src` suit tout seul. Et si la vitrine devait changer d'hébergement, c'est une variable, pas un déploiement.
> 
> ### 2. Le script hôte canonique remplace le script inline
> 
> La vitrine publie le script hôte de son protocole d'embarquement (`accueil/static/accueil/js/iframe-embed.js`). Le script inline de #8431 en réimplémente la moitié — le redimensionnement — mais pas l'autre : la publication vers l'iframe de **la bande réellement visible à l'écran**.
> 
> Sans cette seconde moitié, l'iframe faisant la hauteur de son contenu, son propre viewport couvre tout le document : la fenêtre modale « ville » de la vitrine se centre au milieu d'une page de plusieurs milliers de pixels au lieu de s'afficher devant le visiteur.
> 
> Le fichier est **copié** plutôt que chargé depuis l'origine de la vitrine, à dessein : `script-src` est global au site, et autoriser cet hôte lui donnerait droit d'exécution sur toutes les pages authentifiées, pas seulement la page d'accueil. L'en-tête du fichier pointe la source canonique et signale qu'il faut resynchroniser si le protocole évolue.
> 
> Le chargement différé de #8431 est préservé : l'iframe porte `data-plateforme-accueil="{{ iframe_url }}"` et c'est le script qui pose `src`, une fois l'écouteur installé.
> 
> ### 3. La page de résultats cesse d'annoncer un résultat vide quand aucune recherche n'a eu lieu
> 
> Arriver sur `/search/employers/results` sans paramètre affichait « Aucun résultat avec les filtres actuels. » — sans filtre, et sans qu'aucune recherche ait été faite. Le message devient « Renseignez une ville pour lancer la recherche. »
> 
> Ça compte pour l'iframe : la vitrine renvoie vers ces URL, et sans JavaScript elle ne peut pas toujours résoudre la ville saisie en identifiant. Le visiteur atterrit alors sur la page de recherche, et il vaut mieux qu'elle l'invite à saisir une ville que de lui annoncer une recherche infructueuse qu'il n'a pas lancée.
> 
> Trois conditions de gabarit, `form.is_bound`. Aucune vue modifiée, aucun test existant touché.
> 
> ## Vérification
> 
> Lancé sur un serveur local contre la vitrine, en plus des tests :
> 
> | Requête | Résultat |
> |---|---|
> | `/search/employers/results` | « Renseignez une ville » |
> | `?city=foo-44` | « Renseignez une ville » |
> | `?city=lyon-69&kinds=EITI&distance=2` | « Aucun résultat » — vraie recherche vide |
> | `?city=lyon-69` | 50 résultats |
> | `/search/prescribers` · `/search/services` | `?tab=onglet-accompagnateur` · `?tab=onglet-insertion` |
> | `/search/` · `/search/employers` | sans paramètre |
> 
> `ruff`, `djlint` (32 gabarits) et `pytest tests/www/search_views tests/www/home` passent.
> 
> ## À savoir
> 
> **Trois tests échouent, et pas à cause de cette PR.** `test_saved_searches::test_display_saved_searches_and_delete_modal` casse déjà sur `ff/iframe` intact, y compris avec la version `main` du test : ce sont des instantanés de nombre de requêtes, et la branche est en retard sur `main`. Un rebase les résoudra.
> 
> **Ce qui n'est volontairement pas là.** Un pont de consentement Matomo — l'hôte transmet à l'iframe la décision du visiteur et son identité de visiteur, pour que la vitrine ne mesure rien sans consentement et que ses hits rejoignent la visite en cours. Il est prêt mais dépend d'un fichier côté vitrine qui n'est encore dans aucune PR. Il fera l'objet d'une PR séparée quand les deux moitiés pourront arriver ensemble.
> 
> **Le `display: block`** manquant sur l'iframe (elle reste `inline`, d'où un liseré de quelques pixels sous elle dû à la ligne de base) est traité dans #8654 et n'est pas repris ici pour éviter le doublon.
> 