### PR TITLE
Insertion : Ne pas proposer le formulaire d’orientation si le service n’a pas d’email de contact

### DIFF
--- a/itou/insertion/models.py
+++ b/itou/insertion/models.py
@@ -468,9 +468,9 @@ class Service(GeolocatedAddressMixin, models.Model):
 
     @property
     def has_orientation_action(self):
-        return (self.is_orientable_with_form and not self.from_non_orientable_di_source) or bool(
-            self.mobilization_modes_professionals_external_form_link
-        )
+        return (
+            self.is_orientable_with_form and bool(self.contact_email) and not self.from_non_orientable_di_source
+        ) or bool(self.mobilization_modes_professionals_external_form_link)
 
     def has_mobilization_modes(self):
         return (not self.is_dora and bool(self.mobilizations.all())) or (

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -233,7 +233,9 @@ class OrientationStep(enum.StrEnum):
 
 def start_orientation(request, service_uid):
     service = get_object_or_404(
-        insertion_models.Service.objects.exclude(source__value__in=settings.NON_ORIENTABLE_DI_SOURCES),
+        insertion_models.Service.objects.exclude(source__value__in=settings.NON_ORIENTABLE_DI_SOURCES).exclude(
+            contact_email=""
+        ),
         uid=service_uid,
         is_orientable_with_form=True,
     )

--- a/tests/insertion/factories.py
+++ b/tests/insertion/factories.py
@@ -91,6 +91,7 @@ class ServiceFactory(factory.django.DjangoModelFactory):
     structure = factory.SubFactory(StructureFactory)
     name = factory.Sequence(lambda n: f"Service {n}")
     description = "Description du service."
+    contact_email = "contact@email.fake"
     updated_on = datetime.date(2025, 1, 1)
 
     @factory.post_generation

--- a/tests/insertion/test_models.py
+++ b/tests/insertion/test_models.py
@@ -105,6 +105,11 @@ def test_address_on_one_line_incomplete_returns_none(address_kwargs):
     [
         pytest.param({"is_orientable_with_form": True}, True, id="orientable_with_form"),
         pytest.param(
+            {"is_orientable_with_form": True, "contact_email": ""},
+            False,
+            id="orientable_with_form_without_contact_email",
+        ),
+        pytest.param(
             {"mobilization_modes_professionals_external_form_link": "https://example.com"},
             True,
             id="external_form_link",

--- a/tests/www/insertion_views/__snapshots__/test_views.ambr
+++ b/tests/www/insertion_views/__snapshots__/test_views.ambr
@@ -129,6 +129,20 @@
                               </a>
                           </div>
                       </div>
+                      <div class="c-box mb-3 mb-md-4">
+                          <h2 class="h3">
+                              Contact
+                          </h2>
+                          <ul class="fs-sm list-unstyled mb-0">
+                              <li>
+                                  <i aria-hidden="true" class="ri-mail-line fw-normal flex-shrink-0 me-2">
+                                  </i>
+                                  <a aria-label="Contact par mail" class="text-break" href="mailto:contact@email.fake">
+                                      contact@email.fake
+                                  </a>
+                              </li>
+                          </ul>
+                      </div>
                   </div>
               </div>
           </div>
@@ -691,6 +705,20 @@
                                   Voir la fiche structure
                               </a>
                           </div>
+                      </div>
+                      <div class="c-box mb-3 mb-md-4">
+                          <h2 class="h3">
+                              Contact
+                          </h2>
+                          <ul class="fs-sm list-unstyled mb-0">
+                              <li>
+                                  <i aria-hidden="true" class="ri-mail-line fw-normal flex-shrink-0 me-2">
+                                  </i>
+                                  <a aria-label="Contact par mail" class="text-break" href="mailto:contact@email.fake">
+                                      contact@email.fake
+                                  </a>
+                              </li>
+                          </ul>
                       </div>
                   </div>
               </div>
@@ -2079,6 +2107,11 @@
                                       </span>
                                   </a>
                               </div>
+                              <div class="form-group col-12 col-lg-auto">
+                                  <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                                      Voir les coordonnées de contact du service
+                                  </button>
+                              </div>
                               <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
                                   <div class="dropdown">
                                       <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
@@ -2224,6 +2257,11 @@
                                       </span>
                                   </a>
                               </div>
+                              <div class="form-group col-12 col-lg-auto">
+                                  <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                                      Voir les coordonnées de contact du service
+                                  </button>
+                              </div>
                               <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
                                   <div class="dropdown">
                                       <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
@@ -2363,12 +2401,10 @@
           Actions rapides
       </h2>
       <div class="form-row align-items-center gx-3">
-          <div class="form-group col-12 col-lg">
-              <p class="mb-0 fst-italic text-white">
-                  <i aria-hidden="true" class="ri-information-line fw-normal me-1">
-                  </i>
-                  Informations de contact non renseignées
-              </p>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">
@@ -2405,6 +2441,11 @@
                       Orienter un bénéficiaire
                   </span>
               </a>
+          </div>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">
@@ -2670,6 +2711,11 @@
                   </span>
               </a>
           </div>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
+          </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">
                   <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
@@ -2705,6 +2751,11 @@
                       Lien externe
                   </span>
               </a>
+          </div>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">
@@ -2742,6 +2793,11 @@
                   </span>
               </a>
           </div>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
+          </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">
                   <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-lg btn-link-white btn-block w-lg-auto pe-0" data-bs-toggle="dropdown" id="other_actions_orientation" type="button">
@@ -2777,6 +2833,11 @@
                       Orienter un bénéficiaire
                   </span>
               </a>
+          </div>
+          <div class="form-group col-12 col-lg-auto">
+              <button class="btn btn-lg btn-outline-white btn-block justify-content-center" data-bs-target="#service-contact-modal" data-bs-toggle="modal" data-emplois-mobilization-kind="service_contact" data-matomo-action="clic" data-matomo-category="fiche-service" data-matomo-event="true" data-matomo-option="voir-coordonnees-contact" type="button">
+                  Voir les coordonnées de contact du service
+              </button>
           </div>
           <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">
               <div class="dropdown">

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -277,6 +277,7 @@ class TestServices:
             data-matomo-option="voir-coordonnees-contact">
         Voir les coordonnées de contact du service
     </button>"""
+    MISSING_CONTACT_LABEL = "Informations de contact non renseignées"
     DISPLAY_SERVICE_CONTACT_JS = 'body.set("service_uid", "%s");'
     FORMS_TO_FILL = "Documents à compléter"
 
@@ -551,7 +552,7 @@ class TestServices:
             reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid}),
         )
         assertNotContains(response, "c-box--action")
-        assertNotContains(response, "Informations de contact non renseignées")
+        assertNotContains(response, self.MISSING_CONTACT_LABEL)
 
     def test_detail_orientable_and_user_not_authenticated(self, client):
         service = ServiceFactory(
@@ -630,8 +631,8 @@ class TestServices:
         )
         client.force_login(user)
         response = client.get(self.get_service_url(service))
-        assertNotContains(response, "Voir les coordonnées de contact du service")
-        assertContains(response, "Informations de contact non renseignées")
+        assertNotContains(response, self.DISPLAY_SERVICE_CONTACT_BTN, html=True)
+        assertContains(response, self.MISSING_CONTACT_LABEL)
 
     def test_detail_contact_button_shown_when_authenticated(self, client):
         user = PrescriberFactory(membership=True)

--- a/tests/www/insertion_views/test_views.py
+++ b/tests/www/insertion_views/test_views.py
@@ -583,6 +583,15 @@ class TestServices:
         assertNotContains(response, self.ORIENT_BTN_LABEL)
         assert pretty_indented(parse_response_to_soup(response, ".c-box--action")) == snapshot
 
+    def test_detail_not_orientable_because_of_missing_email(self, client):
+        user = PrescriberFactory(membership=True)
+        service = ServiceFactory(
+            is_orientable_with_form=True, contact_email="", contact_full_name="Ludwig B.", contact_phone="3949"
+        )
+        client.force_login(user)
+        response = client.get(self.get_service_url(service))
+        assertNotContains(response, self.ORIENT_BTN_LABEL)
+
     def test_detail_non_orientable_di_sources(self, client, settings):
         user = PrescriberFactory(membership=True)
         blacklisted_source = "blacklisted-source"

--- a/tests/www/insertion_views/test_wizard.py
+++ b/tests/www/insertion_views/test_wizard.py
@@ -290,6 +290,16 @@ def test_start_with_non_orientable_di_sources(client, settings, is_blacklisted, 
     assert response.status_code == status_code
 
 
+def test_start_with_service_missing_contact_email(client):
+    prescriber = PrescriberFactory(membership=True)
+    service = ServiceFactory(is_orientable_with_form=True, contact_email="")
+    start_url = reverse("insertion_views:start_orientation", kwargs={"service_uid": service.uid})
+    client.force_login(prescriber)
+
+    response = client.get(start_url)
+    assert response.status_code == 404
+
+
 def test_start_orientation_redirects_when_external_link_preferred(client):
     # A DI service that both is form-orientable and has an external link prefers the link:
     # direct access to the form flow must bounce back to the service detail page.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sans `contact_email`, impossible d’envoyer une notification par mail au porteur de service.

Cela concerne quelques dizaines de services.

[ref](https://gip-inclusion.slack.com/archives/C089LM2P3H6/p1788774841751939)
