### PR TITLE
Lien vers Tally réparé dans le bandeau de cookies

### DIFF
--- a/itou/templates/includes/tarteaucitron_matomo.html
+++ b/itou/templates/includes/tarteaucitron_matomo.html
@@ -67,7 +67,8 @@
         "key": "tally",
         "type": "other",
         "name": "Tally",
-        "uri": "https://tally.so/help/terms-and-privacy",
+        "uri": "https://tally.so/",
+        "readmoreLink": "https://tally.so/help/terms-and-privacy",
         "needConsent": true,
         "cookies": [],
         "js": function() {


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le lien autogénéré par tarteaucitron pointait sur https://tarteaucitron.io/service/tally/ qui 404.

## :cake: Comment ? <!-- optionnel -->

J'ai mis un lien vers la page d’accueil de Tally à la place.
<!--
## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran
<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Insertion                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Tech                     |
| Interface                | Vie privée               |
+--------------------------|--------------------------+
-->
