### PR TITLE
Connexion : Script temporaire pour réinitialiser le 2FA

### DIFF
--- a/itou/scripts/management/commands/reset_2fa.py
+++ b/itou/scripts/management/commands/reset_2fa.py
@@ -1,0 +1,30 @@
+from itoutils.django.commands import dry_runnable
+
+from itou.otp.models import ItouStaticDevice, ItouTOTPDevice
+from itou.users.models import User
+from itou.utils.command import BaseCommand
+
+
+# FIXME (dbaty, 2026-09-01): remove this script once users can request
+# a 2FA reset on their own.
+class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
+    def add_arguments(self, parser):
+        parser.add_argument("email")
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
+
+    @dry_runnable
+    def handle(self, email, **options):
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            print(f"ERROR: {email} cannot be found.")
+            return
+
+        deleted, _ = ItouTOTPDevice.objects.filter(user=user).delete()
+        if not deleted:
+            print(f"ERROR: User {email} has no 2FA device. Double-check email!")
+            return
+        ItouStaticDevice.objects.filter(user=user).delete()
+        self.logger.info("Deleted 2FA device and recovery code for user %s", user.pk)

--- a/tests/otp/factories.py
+++ b/tests/otp/factories.py
@@ -2,8 +2,8 @@ import uuid
 
 import factory
 
-from itou.otp.models import ItouTOTPDevice
-from tests.users.factories import ItouStaffFactory
+from itou.otp.models import ItouStaticDevice, ItouStaticToken, ItouTOTPDevice
+from tests.users.factories import ItouStaffFactory, UserFactory
 
 
 class ItouTOTPDeviceFactory(factory.django.DjangoModelFactory):
@@ -12,3 +12,23 @@ class ItouTOTPDeviceFactory(factory.django.DjangoModelFactory):
 
     user = factory.SubFactory(ItouStaffFactory)
     name = factory.LazyFunction(uuid.uuid4)
+
+
+class ItouStaticDeviceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ItouStaticDevice
+
+    user = factory.SubFactory(UserFactory)
+
+
+class ItouStaticTokenFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ItouStaticToken
+
+    class Params:
+        user = factory.SubFactory(UserFactory)
+
+    device = factory.SubFactory(
+        ItouStaticDeviceFactory,
+        user=factory.SelfAttribute("..user"),
+    )

--- a/tests/scripts/test_reset_2fa.py
+++ b/tests/scripts/test_reset_2fa.py
@@ -1,0 +1,28 @@
+from io import StringIO
+
+from django.core import management
+
+from itou.otp.models import ItouStaticDevice, ItouStaticToken, ItouTOTPDevice
+from tests.otp.factories import ItouStaticTokenFactory, ItouTOTPDeviceFactory
+from tests.users.factories import ItouStaffFactory
+
+
+def run_command(*args, **kwargs):
+    out = StringIO()
+    err = StringIO()
+
+    management.call_command("reset_2fa", *args, stdout=out, stderr=err, **kwargs)
+
+    return out.getvalue(), err.getvalue()
+
+
+def test_reset_2fa():
+    user = ItouStaffFactory()
+    ItouTOTPDeviceFactory(user=user)
+    ItouStaticTokenFactory(user=user)
+
+    run_command(user.email, "--wet-run")
+
+    assert ItouTOTPDevice.objects.count() == 0
+    assert ItouStaticToken.objects.count() == 0
+    assert ItouStaticDevice.objects.count() == 0


### PR DESCRIPTION
Pour l'instant, on n'a pas de parcours permettant à un utilisateur de réinitialiser son 2FA. En attendant ([cette carte Notion](https://app.notion.com/p/gip-inclusion/R-initialisation-du-2FA-3b95f321b604803b96dcfe571d46330b)), voici le script que j'utilise  (après diverses vérifications) pour supprimer le matériel 2FA enrôlé **et** le code de récupération.