### PR TITLE
Insertion : Envoyer un log d’erreur lorsque la création d’une orientation échoue

### DIFF
--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -457,7 +457,7 @@ class OrientationWizardView(WizardView):
             try:
                 orientation_response = self.dora_client.create_orientation(payload, attachments)
             except DoraAPIException:
-                logger.info(
+                logger.error(
                     "orientation wizard submission_failed reason=create_orientation "
                     "user=%s service_uid=%s job_seeker=%s",
                     request.user.pk,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement c’est une `info`, et c’est une information qu’elle est bonne à prendre.


