### PR TITLE
Tech : améliorations liées à `syrupy` dans notre suite de tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DBDUMP ?= $(CACHEDIR)/development_db.dump
 VIRTUAL_ENV ?= .venv
 export PATH := $(VIRTUAL_ENV)/bin:$(PATH)
 
-.PHONY: runserver venv buckets quality fix compile-deps
+.PHONY: runserver venv buckets quality fix compile-deps update_snapshots
 
 runserver: $(VIRTUAL_ENV)
 	python manage.py runserver $(RUNSERVER_DOMAIN)
@@ -66,6 +66,17 @@ fast_fix: $(VIRTUAL_ENV)
 
 fix: fast_fix
 	djlint --reformat itou
+
+update_snapshots: $(VIRTUAL_ENV)
+	@find tests -name '*.ambr' | sort | while read -r ambr; do \
+		py=$$(printf '%s' "$$ambr" | sed 's#/__snapshots__/#/#; s#\.ambr$$#.py#'); \
+		if [ -f "$$py" ]; then \
+			printf '%s\n' "$$py"; \
+		else \
+			printf '⚠ orphaned snapshot, no test module: %s\n' "$$ambr" >&2; \
+		fi; \
+	done | sort -u | xargs --no-run-if-empty \
+		pytest --snapshot-update --numprocesses=logical
 
 # Django.
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,4 @@ addopts = [
 markers = [
     "no_django_db: mark tests that should not be marked with django_db.",
     "slow: slow tests that are skipped unless pytest is run with `--runslow`",
-    "snapshot: automic mark added to tests using snapshots",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,8 +66,6 @@ def pytest_collection_modifyitems(config, items):
         markers = {marker.name for marker in item.iter_markers()}
         if "no_django_db" not in markers and "django_db" not in markers:
             item.add_marker(pytest.mark.django_db)
-        if "snapshot" in item.fixturenames:
-            item.add_marker(pytest.mark.snapshot)
         if "slow" in markers and not run_slow:
             item.add_marker(skip_slow_marker)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Syrupy 6.0.0 applique désormais automatiquement un marker `syrupy_snapshot` à tous les tests utilisant le fixture `snapshot`. Notre hook maison dans `pytest_collection_modifyitems` faisait exactement la même chose et devenait donc redondant.

Par ailleurs, la mise à jour manuelle des snapshots reposait sur une commande `find | sed | xargs` certes pratique mais fragile et peu intuitive, non compatible avec `pytest-xdist` (cf. [cette discussion](https://gip-inclusion.slack.com/archives/C0412CTV63D/p1775723615176359)). Une mise à jour récente de`syrupy` rend la lib compatible avec `pytest-xdist`, profitons-en.

## :cake: Comment ?

- Suppression du marker snapshot custom et de sa déclaration dans `pyproject.toml` / `conftest.py`, au profit du marker natif `syrupy_snapshot` (sélection via `-m syrupy_snapshot`).
- Ajout d'une target `update_snapshots` au Makefile qui relance chaque module de test possédant un fichier `.ambr` avec `--snapshot-update`, avec parallélisation des tests (`--numprocesses=logical`). Cette règle purge les entrées obsolètes en plus de mettre à jour les snapshots.

## :desert_island: Comment tester ?

Par exemple, supprimer un fichier de tests utilisant des `snapshots` sans supprimer le fichier `.ambr` correspondant, puis lancer `make update_snapshots`.