### PR TITLE
Accompagnements : Mettre à jour les accompagnements lors de l’orientation d’un bénéficiaire

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,13 +23,13 @@
  +-------------------------|--------------------------+
 | API                      | Insertion                |
 | Accessibilité            | Notifications            |
-| Admin                    | Page d’accueil           |
-| Annexes financières      | PASS IAE                 |
-| Candidature              | Performances             |
-| Connexion                | Pilotage                 |
-| Contrôle a posteriori    | Prescripteur             |
-| Demandes de prolongation | Profil salarié           |
-| Demandeur d’emploi       | Recherche employeur      |
+| Accompagnements          | Page d’accueil           |
+| Admin                    | PASS IAE                 |
+| Annexes financières      | Performances             |
+| Candidature              | Pilotage                 |
+| Connexion                | Prescripteur             |
+| Contrôle a posteriori    | Profil salarié           |
+| Demandes de prolongation | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -67,6 +67,7 @@ class ActionKind(models.TextChoices):
     IAE_ELIGIBILITY = "IAE_ELIGIBILITY", "validation de l'éligibilité IAE"
     GEIQ_ELIGIBILITY = "GEIQ_ELIGIBILITY", "validation de l'éligibilité GEIQ"
     SELF_ASSIGN = "SELF_ASSIGN", "se positionner comme accompagnateur"
+    ORIENT = "ORIENT", "orientation vers un service"
 
 
 class AssignmentEndReason(models.TextChoices):

--- a/itou/users/management/commands/update_assignments_with_orientations.py
+++ b/itou/users/management/commands/update_assignments_with_orientations.py
@@ -1,0 +1,96 @@
+import time
+
+from django.db import transaction
+
+from itou.insertion.models import Orientation
+from itou.users.enums import ActionKind
+from itou.users.models import JobSeekerAssignment
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Update existing job seekers assignments with orientations."
+
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--wet-run",
+            dest="wet_run",
+            action="store_true",
+            help="Effectively update the assignments in the database.",
+        )
+
+    def handle(self, wet_run=False, **options):
+        start_time = time.perf_counter()
+        self.logger.info("Script starting!")
+
+        count_created = 0
+        count_updated = 0
+        # there are about ~100 orientations only
+        orientations = (
+            Orientation.objects.all()
+            .order_by(
+                "beneficiary",
+                "sender",
+                "sender_prescriber_organization",
+                "sender_company",
+                "-created_at",
+            )
+            .distinct("beneficiary", "sender", "sender_prescriber_organization", "sender_company")
+        )  # keep only the last orientation sent by a sender for a given beneficiary
+
+        with transaction.atomic():
+            # Filter existing assignments based on job seekers
+            assignments_qs = JobSeekerAssignment.objects.filter(
+                job_seeker__in=orientations.values_list("beneficiary_id")
+            ).select_for_update(of=("self",), no_key=True)
+            self.logger.info(
+                f"Found {len(assignments_qs)} assignments of job seekers associated to existing orientations."
+            )
+            assignments = {
+                (a.job_seeker_id, a.professional_id, a.prescriber_organization_id, a.company_id): a
+                for a in assignments_qs
+            }
+
+            assignments_to_update = []
+            assignments_to_create = []
+            for orientation in orientations:
+                key = (
+                    orientation.beneficiary_id,
+                    orientation.sender_id,
+                    orientation.sender_prescriber_organization_id,
+                    orientation.sender_company_id,
+                )
+                if assignment := assignments.get(key):
+                    if assignment.last_action_at < orientation.created_at:
+                        assignment.last_action_kind = ActionKind.ORIENT
+                        assignment.last_action_at = orientation.created_at
+                        assignments_to_update.append(assignment)
+                        count_updated += 1
+                else:
+                    assignments_to_create.append(
+                        JobSeekerAssignment(
+                            job_seeker=orientation.beneficiary,
+                            professional=orientation.sender,
+                            prescriber_organization=orientation.sender_prescriber_organization,
+                            company=orientation.sender_company,
+                            last_action_kind=ActionKind.ORIENT,
+                            last_action_at=orientation.created_at,
+                        )
+                    )
+                    count_created += 1
+
+            if wet_run:
+                JobSeekerAssignment.objects.bulk_create(assignments_to_create)
+                JobSeekerAssignment.objects.bulk_update(
+                    assignments_to_update, fields=["last_action_kind", "last_action_at"]
+                )
+
+            print(
+                f"Elapsed time: {time.perf_counter() - start_time:.2f}s",
+                end="\r",
+            )
+        self.logger.info(f"Created {count_created} assignments")
+        self.logger.info(f"Updated {count_updated} assignments")

--- a/itou/users/migrations/0043_jobseekerassignment.py
+++ b/itou/users/migrations/0043_jobseekerassignment.py
@@ -74,6 +74,7 @@ class Migration(migrations.Migration):
                             ("IAE_ELIGIBILITY", "validation de l'éligibilité IAE"),
                             ("GEIQ_ELIGIBILITY", "validation de l'éligibilité GEIQ"),
                             ("SELF_ASSIGN", "se positionner comme accompagnateur"),
+                            ("ORIENT", "orientation vers un service"),
                         ],
                         default="CREATE",
                         verbose_name="dernière action effectuée",

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -30,8 +30,8 @@ from itou.insertion.utils import (
 )
 from itou.job_applications.enums import SenderKind
 from itou.prescribers.models import PrescriberOrganization
-from itou.users.enums import UserKind
-from itou.users.models import User
+from itou.users.enums import ActionKind, UserKind
+from itou.users.models import JobSeekerAssignment, User
 from itou.users.perms import (
     add_user_can_view_personal_information,
     can_orient_towards_insertion_service,
@@ -529,6 +529,11 @@ class OrientationWizardView(WizardView):
             if event is not None:
                 event.orientation = orientation
                 event.save(update_fields=["orientation"])
+
+            # Sync job seeker assignment
+            JobSeekerAssignment.objects.upsert_assignment(
+                self.job_seeker, request.user, request.current_organization, ActionKind.ORIENT
+            )
 
             confirmation_url = reverse(
                 "insertion_views:orientation_confirmation",

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -20,9 +20,9 @@ from itou.companies.enums import CompanyKind
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.models import JobApplication, JobApplicationState
 from itou.prescribers.enums import PrescriberOrganizationKind
-from itou.users.enums import AssignmentEndReason, IdentityCertificationAuthorities, IdentityProvider
+from itou.users.enums import ActionKind, AssignmentEndReason, IdentityCertificationAuthorities, IdentityProvider
 from itou.users.management.commands import send_check_authorized_members_email
-from itou.users.models import NirModificationRequest, User
+from itou.users.models import JobSeekerAssignment, NirModificationRequest, User
 from itou.utils import triggers
 from itou.utils.apis.enums import PEApiRechercheIndividuExitCode
 from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse
@@ -30,6 +30,7 @@ from itou.utils.brevo import BrevoListID
 from tests.approvals.factories import ApprovalFactory
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
 from tests.eligibility.factories import IAEEligibilityDiagnosisFactory
+from tests.insertion.factories import OrientationFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import (
@@ -1601,3 +1602,48 @@ def test_archive_old_assignments_command():
     ended_assignment.refresh_from_db()
     assert ended_assignment.ended_at == old_ended_at
     assert ended_assignment.end_reason == AssignmentEndReason.MANUAL
+
+
+def test_update_assignments_with_orientations():
+    older_assignment = JobSeekerAssignmentFactory(prescriber_organization=PrescriberOrganizationFactory())
+    older_assignment_datetime = older_assignment.last_action_at
+    OrientationFactory(
+        beneficiary=older_assignment.job_seeker,
+        sender=older_assignment.professional,
+        sender_prescriber_organization=older_assignment.prescriber_organization,
+    )
+
+    older_orientation = OrientationFactory()
+    newer_assignment = JobSeekerAssignmentFactory(
+        job_seeker=older_orientation.beneficiary,
+        professional=older_orientation.sender,
+        prescriber_organization=older_orientation.sender_prescriber_organization,
+        company=older_orientation.sender_company,
+    )
+    newer_assignment_datetime = newer_assignment.last_action_at
+
+    orientation_alone = OrientationFactory()
+    second_orientation_alone = OrientationFactory(
+        beneficiary=orientation_alone.beneficiary,
+        sender=orientation_alone.sender,
+        sender_prescriber_organization=orientation_alone.sender_prescriber_organization,
+    )
+
+    call_command("update_assignments_with_orientations", wet_run=True)
+
+    older_assignment.refresh_from_db()
+    newer_assignment.refresh_from_db()
+    # older was updated
+    assert older_assignment.last_action_kind == ActionKind.ORIENT.value
+    assert older_assignment.last_action_at != older_assignment_datetime
+    # newer was not
+    assert newer_assignment.last_action_kind != ActionKind.ORIENT.value
+    assert newer_assignment.last_action_at == newer_assignment_datetime
+
+    assert JobSeekerAssignment.objects.filter(
+        job_seeker=orientation_alone.beneficiary,
+        professional=orientation_alone.sender,
+        prescriber_organization=orientation_alone.sender_prescriber_organization,
+        last_action_kind=ActionKind.ORIENT,
+        last_action_at=second_orientation_alone.created_at,
+    ).exists()

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -11,6 +11,8 @@ from pytest_django.asserts import assertContains, assertNotContains, assertQuery
 from itou.files.models import File
 from itou.insertion.models import GenericReferenceItemKind, MobilizationEventKind, Orientation
 from itou.job_applications.enums import SenderKind
+from itou.users.enums import ActionKind
+from itou.users.models import JobSeekerAssignment
 from itou.utils.apis.dora import DoraAPIException
 from itou.www.insertion_views.views import OrientationStep, OrientationWizardView
 from itou.www.job_seekers_views.enums import JobSeekerSessionKinds
@@ -23,11 +25,12 @@ from tests.utils.testing import get_session_name, parse_response_to_soup, pretty
 
 @pytest.mark.usefixtures("temporary_bucket")
 def test_orientation_wizard_happy_path(client, snapshot, mocker):
-    prescriber = PrescriberMembershipFactory(
+    membership = PrescriberMembershipFactory(
         organization__authorized=True,
         organization__for_snapshot=True,
         user__for_snapshot=True,
-    ).user
+    )
+    prescriber = membership.user
     job_seeker = JobSeekerFactory(
         for_snapshot=True,
         email="usager@example.org",
@@ -149,7 +152,7 @@ def test_orientation_wizard_happy_path(client, snapshot, mocker):
     assert orientation.beneficiary == job_seeker
     assert orientation.sender == prescriber
     assert orientation.sender_kind == SenderKind.PRESCRIBER
-    assert orientation.sender_prescriber_organization == prescriber.prescribermembership_set.get().organization
+    assert orientation.sender_prescriber_organization == membership.organization
     assert orientation.sender_company is None
     assert orientation.service == service
     assert orientation.referent_first_name == "Jean"
@@ -166,6 +169,13 @@ def test_orientation_wizard_happy_path(client, snapshot, mocker):
         File.objects.filter(key__in=["orientations/doc.pdf", "orientations/proof.pdf"]),
         ordered=False,
     )
+
+    assert JobSeekerAssignment.objects.filter(
+        job_seeker=job_seeker,
+        professional=prescriber,
+        prescriber_organization=membership.organization,
+        last_action_kind=ActionKind.ORIENT,
+    ).exists()
 
     payload, _ = mock_dora.return_value.create_orientation.call_args.args
     assert payload == {
@@ -579,6 +589,7 @@ def test_orientation_wizard_sends_empty_beneficiary_phone_when_job_seeker_phone_
     view.dora_client.create_orientation.return_value = {"emplois_sync_uid": "job-seeker-uid"}
     mocker.patch("itou.www.insertion_views.views.insertion_models.Orientation.from_data")
     mocker.patch("itou.www.insertion_views.views.insertion_models.MobilizationEvent")
+    mocker.patch("itou.www.insertion_views.views.JobSeekerAssignment")
 
     request = mocker.Mock()
     request.user.pk = 1
@@ -648,6 +659,13 @@ def test_orientation_wizard_happy_path_as_employer(client, mocker):
     assert orientation.sender_company == organization
     assert orientation.sender_prescriber_organization is None
     assert orientation.attachments == []
+
+    assert JobSeekerAssignment.objects.filter(
+        job_seeker=job_seeker,
+        professional=user,
+        company=organization,
+        last_action_kind=ActionKind.ORIENT,
+    ).exists()
 
 
 def test_orientation_wizard_links_latest_unlinked_mobilization_event(client, mocker):

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestAdvisorsTab.test_assigment_display[ACTIVE_NO_ORG]
+# name: TestAdvisorsTab.test_assignment_display[ACTIVE_NO_ORG]
   '''
   <html>
       <head>
@@ -101,7 +101,7 @@
   
   '''
 # ---
-# name: TestAdvisorsTab.test_assigment_display[ACTIVE_WITH_ORG_AND_MEMBERSHIP]
+# name: TestAdvisorsTab.test_assignment_display[ACTIVE_WITH_ORG_AND_MEMBERSHIP]
   '''
   <html>
       <head>
@@ -205,7 +205,7 @@
   
   '''
 # ---
-# name: TestAdvisorsTab.test_assigment_display[ACTIVE_WITH_ORG_NO_MEMBERSHIP]
+# name: TestAdvisorsTab.test_assignment_display[ACTIVE_WITH_ORG_NO_MEMBERSHIP]
   '''
   <html>
       <head>
@@ -343,7 +343,7 @@
   
   '''
 # ---
-# name: TestAdvisorsTab.test_assigment_display[INACTIVE_NO_ORG]
+# name: TestAdvisorsTab.test_assignment_display[INACTIVE_NO_ORG]
   '''
   <html>
       <head>
@@ -403,7 +403,7 @@
   
   '''
 # ---
-# name: TestAdvisorsTab.test_assigment_display[INACTIVE_WITH_ORG]
+# name: TestAdvisorsTab.test_assignment_display[INACTIVE_WITH_ORG]
   '''
   <html>
       <head>
@@ -518,7 +518,7 @@
   
   '''
 # ---
-# name: TestAdvisorsTab.test_assigment_display[UNKNOWN_ADVISOR]
+# name: TestAdvisorsTab.test_assignment_display[UNKNOWN_ADVISOR]
   '''
   <html>
       <head>
@@ -1464,7 +1464,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[ACTIVE_NO_ORG]
+# name: TestLastAdvisor.test_last_assignment_display[ACTIVE_NO_ORG]
   '''
   <html>
       <head>
@@ -1541,7 +1541,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[ACTIVE_WITH_ORG_AND_MEMBERSHIP]
+# name: TestLastAdvisor.test_last_assignment_display[ACTIVE_WITH_ORG_AND_MEMBERSHIP]
   '''
   <html>
       <head>
@@ -1618,7 +1618,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[ACTIVE_WITH_ORG_NO_MEMBERSHIP]
+# name: TestLastAdvisor.test_last_assignment_display[ACTIVE_WITH_ORG_NO_MEMBERSHIP]
   '''
   <html>
       <head>
@@ -1728,7 +1728,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[INACTIVE_NO_ORG]
+# name: TestLastAdvisor.test_last_assignment_display[INACTIVE_NO_ORG]
   '''
   <html>
       <head>
@@ -1773,7 +1773,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[INACTIVE_WITH_ORG]
+# name: TestLastAdvisor.test_last_assignment_display[INACTIVE_WITH_ORG]
   '''
   <html>
       <head>
@@ -1867,7 +1867,7 @@
   
   '''
 # ---
-# name: TestLastAdvisor.test_last_assigment_display[UNKNOWN_ADVISOR]
+# name: TestLastAdvisor.test_last_assignment_display[UNKNOWN_ADVISOR]
   '''
   <html>
       <head>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -1257,6 +1257,110 @@
   
   '''
 # ---
+# name: TestAdvisorsTab.test_assignment_display_actions[ORIENT]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Orientation vers un service
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
 # name: TestAdvisorsTab.test_assignment_display_actions[SELF_ASSIGN]
   '''
   <html>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -633,6 +633,734 @@
   
   '''
 # ---
+# name: TestAdvisorsTab.test_assignment_display_actions[ACCEPT]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Acceptation de candidature
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[APPLY]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Envoi de candidature
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[CREATE]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Création du compte candidat
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[GEIQ_ELIGIBILITY]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Validation de l'éligibilité GEIQ
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[HIRE]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Déclaration d'embauche
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[IAE_ELIGIBILITY]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Validation de l'éligibilité IAE
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
+# name: TestAdvisorsTab.test_assignment_display_actions[SELF_ASSIGN]
+  '''
+  <html>
+      <head>
+      </head>
+      <body>
+          <div class="c-box c-box--results has-links-inside mb-3 mb-md-4">
+              <div class="c-box--results__header">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-home-smile-line">
+                          </i>
+                          <div>
+                              <div class="d-flex align-items-center gap-2">
+                                  <h3>
+                                      Pierre DUPONT
+                                  </h3>
+                              </div>
+                              <span>
+                                  Orienteur pour [Org display name]
+                              </span>
+                          </div>
+                      </div>
+                      <div>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-arrow-right-line">
+                              </i>
+                              Depuis le 08/08/2026
+                          </span>
+                      </div>
+                  </div>
+              </div>
+              <hr class="m-0"/>
+              <div class="c-box--results__body">
+                  <ul class="list-data">
+                      <li>
+                          <small>
+                              Adresse e-mail
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_email" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/email" hx-swap="outerHTML" id="email-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-mail-send-line">
+                                  </i>
+                                  <span>
+                                      Afficher l’adresse e-mail
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Téléphone
+                          </small>
+                          <button class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="advisors" data-matomo-event="true" data-matomo-option="displayed_advisor_phone" hx-include="#display-contact-info-form" hx-post="/job-seekers/display/[JobSeekerAssignment PK]/phone" hx-swap="outerHTML" id="phone-[JobSeekerAssignment PK]">
+                              <div class="stable-text">
+                                  <i aria-hidden="true" class="ri-phone-line">
+                                  </i>
+                                  <span>
+                                      Afficher le téléphone
+                                  </span>
+                              </div>
+                              <div class="loading-text">
+                                  <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status">
+                                  </span>
+                                  <span>
+                                      Affichage en cours
+                                  </span>
+                              </div>
+                          </button>
+                      </li>
+                      <li>
+                          <small>
+                              Dernière action
+                          </small>
+                          <span>
+                              <strong>
+                                  Se positionner comme accompagnateur
+                              </strong>
+                              - 08/08/2026
+                          </span>
+                      </li>
+                      <li>
+                          <small>
+                              Motif de l’accompagnement
+                          </small>
+                          <i class="text-disabled">
+                              Non renseigné
+                          </i>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </body>
+  </html>
+  
+  '''
+# ---
 # name: TestAdvisorsTab.test_tab[active_only]
   '''
   <main class="s-main" id="main" role="main">

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -1151,6 +1151,42 @@ class TestAdvisorsTab:
             )
         assert pretty_indented(rendered) == snapshot
 
+    @pytest.mark.parametrize("action_kind", ActionKind)
+    @freeze_time("2026-08-08")
+    def test_assignment_display_actions(self, snapshot, action_kind):
+        assignment = JobSeekerAssignmentFactory(
+            job_seeker__for_snapshot=True,
+            display_mode=JobSeekerAssignmentDisplayMode.ACTIVE_WITH_ORG_AND_MEMBERSHIP,  # pick one arbitrarily
+            professional__for_snapshot=True,
+            last_action_kind=action_kind,
+        )
+        request = get_request(PrescriberFactory())
+
+        template = load_template("job_seekers_views/includes/advisor.html")
+        rendered = template.render(Context({"assignment": assignment, "request": request}))
+        rendered = rendered.replace(
+            f"/job-seekers/display/{assignment.pk}",
+            "/job-seekers/display/[JobSeekerAssignment PK]",
+        )
+        rendered = rendered.replace(
+            f"card-{assignment.pk}",
+            "card-[JobSeekerAssignment PK]",
+        )
+        rendered = rendered.replace(
+            f"email-{assignment.pk}",
+            "email-[JobSeekerAssignment PK]",
+        )
+        rendered = rendered.replace(
+            f"phone-{assignment.pk}",
+            "phone-[JobSeekerAssignment PK]",
+        )
+        if assignment.organization:
+            rendered = rendered.replace(
+                assignment.organization.display_name,
+                "[Org display name]",
+            )
+        assert pretty_indented(rendered) == snapshot
+
     def test_oneself_assignment_display(self, client):
         assignment = JobSeekerAssignmentFactory(
             job_seeker__for_snapshot=True,

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -706,7 +706,7 @@ class TestLastAdvisor:
 
     @pytest.mark.parametrize("display_mode", JobSeekerAssignmentDisplayMode)
     @freeze_time("2026-08-08")
-    def test_last_assigment_display(self, snapshot, display_mode):
+    def test_last_assignment_display(self, snapshot, display_mode):
         assignment = JobSeekerAssignmentFactory(
             job_seeker__for_snapshot=True,
             display_mode=display_mode,
@@ -744,7 +744,7 @@ class TestLastAdvisor:
             )
         assert pretty_indented(rendered) == snapshot
 
-    def test_oneself_assigment_display(self, client):
+    def test_oneself_assignment_display(self, client):
         assignment = JobSeekerAssignmentFactory(
             job_seeker__for_snapshot=True,
             professional__for_snapshot=True,
@@ -1117,7 +1117,7 @@ class TestAdvisorsTab:
 
     @pytest.mark.parametrize("display_mode", JobSeekerAssignmentDisplayMode)
     @freeze_time("2026-08-08")
-    def test_assigment_display(self, snapshot, display_mode):
+    def test_assignment_display(self, snapshot, display_mode):
         assignment = JobSeekerAssignmentFactory(
             job_seeker__for_snapshot=True,
             display_mode=display_mode,
@@ -1151,7 +1151,7 @@ class TestAdvisorsTab:
             )
         assert pretty_indented(rendered) == snapshot
 
-    def test_oneself_assigment_display(self, client):
+    def test_oneself_assignment_display(self, client):
         assignment = JobSeekerAssignmentFactory(
             job_seeker__for_snapshot=True,
             professional__for_snapshot=True,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une des actions de la plateforme est l’orientation vers un service d’insertion. 
On veut tenir compte de cette action dans les accompagnements.

[Carte notion](https://app.notion.com/p/gip-inclusion/Rajouter-le-b-n-ficiaire-d-une-orientation-dans-mes-accompagnements-3d15f321b60480fcba43e6f9ae0da43e?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link)

## :cake: Comment ? <!-- optionnel -->

Un `upsert_assignment` là où il faut + commande pour la petite reprise de stock.

Aussi, modification du template de PR pour remplacer "Demandeurs d’emplois" par "Accompagnements" déjà bien plus utilisé dans le journal des changements.

