### PR TITLE
Interface: Renommage et réorganisation des items du menu "Structure" des employeurs

### DIFF
--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -19,12 +19,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="1">
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:overview' %}" {% matomo_event "employeurs" "clic" "structure-presentation" %}>
-                Présentation
+                Fiche de présentation
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link active" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                Métiers et recrutements
+            <a class="nav-link active" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "fiches-de-postes" %}>
+                Fiches de postes
             </a>
         </li>
         <li class="nav-item">
@@ -47,7 +47,7 @@
                 <div class="s-section__col col-12">
                     <div class="tab-content">
                         <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
-                            <h2 class="mb-0">Métiers et recrutements</h2>
+                            <h2 class="mb-0">Fiches de postes</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les candidatures">
                                 <form method="post" id="block_job_applications_form" hx-boost="true">
                                     {% csrf_token %}

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -17,12 +17,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="2">
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:overview' %}" {% matomo_event "employeurs" "clic" "structure-presentation" %}>
-                Présentation
+                Fiche de présentation
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                Métiers et recrutements
+            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "fiches-de-postes" %}>
+                Fiches de postes
             </a>
         </li>
         <li class="nav-item">

--- a/itou/templates/companies/overview.html
+++ b/itou/templates/companies/overview.html
@@ -18,12 +18,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         <li class="nav-item">
             <a class="nav-link active" href="{% url 'companies_views:overview' %}" {% matomo_event "employeurs" "clic" "structure-presentation" %}>
-                Présentation
+                Fiche de présentation
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                Métiers et recrutements
+            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "fiches-de-postes" %}>
+                Fiches de postes
             </a>
         </li>
         <li class="nav-item">
@@ -46,7 +46,7 @@
                 <div class="s-section__col col-12">
                     <div class="tab-content">
                         <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
-                            <h2 class="mb-0">Présentation</h2>
+                            <h2 class="mb-0">Fiche de présentation</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur la structure">
                                 <a class="btn btn-outline-primary btn-ico"
                                    href="{{ request.current_organization.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -43,12 +43,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="3">
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:overview' %}" {% matomo_event "employeurs" "clic" "structure-presentation" %}>
-                Présentation
+                Fiche de présentation
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                Métiers et recrutements
+            <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "fiches-de-postes" %}>
+                Fiches de postes
             </a>
         </li>
         <li class="nav-item">

--- a/itou/templates/dashboard/includes/employer_company_card.html
+++ b/itou/templates/dashboard/includes/employer_company_card.html
@@ -10,16 +10,16 @@
             <span class="badge rounded-pill badge-sm bg-primary">{{ request.current_organization.kind }} - ID {{ request.current_organization.id }}</span>
         {% endfragment %}
         {% fragment as cta %}
-            <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-block btn-ico mb-3" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
+            <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-block btn-ico mb-3" {% matomo_event "employeurs" "clic" "fiches-de-postes" %}>
                 <i class="ri-briefcase-line ri-lg fw-normal" aria-hidden="true"></i>
-                <span>Gérer les métiers et recrutements</span>
+                <span>Gérer les fiches de postes</span>
             </a>
         {% endfragment %}
         {% fragment as list %}
             <li class="d-flex justify-content-between align-items-center mb-3">
-                <a href="{{ request.current_organization.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-infos-entreprise" %}>
+                <a href="{% url 'companies_views:overview' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-infos-entreprise" %}>
                     <i class="ri-eye-line ri-lg fw-normal" aria-hidden="true"></i>
-                    <span>Voir la fiche publique</span>
+                    <span>Fiche de présentation</span>
                 </a>
             </li>
             {% if request.is_current_organization_admin %}
@@ -34,7 +34,7 @@
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'companies_views:members' %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "gerer-collaborateurs" %}>
                         <i class="ri-team-line ri-lg fw-normal" aria-hidden="true"></i>
-                        <span>Gérer les collaborateurs</span>
+                        <span>Collaborateurs</span>
                     </a>
                 </li>
             {% endif %}
@@ -42,7 +42,7 @@
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'companies_views:show_financial_annexes' %}" class="btn-link btn-ico">
                         <i class="ri-folder-chart-line ri-lg fw-normal" aria-hidden="true"></i>
-                        <span>Voir les annexes financières</span>
+                        <span>Annexes financières</span>
                     </a>
                     {% if not request.current_organization.is_active %}
                         <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning"><i class="ri-error-warning-line" aria-hidden="true"></i>Action requise</span>

--- a/itou/templates/dashboard/includes/labor_inspector_organization_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_organization_card.html
@@ -12,7 +12,7 @@
             <li class="d-flex justify-content-between align-items-center mb-3">
                 <a href="{% url 'institutions_views:members' %}" class="btn-link btn-ico">
                     <i class="ri-group-line ri-lg fw-normal" aria-hidden="true"></i>
-                    <span>Gérer les collaborateurs</span>
+                    <span>Collaborateurs</span>
                 </a>
             </li>
         {% endfragment %}

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -242,7 +242,7 @@ NAV_ENTRIES = {
         matomo_event_option="fiches-salaries-asp",
     ),
     "employer-company": NavItem(
-        label="Présentation",
+        label="Fiche de présentation",
         target=reverse("companies_views:overview"),
         active_view_names=["companies_views:overview"],
         matomo_event_category="offcanvasNav",
@@ -250,12 +250,12 @@ NAV_ENTRIES = {
         matomo_event_option="structure-presentation",
     ),
     "employer-jobs": NavItem(
-        label="Métiers et recrutements",
+        label="Fiches de postes",
         target=reverse("companies_views:job_description_list"),
         active_view_names=["companies_views:job_description_list"],
         matomo_event_category="offcanvasNav",
         matomo_event_name="clic",
-        matomo_event_option="metiers-recrutement",
+        matomo_event_option="fiches-de-postes",
     ),
     "employer-members": NavItem(
         label="Collaborateurs",

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -271,12 +271,12 @@
                           <ul>
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="structure-presentation" href="/company/overview">
-                                      Présentation
+                                      Fiche de présentation
                                   </a>
                               </li>
                               <li>
-                                  <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="metiers-recrutement" href="/company/job_description_list">
-                                      Métiers et recrutements
+                                  <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="fiches-de-postes" href="/company/job_description_list">
+                                      Fiches de postes
                                   </a>
                               </li>
                               <li>

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -37,12 +37,12 @@
                       <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="2">
                           <li class="nav-item">
                               <a class="nav-link" data-matomo-action="clic" data-matomo-category="employeurs" data-matomo-event="true" data-matomo-option="structure-presentation" href="/company/overview">
-                                  Présentation
+                                  Fiche de présentation
                               </a>
                           </li>
                           <li class="nav-item">
-                              <a class="nav-link" data-matomo-action="clic" data-matomo-category="employeurs" data-matomo-event="true" data-matomo-option="voir-liste-metiers" href="/company/job_description_list">
-                                  Métiers et recrutements
+                              <a class="nav-link" data-matomo-action="clic" data-matomo-category="employeurs" data-matomo-event="true" data-matomo-option="fiches-de-postes" href="/company/job_description_list">
+                                  Fiches de postes
                               </a>
                           </li>
                           <li class="nav-item">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour les des employeurs.
Réorganisation des items du menu latéral "Stuctures" et de la box du tableau de bord 
https://app.notion.com/p/gip-inclusion/EMPLOYEURS-R-organisation-du-menu-lat-ral-et-des-blocs-th-matiques-du-tableau-de-bord-67d5f321b60482a7b9dc01fb6d9c4572?v=2715f321b60480088826000c5284ddfc&source=copy_link

## :cake: Comment ? <!-- optionnel -->

En plusieurs étapes.

Dans cette PR, il s'agit de:
- renommer "Présentation" en "Fiche de présentation"
- renommer  "Métiers et recrutemens" en "Fiches de postes"  