### PR TITLE
Interface: Renommage de "Présentation" et de "Voir la liste des organisations conventionnées" dans le menu Organisation

### DIFF
--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -23,9 +23,9 @@
                 {% endif %}
                 {% if card_url %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
+                        <a href="{% url 'prescribers_views:overview' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
                             <i class="ri-eye-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>
-                            <span>Voir la fiche publique</span>
+                            <span>Fiche de présentation</span>
                         </a>
                     </li>
                 {% endif %}
@@ -33,14 +33,14 @@
             <li class="d-flex justify-content-between align-items-center mb-3">
                 <a href="{% url 'prescribers_views:members' %}" class="btn-link btn-ico">
                     <i class="ri-team-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>
-                    <span>Gérer les collaborateurs</span>
+                    <span>Collaborateurs</span>
                 </a>
             </li>
             {% if request.current_organization.kind == PrescriberOrganizationKind.DEPT and request.is_current_organization_admin %}
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'prescribers_views:list_accredited_organizations' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
                         <i class="ri-list-unordered ri-lg ri-lg fw-normal" aria-hidden="true"></i>
-                        <span>Voir la liste des organisations conventionnées</span>
+                        <span>Organisations conventionnées</span>
                     </a>
                 </li>
             {% endif %}

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -12,7 +12,7 @@
             <span class="badge rounded-pill badge-sm bg-primary">ID {{ request.current_organization.id }}</span>
         {% endfragment %}
         {% fragment as list %}
-            {% with card_url=request.current_organization.get_card_url %}
+            {% with has_public_card=request.current_organization.get_card_url %}
                 {% if request.is_current_organization_admin %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'prescribers_views:edit_organization' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
@@ -21,7 +21,7 @@
                         </a>
                     </li>
                 {% endif %}
-                {% if card_url %}
+                {% if has_public_card %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'prescribers_views:overview' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
                             <i class="ri-eye-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -17,7 +17,7 @@
         <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
             <li class="nav-item">
                 <a class="nav-link" href="{% url 'prescribers_views:overview' %}" {% matomo_event "prescribers" "clic" "organisation-presentation" %}>
-                    Présentation
+                    Fiche de présentation
                 </a>
             </li>
             <li class="nav-item">

--- a/itou/templates/prescribers/overview.html
+++ b/itou/templates/prescribers/overview.html
@@ -5,7 +5,7 @@
 {% load matomo %}
 {% load static %}
 
-{% block title %}Présentation {{ block.super }}{% endblock %}
+{% block title %}Fiche de présentation {{ block.super }}{% endblock %}
 
 {% block title_content %}
     {% component_title c_title__main=c_title__main %}
@@ -18,7 +18,7 @@
 {% block title_extra %}
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         <li class="nav-item">
-            <a class="nav-link active" href="{% url 'prescribers_views:overview' %}" {% matomo_event "prescribers" "clic" "organisation-presentation" %}>Présentation</a>
+            <a class="nav-link active" href="{% url 'prescribers_views:overview' %}" {% matomo_event "prescribers" "clic" "organisation-presentation" %}>Fiche de présentation</a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="{% url 'prescribers_views:members' %}" {% matomo_event "prescribers" "clic" "gerer-collaborateurs" %}>Collaborateurs</a>
@@ -34,7 +34,7 @@
                 <div class="s-section__col col-12">
                     <div class="tab-content">
                         <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
-                            <h2 class="mb-0">Présentation</h2>
+                            <h2 class="mb-0">Fiche de présentation</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur l'organisation">
                                 <a class="btn {% if can_edit %}btn-outline-primary{% else %}btn-primary{% endif %} btn-ico"
                                    href="{{ organization.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"

--- a/itou/templates/utils/templatetags/nav.html
+++ b/itou/templates/utils/templatetags/nav.html
@@ -20,7 +20,6 @@
                         {% if menu_group_or_item.is_beta %}
                             {% beta_badge %}
                         {% endif %}
-
                     </span>
                 </button>
                 <div class="collapse{% if menu_group_or_item.active %} show{% endif %}" id="collapse-nav-{{ menu_group_or_item.slug }}">

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -2,6 +2,7 @@ from django import template
 from django.urls import reverse
 from django.utils.text import slugify
 
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.utils.errors import silently_report_exception
 from itou.www.geiq_assessments_views.views import (
     INSTITUTION_KINDS_CAN_VIEW_ASSESSMENT_LIST,
@@ -157,7 +158,7 @@ NAV_ENTRIES = {
         matomo_event_option="orientations-prescripteurs",
     ),
     "prescriber-overview": NavItem(
-        label="Présentation",
+        label="Fiche de présentation",
         target=reverse("prescribers_views:overview"),
         active_view_names=["prescribers_views:overview"],
         matomo_event_category="offcanvasNav",
@@ -179,6 +180,14 @@ NAV_ENTRIES = {
         matomo_event_category="offcanvasNav",
         matomo_event_name="clic",
         matomo_event_option="collaborateurs",
+    ),
+    "prescriber-accredited-organizations": NavItem(
+        label="Organisations conventionnées",
+        target=reverse("prescribers_views:list_accredited_organizations"),
+        active_view_names=["prescribers_views:list_accredited_organizations"],
+        matomo_event_category="offcanvasNav",
+        matomo_event_name="clic",
+        matomo_event_option="prescribers-list-accredited-organizations",
     ),
     # Employers.
     "employer-job-apps": NavItem(
@@ -334,6 +343,11 @@ def nav(request):
                 ),
                 NAV_ENTRIES["prescriber-members"],
             ]
+            if (
+                request.current_organization.kind == PrescriberOrganizationKind.DEPT
+                and request.is_current_organization_admin
+            ):
+                organization_items.append(NAV_ENTRIES["prescriber-accredited-organizations"])
             menu_items.append(
                 NavGroup(
                     label="Organisation",

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -1302,7 +1302,7 @@
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="prescriber-presentation" href="/prescribers/overview">
-                                      Présentation
+                                      Fiche de présentation
                                   </a>
                               </li>
                               <li>

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -132,7 +132,7 @@ class TestMembers:
         TAB_MARKUP = f"""<a class="nav-link" href="{reverse("prescribers_views:overview")}" data-matomo-event="true"
                         data-matomo-category="prescribers" data-matomo-action="clic"
                         data-matomo-option="organisation-presentation">
-                        Présentation</a>"""
+                        Fiche de présentation</a>"""
         organization = factory()
         client.force_login(organization.members.first())
         response = client.get(reverse("prescribers_views:members"))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour les prescripteurs.
Réorganisation des items du menu latéral "Organisation" et des blocs thématiques du tableau de bord 
https://app.notion.com/p/gip-inclusion/PRESCRIPTEURS-R-organisation-du-menu-lat-ral-et-des-blocs-th-matiques-du-tableau-de-bord-3c15f321b604801f9887fdb92aba186d

## :cake: Comment ? <!-- optionnel -->

En plusieurs étapes.

Dans cette PR, il s'agit de:
- renommer "Présentation" en "Fiche de présentation"
- renommer  "Voir la liste des organisations conventionnées" et l'ajouter au menu lateral  


