### PR TITLE
Pilotage : ajouts de champs liés aux candidatures dans Metabase

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -86,6 +86,20 @@ def log_retry_attempt(retry_state):
     logging.info("Attempt failed with outcome=%s", retry_state.outcome)
 
 
+def first_transition_timestamp(**filters):
+    """Timestamp of the outer job application's first transition matching `filters`."""
+    return (
+        JobApplicationTransitionLog.objects.filter(job_application=OuterRef("pk"), **filters)
+        .values("job_application")
+        .annotate(first_timestamp=Min("timestamp"))
+        .values("first_timestamp")
+    )
+
+
+def time_spent_from_new_to(**filters):
+    return Subquery(first_transition_timestamp(**filters)) - F("created_at")
+
+
 class Command(BaseCommand):
     help = "Populate metabase database."
 
@@ -471,33 +485,15 @@ class Command(BaseCommand):
             .exclude(origin=Origin.PE_APPROVAL)
             .filter(to_company_id__in=Company.objects.active())
             .annotate(
-                transition_accepted_date=JobApplicationTransitionLog.objects.filter(
-                    job_application=OuterRef("pk"),
-                    transition=JobApplicationWorkflow.TRANSITION_ACCEPT,
-                )
-                .values("job_application")
-                .annotate(first_timestamp=Min("timestamp"))
-                .values("first_timestamp"),
-                time_spent_from_new_to_processing=Subquery(
-                    JobApplicationTransitionLog.objects.filter(
-                        job_application=OuterRef("pk"),
-                        transition=JobApplicationWorkflow.TRANSITION_PROCESS,
-                    )
-                    .values("job_application")
-                    .annotate(first_timestamp=Min("timestamp"))
-                    .values("first_timestamp")
-                )
-                - F("created_at"),
-                time_spent_from_new_to_accepted_or_refused=Subquery(
-                    JobApplicationTransitionLog.objects.filter(
-                        job_application=OuterRef("pk"),
-                        to_state__in=[JobApplicationState.ACCEPTED, JobApplicationState.REFUSED],
-                    )
-                    .values("job_application")
-                    .annotate(first_timestamp=Min("timestamp"))
-                    .values("first_timestamp")
-                )
-                - F("created_at"),
+                transition_accepted_date=first_transition_timestamp(
+                    transition=JobApplicationWorkflow.TRANSITION_ACCEPT
+                ),
+                time_spent_from_new_to_processing=time_spent_from_new_to(
+                    transition=JobApplicationWorkflow.TRANSITION_PROCESS
+                ),
+                time_spent_from_new_to_accepted_or_refused=time_spent_from_new_to(
+                    to_state__in=[JobApplicationState.ACCEPTED, JobApplicationState.REFUSED]
+                ),
             )
             .only(
                 "archived_at",

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -22,6 +22,7 @@ import tenacity
 from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, F, Max, Min, OuterRef, Prefetch, Q, Subquery
+from django.db.models.functions import JSONObject
 from django.utils import timezone
 
 import itou.metabase.db as metabase_db
@@ -37,7 +38,7 @@ from itou.geiq_assessments.models import Assessment, AssessmentInstitutionLink, 
 from itou.insertion.models import MobilizationEvent
 from itou.institutions.models import Institution, InstitutionMembership
 from itou.job_applications.enums import JobApplicationState, Origin, RefusalReason, SenderKind
-from itou.job_applications.models import JobApplication, JobApplicationTransitionLog, JobApplicationWorkflow
+from itou.job_applications.models import JobApplication, JobApplicationTransitionLog
 from itou.jobs.models import Rome
 from itou.metabase.dataframes import get_df_from_rows, store_df
 from itou.metabase.tables import (
@@ -86,18 +87,35 @@ def log_retry_attempt(retry_state):
     logging.info("Attempt failed with outcome=%s", retry_state.outcome)
 
 
-def first_transition_timestamp(**filters):
-    """Timestamp of the outer job application's first transition matching `filters`."""
-    return (
-        JobApplicationTransitionLog.objects.filter(job_application=OuterRef("pk"), **filters)
+def first_transition_timestamps():
+    """First transitions described by FIRST_TRANSITION_FILTERS, aggregated into a single JSON object.
+
+    Filtered aggregates in a single subquery avoid walking the (job_application_id) index once per annotation.
+
+    Example for a single job application:
+    {
+        "processing": "2026-03-01T10:00:00+00:00",
+        "postponed": None,
+        "accepted": "2026-03-05T14:22:00+00:00",
+        "refused": None,
+        "cancelled": None,
+        ...
+        "process_transition": "2026-03-01T10:00:00+00:00",
+    }
+    """
+    return Subquery(
+        JobApplicationTransitionLog.objects.filter(job_application=OuterRef("pk"))
         .values("job_application")
-        .annotate(first_timestamp=Min("timestamp"))
-        .values("first_timestamp")
+        .annotate(
+            timestamps=JSONObject(
+                **{
+                    key: Min("timestamp", filter=Q(**filters))
+                    for key, filters in job_applications.FIRST_TRANSITION_FILTERS.items()
+                }
+            )
+        )
+        .values("timestamps")
     )
-
-
-def time_spent_from_new_to(**filters):
-    return Subquery(first_transition_timestamp(**filters)) - F("created_at")
 
 
 class Command(BaseCommand):
@@ -484,17 +502,7 @@ class Command(BaseCommand):
             )
             .exclude(origin=Origin.PE_APPROVAL)
             .filter(to_company_id__in=Company.objects.active())
-            .annotate(
-                transition_accepted_date=first_transition_timestamp(
-                    transition=JobApplicationWorkflow.TRANSITION_ACCEPT
-                ),
-                time_spent_from_new_to_processing=time_spent_from_new_to(
-                    transition=JobApplicationWorkflow.TRANSITION_PROCESS
-                ),
-                time_spent_from_new_to_accepted_or_refused=time_spent_from_new_to(
-                    to_state__in=[JobApplicationState.ACCEPTED, JobApplicationState.REFUSED]
-                ),
-            )
+            .annotate(first_transition_timestamps=first_transition_timestamps())
             .only(
                 "archived_at",
                 "refusal_reason",

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -1,7 +1,9 @@
 from operator import attrgetter
 
+from django.utils.dateparse import parse_datetime
+
 from itou.job_applications.enums import JobApplicationState, Origin, RefusalReason, SenderKind
-from itou.job_applications.models import JobApplication
+from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.metabase.tables.utils import (
     MetabaseTable,
     get_choice,
@@ -77,6 +79,54 @@ def get_ja_sender_full_name_if_pe_or_spip(ja):
     return None
 
 
+FIRST_TRANSITION_FILTERS = {
+    **{
+        state.value: {"to_state": state}
+        for state in [state for state in JobApplicationState if state != JobApplicationState.NEW]
+    },
+    # Legacy, kept as is for the existing Metabase dashboards. This is the only transition based filter
+    # that is not redundant with a state based one: an application going NEW -> PRIOR_TO_HIRE -> PROCESSING
+    # never invokes `process`. See also `test_populate_job_applications_legacy_delays`.
+    "process_transition": {"transition": JobApplicationWorkflow.TRANSITION_PROCESS},
+}
+
+
+def _get_first_transition_timestamp(job_application, key):
+    # first_transition_timestamps is None when the job application has no transition log at all,
+    # and a given key is null when none of the logged transitions matched its filter
+    if timestamps := job_application.first_transition_timestamps:
+        if timestamp := timestamps[key]:
+            return parse_datetime(timestamp)
+    return None
+
+
+def _get_first_transition_delay(job_application, *keys):
+    """Delay from the job application creation to the earliest of its first transitions matching `keys`."""
+    timestamps = [
+        timestamp for key in keys if (timestamp := _get_first_transition_timestamp(job_application, key)) is not None
+    ]
+    return min(timestamps) - job_application.created_at if timestamps else None
+
+
+def first_transition_delay_column(state):
+    column_name = state.label.lower().replace("'", "_").replace("’", "_").replace(" ", "_")
+    comment = (
+        "Temps écoulé entre la création de la candidature et son premier passage"
+        f" par l'état « {state.label} », si elle est passée par cet état"
+    )
+    if state == JobApplicationState.REFUSED:
+        comment += (
+            ". Inclut les refus automatiques, qui ne sont pas une action de l'employeur :"
+            " filtrer sur candidature_refusée_automatiquement pour les exclure"
+        )
+    return {
+        "name": f"délai_{column_name}",
+        "type": "interval",
+        "comment": comment,
+        "fn": lambda o: _get_first_transition_delay(o, state.value),
+    }
+
+
 TABLE = MetabaseTable(name="candidatures")
 TABLE.add_columns(
     [
@@ -133,22 +183,33 @@ TABLE.add_columns(
             ),
         ),
         {
+            # TODO: mostly redundant with the `délai_candidature_à_l_étude` column generated below, see
+            # FIRST_TRANSITION_FILTERS for the edge case where they differ. Remove once the Metabase
+            # dashboards have been migrated.
             "name": "délai_prise_en_compte",
             "type": "interval",
             "comment": (
                 "Temps écoulé rétroactivement de état nouveau à état étude si la candidature est passée par ces états"
             ),
-            "fn": attrgetter("time_spent_from_new_to_processing"),
+            "fn": lambda o: _get_first_transition_delay(o, "process_transition"),
         },
         {
+            # TODO: redundant with the `délai_candidature_acceptée` and `délai_candidature_déclinée`
+            # columns generated below, remove once the Metabase dashboards have been migrated.
             "name": "délai_de_réponse",
             "type": "interval",
             "comment": (
                 "Temps écoulé rétroactivement de état nouveau à état accepté"
                 " ou refusé si la candidature est passée par ces états"
             ),
-            "fn": attrgetter("time_spent_from_new_to_accepted_or_refused"),
+            "fn": lambda o: _get_first_transition_delay(
+                o, JobApplicationState.ACCEPTED.value, JobApplicationState.REFUSED.value
+            ),
         },
+        *[
+            first_transition_delay_column(state)
+            for state in [state for state in JobApplicationState if state != JobApplicationState.NEW]
+        ],
         {
             "name": "motif_de_refus",
             "type": "varchar",
@@ -222,7 +283,7 @@ TABLE.add_columns(
             "name": "date_embauche",
             "type": "date",
             "comment": "Date embauche le cas échéant",
-            "fn": attrgetter("transition_accepted_date"),
+            "fn": lambda o: _get_first_transition_timestamp(o, JobApplicationState.ACCEPTED.value),
         },
         {
             "name": "injection_ai",

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
@@ -4871,7 +4871,7 @@
 # ---
 # name: test_populate_job_applications
   dict({
-    'num_queries': 44,
+    'num_queries': 52,
     'queries': list([
       dict({
         'origin': list([
@@ -4932,7 +4932,7 @@
         ]),
         'sql': '''
           CREATE TABLE IF NOT EXISTS "z_new_candidatures" ("id" UUID,
-                                                                "candidature_archivee" integer,"candidature_refusée_automatiquement" integer,"date_candidature" date,"date_début_contrat" date,"date_traitement" date,"état" varchar,"origine" varchar,"origine_détaillée" varchar,"origine_id_structure" integer,"parcours_de_création" varchar,"délai_prise_en_compte" interval,"délai_de_réponse" interval,"motif_de_refus" varchar,"id_candidat" integer,"id_structure" integer,"type_structure" varchar,"nom_structure" varchar,"nom_complet_structure" varchar,"département_structure" varchar,"nom_département_structure" varchar,"région_structure" varchar,"id_org_prescripteur" integer,"nom_org_prescripteur" varchar,"safir_org_prescripteur" varchar,"nom_prénom_conseiller" varchar,"id_utilisateur_origine_candidature" integer,"date_embauche" date,"injection_ai" integer,"mode_attribution_pass_iae" varchar,"type_contrat" varchar,"présence_de_cv" integer,"nombre_caracteres_message_candidature" integer,"date_mise_à_jour_metabase" date)
+                                                                "candidature_archivee" integer,"candidature_refusée_automatiquement" integer,"date_candidature" date,"date_début_contrat" date,"date_traitement" date,"état" varchar,"origine" varchar,"origine_détaillée" varchar,"origine_id_structure" integer,"parcours_de_création" varchar,"délai_prise_en_compte" interval,"délai_de_réponse" interval,"délai_candidature_à_l_étude" interval,"délai_candidature_en_attente" interval,"délai_action_préalable_à_l_embauche" interval,"délai_candidature_acceptée" interval,"délai_candidature_déclinée" interval,"délai_embauche_annulée" interval,"délai_embauché_ailleurs" interval,"délai_vivier_de_candidatures" interval,"motif_de_refus" varchar,"id_candidat" integer,"id_structure" integer,"type_structure" varchar,"nom_structure" varchar,"nom_complet_structure" varchar,"département_structure" varchar,"nom_département_structure" varchar,"région_structure" varchar,"id_org_prescripteur" integer,"nom_org_prescripteur" varchar,"safir_org_prescripteur" varchar,"nom_prénom_conseiller" varchar,"id_utilisateur_origine_candidature" integer,"date_embauche" date,"injection_ai" integer,"mode_attribution_pass_iae" varchar,"type_contrat" varchar,"présence_de_cv" integer,"nombre_caracteres_message_candidature" integer,"date_mise_à_jour_metabase" date)
         ''',
       }),
       dict({
@@ -5090,6 +5090,102 @@
           'Command.execute[itoutils/django/commands.py]',
         ]),
         'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_de_réponse" IS \'Temps écoulé rétroactivement de état nouveau à état accepté ou refusé si la candidature est passée par ces états\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_candidature_à_l_étude" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Candidature à l\'\'étude », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_candidature_en_attente" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Candidature en attente », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_action_préalable_à_l_embauche" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Action préalable à l’embauche », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_candidature_acceptée" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Candidature acceptée », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_candidature_déclinée" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Candidature déclinée », si elle est passée par cet état. Inclut les refus automatiques, qui ne sont pas une action de l\'\'employeur : filtrer sur candidature_refusée_automatiquement pour les exclure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_embauche_annulée" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Embauche annulée », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_embauché_ailleurs" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Embauché ailleurs », si elle est passée par cet état\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.populate[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_vivier_de_candidatures" IS \'Temps écoulé entre la création de la candidature et son premier passage par l\'\'état « Vivier de candidatures », si elle est passée par cet état\'',
       }),
       dict({
         'origin': list([
@@ -5372,24 +5468,19 @@
                  "job_applications_jobapplication"."processed_at",
                  "job_applications_jobapplication"."contract_type",
           
-            (SELECT MIN(U0."timestamp") AS "first_timestamp"
+            (SELECT JSON_OBJECT(((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                               WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                           WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                       WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                   WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                                                                                               WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                           WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   WHERE (U0."to_state" = %s)), ((%s)::text) VALUE MIN(U0."timestamp") FILTER (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               WHERE (U0."transition" = %s)) RETURNING JSONB) AS "timestamps"
              FROM "job_applications_jobapplicationtransitionlog" U0
-             WHERE (U0."job_application_id" = ("job_applications_jobapplication"."id")
-                    AND U0."transition" = %s)
-             GROUP BY U0."job_application_id") AS "transition_accepted_date",
-                 (
-                    (SELECT MIN(U0."timestamp") AS "first_timestamp"
-                     FROM "job_applications_jobapplicationtransitionlog" U0
-                     WHERE (U0."job_application_id" = ("job_applications_jobapplication"."id")
-                            AND U0."transition" = %s)
-                     GROUP BY U0."job_application_id") - "job_applications_jobapplication"."created_at") AS "time_spent_from_new_to_processing",
-                 (
-                    (SELECT MIN(U0."timestamp") AS "first_timestamp"
-                     FROM "job_applications_jobapplicationtransitionlog" U0
-                     WHERE (U0."job_application_id" = ("job_applications_jobapplication"."id")
-                            AND U0."to_state" IN (%s,
-                                                  %s))
-                     GROUP BY U0."job_application_id") - "job_applications_jobapplication"."created_at") AS "time_spent_from_new_to_accepted_or_refused",
+             WHERE U0."job_application_id" = ("job_applications_jobapplication"."id")
+             GROUP BY U0."job_application_id") AS "first_transition_timestamps",
                  "users_user"."id",
                  "users_user"."first_name",
                  "users_user"."last_name",
@@ -5476,6 +5567,14 @@
                                      "parcours_de_création",
                                      "délai_prise_en_compte",
                                      "délai_de_réponse",
+                                     "délai_candidature_à_l_étude",
+                                     "délai_candidature_en_attente",
+                                     "délai_action_préalable_à_l_embauche",
+                                     "délai_candidature_acceptée",
+                                     "délai_candidature_déclinée",
+                                     "délai_embauche_annulée",
+                                     "délai_embauché_ailleurs",
+                                     "délai_vivier_de_candidatures",
                                      "motif_de_refus",
                                      "id_candidat",
                                      "id_structure",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -22,8 +22,9 @@ from itou.geo.utils import coords_to_geometry
 from itou.insertion.enums import MobilizationEventKind
 from itou.institutions.enums import InstitutionKind
 from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplicationTransitionLog, JobApplicationWorkflow
 from itou.jobs.models import Rome
-from itou.metabase.tables import geiq_assessments, mobilization_events
+from itou.metabase.tables import geiq_assessments, job_applications, mobilization_events
 from itou.metabase.tables.utils import hash_content
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import KIND_EMPLOYER, KIND_PRESCRIBER, IdentityProvider
@@ -545,9 +546,17 @@ def test_populate_job_applications(snapshot):
                 "Employeur GEIQ",
                 ja.sender_company.pk,
                 "default",
-                None,
-                None,
-                None,
+                None,  # délai_prise_en_compte
+                None,  # délai_de_réponse
+                None,  # délai_candidature_à_l_étude
+                None,  # délai_candidature_en_attente
+                None,  # délai_action_préalable_à_l_embauche
+                None,  # délai_candidature_acceptée
+                None,  # délai_candidature_déclinée
+                None,  # délai_embauche_annulée
+                None,  # délai_embauché_ailleurs
+                None,  # délai_vivier_de_candidatures
+                None,  # motif_de_refus
                 ja.job_seeker_id,
                 ja.to_company_id,
                 ja.to_company.kind,
@@ -584,6 +593,97 @@ def test_populate_job_applications(snapshot):
                 datetime.date(2023, 2, 2),
             ),
         ]
+
+
+@freeze_time("2023-03-02")
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "state", [state for state in JobApplicationState if state != JobApplicationState.NEW], ids=str
+)
+def test_populate_job_applications_first_transition_delays(state):
+    created_at = datetime.datetime(2023, 1, 2, tzinfo=datetime.UTC)
+    job_application = JobApplicationFactory(sent_by_prescriber_alone=True, created_at=created_at, state=state)
+    for days in [10, 20]:  # Only the first transition to a given state should count
+        JobApplicationTransitionLog.objects.create(
+            job_application=job_application,
+            to_state=state,
+            timestamp=created_at + datetime.timedelta(days=days),
+        )
+
+    management.call_command("populate_metabase_emplois", mode="job_applications")
+
+    columns = [
+        job_applications.first_transition_delay_column(s)["name"]
+        for s in [state for state in JobApplicationState if state != JobApplicationState.NEW]
+    ]
+    with connection.cursor() as cursor:
+        cursor.execute(f"SELECT {', '.join(f'"{column}"' for column in columns)} FROM candidatures")
+        [row] = cursor.fetchall()
+
+    expected_column = job_applications.first_transition_delay_column(state)["name"]
+    assert dict(zip(columns, row, strict=True)) == {
+        column: datetime.timedelta(days=10) if column == expected_column else None for column in columns
+    }
+
+
+@freeze_time("2026-03-02")
+@pytest.mark.django_db(transaction=True)
+def test_populate_job_applications_legacy_delays():
+    """`délai_prise_en_compte` filters on the `process` transition, not on the PROCESSING state.
+
+    The two are not perfectly interchangeable: `cancel_prior_to_hire` also lands on PROCESSING, so an application
+    going NEW -> PRIOR_TO_HIRE -> PROCESSING reaches that state without the employer ever invoking `process`.
+    The legacy column stays empty there while `délai_candidature_à_l_étude` is filled, which is why the
+    `process_transition` key is kept in FIRST_TRANSITION_FILTERS.
+    """
+    created_at = datetime.datetime(2023, 1, 2, tzinfo=datetime.UTC)
+    job_application = JobApplicationFactory(
+        sent_by_prescriber_alone=True, created_at=created_at, state=JobApplicationState.ACCEPTED
+    )
+    for days, transition, from_state, to_state in [
+        (
+            5,
+            JobApplicationWorkflow.TRANSITION_MOVE_TO_PRIOR_TO_HIRE,
+            JobApplicationState.NEW,
+            JobApplicationState.PRIOR_TO_HIRE,
+        ),
+        (
+            10,
+            JobApplicationWorkflow.TRANSITION_CANCEL_PRIOR_TO_HIRE,
+            JobApplicationState.PRIOR_TO_HIRE,
+            JobApplicationState.PROCESSING,
+        ),
+        (
+            40,
+            JobApplicationWorkflow.TRANSITION_ACCEPT,
+            JobApplicationState.PROCESSING,
+            JobApplicationState.ACCEPTED,
+        ),
+    ]:
+        JobApplicationTransitionLog.objects.create(
+            job_application=job_application,
+            transition=transition,
+            from_state=from_state,
+            to_state=to_state,
+            timestamp=created_at + datetime.timedelta(days=days),
+        )
+
+    management.call_command("populate_metabase_emplois", mode="job_applications")
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            'SELECT "date_embauche", "délai_prise_en_compte", "délai_de_réponse",'
+            ' "délai_candidature_à_l_étude", "délai_candidature_acceptée" FROM candidatures'
+        )
+        [row] = cursor.fetchall()
+
+    assert row == (
+        datetime.date(2023, 2, 11),  # date_embauche
+        None,  # délai_prise_en_compte: `process` was never invoked
+        datetime.timedelta(days=40),  # délai_de_réponse
+        datetime.timedelta(days=10),  # délai_candidature_à_l_étude
+        datetime.timedelta(days=40),  # délai_candidature_acceptée
+    )
 
 
 @freeze_time("2023-02-02")


### PR DESCRIPTION
## :thinking: Pourquoi ?

La demande initiale (voir [cette carte sur Notion](https://app.notion.com/p/gip-inclusion/Ajouter-une-date-de-traitement-lors-du-changement-de-statut-d-une-candidature-passage-en-attente--32e5f321b6048257add3013121bee40f)) portait sur l'ajout d'une date de traitement lors du passage d'une candidature en statut "en attente" (`/apply/[uuid]/siae/postpone`), afin de pouvoir considérer une candidature "en attente" comme "traitée" dans nos statistiques.

En creusant le sujet, il s'est avéré que corriger la logique de `processed_at` (piste initiale évoquée sur Notion) n'était pas la bonne approche : ce besoin ne vient pas d'un usage réel des utilisateurs de l'app, mais d'un besoin interne à l'équipe data et aux tableaux de bord Metabase. Modifier `processed_at` aurait donc mélangé une notion métier destinée aux utilisateurs avec un besoin de reporting interne, avec pas mal d'effets de bord potentiels, sans bénéfice dans l'app elle-même.

Par ailleurs, après plusieurs échanges avec Pierre, Yannick et Samia, il est apparu que le cas "en attente" n'était pas le seul état manquant côté Metabase : plus généralement, on ne disposait pas du délai de premier passage dans chacun des états d'une candidature (acceptée, déclinée, en attente, ajoutée au vivier de candidatures, etc.), ce qui limitait les analyses possibles sur l'ensemble du cycle de vie d'une candidature.

## :cake: Comment ?

Plutôt que de toucher à `processed_at`, on expose directement dans l'export Metabase (`populate_metabase_emplois`) une colonne de délai pour chaque état de `JobApplicationState` (hors état initial "nouvelle candidature") :

- Ajout de `first_transition_delay_annotation(state)` et `first_transition_delay_column(state)` dans `itou/metabase/tables/job_applications.py`, qui génèrent respectivement le nom d'annotation et la définition de colonne (nom, type, commentaire) pour le délai de premier passage vers un état donné.
- Génération dynamique d'une colonne `délai_<état>` pour chaque état de candidature, avec un commentaire dédié pour l'état "refusée" précisant qu'il inclut les refus automatiques.
- Les colonnes historiques `délai_prise_en_compte` et `délai_de_réponse` sont conservées (avec un commentaire TODO) le temps que les dashboards Metabase existants soient migrés vers les nouvelles colonnes par état.
- Dans un second temps, les sous-requêtes calculant ces délais (une par état) ont été fusionnées en une seule requête utilisant une agrégation JSON, pour éviter la multiplication des sous-requêtes SQL et améliorer les performances de la commande.
- Mise à jour des tests (`test_populate_metabase_emplois.py` et snapshot `.ambr`) pour couvrir ces nouvelles colonnes.