### PR TITLE
Interface : Meilleure gestion de la redirection vers le nouveau domaine pour les pages d'admin avec paramètres

### DIFF
--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -178,5 +178,8 @@ def _get_redirect_url(request):
         return None
 
     query = QueryDict(request.GET.urlencode(), mutable=True)
-    query[REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM] = "1"
+    if request.resolver_match.app_name != "admin":
+        # Django-admin redirects the request (by removing all query
+        # params) if a query param is not a filterable column.
+        query[REDIRECTED_FROM_OLD_DOMAIN_QUERY_PARAM] = "1"
     return f"https://{settings.NEW_DOMAIN}{request.path}?{query.urlencode()}"

--- a/tests/www/middleware/tests.py
+++ b/tests/www/middleware/tests.py
@@ -17,13 +17,22 @@ class TestRedirectToNewDomainMiddleware:
 
         settings.REDIRECT_TO_NEW_DOMAIN = True
         response = client.get(
+            "/search/employers/results",
+            HTTP_HOST="old.domain",
+        )
+        assert response.status_code == 302
+        assert response.url == "https://new.domain/search/employers/results?redirected-from-old-domain=1"
+
+        # Admin pages are redirected _without_ the extra
+        # `redirected-from-old-domain` query parameter.
+        response = client.get(
             "/admin/",
             query_params={"foo": "bar"},
             HTTP_HOST="old.domain",
             follow=False,
         )
         assert response.status_code == 302
-        assert response.url == "https://new.domain/admin/?foo=bar&redirected-from-old-domain=1"
+        assert response.url == "https://new.domain/admin/?foo=bar"
 
         response = client.get("/admin/", HTTP_HOST="new.domain")
         assert response.status_code == 200  # no redirect (already on new domain)


### PR DESCRIPTION
Requests like `/admin/users/user/?q=something` where redirected to the new domain to `.../?q=something&redirected-from-old-domain=1`. The latter query param was rejected by Django-admin, which redirected to the list page (`/admin/users/user/`), losing the initial query params.

Since the `redirected-from-old-domain` param is not used when displaying admin pages, the middleware now omits it.