### PR TITLE
Contrôle a posteriori : fix org_filter consultation justificatif

### DIFF
--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -11,7 +11,9 @@ from django.views import generic
 from django.views.decorators.http import require_POST
 from django.views.generic.detail import SingleObjectMixin
 
+from itou.companies.models import Company
 from itou.files.models import save_file
+from itou.institutions.models import Institution
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.emails import InstitutionEmailFactory, SIAEEmailFactory
 from itou.siae_evaluations.models import (
@@ -838,13 +840,22 @@ def siae_submit_proofs(request, evaluated_siae_pk):
 
 @readonly_view
 def view_proof(request, evaluated_administrative_criteria_id):
+    # request.organizations contains every organization the user belongs to, whatever its kind: we only keep those
+    # matching the lookup as other kinds (e.g. PrescriberOrganization) would break the query.
     if request.from_employer:
-        org_lookup = "evaluated_job_application__evaluated_siae__siae__in"
+        org_filter = {
+            "evaluated_job_application__evaluated_siae__siae__in": [
+                org for org in request.organizations if isinstance(org, Company)
+            ]
+        }
     elif request.from_institution:
-        org_lookup = "evaluated_job_application__evaluated_siae__evaluation_campaign__institution__in"
+        org_filter = {
+            "evaluated_job_application__evaluated_siae__evaluation_campaign__institution__in": [
+                org for org in request.organizations if isinstance(org, Institution)
+            ]
+        }
     else:
         raise Http404(request.user.kind)
-    org_filter = {org_lookup: request.organizations}
     criteria = get_object_or_404(
         EvaluatedAdministrativeCriteria.objects.select_related("proof"),
         pk=evaluated_administrative_criteria_id,

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -11,10 +11,12 @@ from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.siae_evaluations import enums as evaluation_enums
+from itou.utils import constants as global_constants
 from itou.utils.types import InclusiveDateRange
 from tests.companies.factories import CompanyMembershipFactory
 from tests.files.factories import FileFactory
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory
+from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.siae_evaluations.factories import (
     EvaluatedAdministrativeCriteriaFactory,
     EvaluatedJobApplicationFactory,
@@ -467,6 +469,44 @@ class TestViewProof:
             assertRedirects(response, crit.proof.url(), fetch_redirect_response=False)
         pdf_file.seek(0)
         assert httpx.get(response.url).content == pdf_file.read()
+
+    def test_access_siae_member_of_a_prescriber_organization(self, client):
+        # request.organizations contains every organization of the user, whatever its kind.
+        job_app = EvaluatedJobApplicationFactory()
+        criterion = EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=job_app)
+        membership = CompanyMembershipFactory(company_id=job_app.evaluated_siae.siae_id)
+        PrescriberMembershipFactory(user=membership.user)
+        url = reverse(
+            "siae_evaluations_views:view_proof", kwargs={"evaluated_administrative_criteria_id": criterion.pk}
+        )
+        client.force_login(membership.user)
+        session = client.session
+        session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = membership.company.organization_switch_key
+        session.save()
+        with freeze_time():
+            response = client.get(url)
+            assertRedirects(response, criterion.proof.url(), fetch_redirect_response=False)
+
+    def test_access_institution_member_of_a_prescriber_organization(self, client):
+        # request.organizations contains every organization of the user, whatever its kind.
+        membership = InstitutionMembershipFactory()
+        PrescriberMembershipFactory(user=membership.user)
+        job_app = EvaluatedJobApplicationFactory(
+            evaluated_siae__evaluation_campaign__institution=membership.institution
+        )
+        criterion = EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=job_app)
+        url = reverse(
+            "siae_evaluations_views:view_proof", kwargs={"evaluated_administrative_criteria_id": criterion.pk}
+        )
+        client.force_login(membership.user)
+        session = client.session
+        session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = (
+            membership.institution.organization_switch_key
+        )
+        session.save()
+        with freeze_time():
+            response = client.get(url)
+            assertRedirects(response, criterion.proof.url(), fetch_redirect_response=False)
 
     def test_access_other_institution(self, client):
         job_app = EvaluatedJobApplicationFactory(evaluated_siae__evaluation_campaign__institution__department="01")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le `get_object_or_404` était mal construit et, lorsqu'un utilisateur membre d'une `PrescriberOrganization` tentait de consulter un justificatif via la vue [`view_proof`](https://github.com/gip-inclusion/les-emplois/blob/7353ddb688f814d327e7ae1fc54740d637aa14dc/itou/www/siae_evaluations_views/views.py#L847), il se prenait une 404 en pleine poire.

## :cake: Comment ?

On filtre pour ne conserver que les `Company` et les `Institution`.

Avec deux tests pour s'assurer que ça ne pète plus.

## :desert_island: Comment tester ?

N/A

## :computer: Captures d'écran

N/A