### PR TITLE
Tech: ajout d'un scope manquant pour l'appel à l'API RQTH

### DIFF
--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -117,6 +117,11 @@ def certify_criterion_with_api_france_travail(criterion):
     criterion.save(update_fields={"last_certification_attempt_at"})
 
     with pole_emploi_agent_api_client() as pe_client:
+        # Predeclare needed scopes to avoid requesting 2 tokens
+        # For rechercher_usager
+        pe_client.needed_scopes |= {"api_rechercheindividucertifiev1", "rechercherIndividuCertifie"}
+        # For rqth
+        pe_client.needed_scopes |= {"api_donnees-rqthv1"}
         user_found = False
         try:
             token = pe_client.rechercher_usager(jobseeker_profile=profile)

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -564,6 +564,7 @@ class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
         return data["jetonUsager"]
 
     def rqth(self, jeton_usager):
+        self.needed_scopes |= {"api_donnees-rqthv1"}
         data = self._request(
             f"{self.base_url}{Endpoints.RQTH}",
             method="GET",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car cela plante depuis https://github.com/gip-inclusion/les-emplois/pull/8607/changes/ea799eef2a67f21b6feaecb069784563ee10b073

Il manque peut-être aussi le scope `h2a` (cf https://github.com/gip-inclusion/les-emplois/commit/eef8119b2715f88f25f8f36803c69affdb9a22e0) mais le site de la documentation de l'API ne se charge pas chez moi...

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
