### PR TITLE
Tech : ajout d'une commande notifiant des fichiers manquant

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -53,6 +53,7 @@
   "55 23 * * * $ROOT/clevercloud/run_management_command.sh purge_orphaned_support_remarks --wet-run",
 
   "0 6 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_cancelled_approvals --wet-run",
+  "30 11 * * MON-FRI $ROOT/clevercloud/run_management_command.sh detect_missing_asp_files",
   "0 12 * * MON-FRI $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
 
   "0 0 * * MON CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -538,7 +538,7 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 
-# Slack notifications sent by Metabase cronjobs.
+# Slack notifications sent by cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")
 
 # Slack notifications sent by check_inconsistencies cronjobs.

--- a/itou/employee_record/management/commands/detect_missing_asp_files.py
+++ b/itou/employee_record/management/commands/detect_missing_asp_files.py
@@ -1,0 +1,63 @@
+import datetime
+
+from django.conf import settings
+from django.db.models import Count
+from django.utils import timezone
+
+from itou.employee_record.enums import NotificationStatus, Status
+from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification
+from itou.utils.command import BaseCommand
+from itou.utils.slack import send_slack_message
+
+
+# Some files are sent on friday afternoon: the answer is expected on monday morning.
+TOO_LONG = datetime.timedelta(days=3)
+
+
+class Command(BaseCommand):
+    """Search for missing files from ASP and send notification to Slack."""
+
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
+    def handle(self, **options):
+        self.logger.info("Checking employee records waiting for an ASP response")
+
+        missing_files = []
+        for model in [EmployeeRecord, EmployeeRecordUpdateNotification]:
+            sent_status = (
+                Status.SENT if model == EmployeeRecord else NotificationStatus.SENT
+            )  # Yes, this is quite useless
+            for filename, er_count in (
+                model.objects.filter(status=sent_status)
+                .values("asp_batch_file")
+                .annotate(Count("pk"))
+                .values_list("asp_batch_file", "pk__count")
+            ):
+                file_sent_at = EmployeeRecordBatch.datetime_from_asp_batch_file(filename)
+                if timezone.now() - file_sent_at > TOO_LONG:
+                    self.logger.warning(
+                        "Found filename=%s for model=%s that seems to have been lost", filename, model.__name__
+                    )
+                    missing_files.append((model.__name__, filename, er_count))
+
+        if not missing_files:
+            self.logger.info("No missing file found")
+            return
+
+        if settings.SLACK_CRON_WEBHOOK_URL:
+            msg_lines = ["Des fichiers de l'ASP semblent s'être perdus :"]
+            for model_name, filename, er_count in missing_files:
+                msg_lines.append(f" - {filename} : contenant {er_count} {model_name}")
+            msg_lines.append("")
+            msg_lines.append(
+                "Cf https://app.notion.com/p/gip-inclusion/Fiches-Salari-s-Interconnexion-RIAE-ASP-2415f321b60480c39ff9dfd2078d0c8d"  # noqa: E501
+            )
+
+            send_slack_message(
+                text="\n".join(msg_lines),
+                url=settings.SLACK_CRON_WEBHOOK_URL,
+            )
+            self.logger.info("Found missing files: %s and notification successfully sent to Slack", missing_files)
+        else:
+            self.logger.error("Found missing files: %s but no Slack webhook configured", missing_files)

--- a/tests/employee_record/__snapshots__/test_detect_missing_asp_files.ambr
+++ b/tests/employee_record/__snapshots__/test_detect_missing_asp_files.ambr
@@ -1,0 +1,29 @@
+# serializer version: 1
+# name: test_nothing_to_report[False]
+  list([
+    'Checking employee records waiting for an ASP response',
+    'No missing file found',
+  ])
+# ---
+# name: test_nothing_to_report[True]
+  list([
+    'Checking employee records waiting for an ASP response',
+    'No missing file found',
+  ])
+# ---
+# name: test_report[False]
+  list([
+    'Checking employee records waiting for an ASP response',
+    'Found filename=RIAE_FS_20000101120001.json for model=EmployeeRecord that seems to have been lost',
+    'Found filename=RIAE_FS_20000101120001.json for model=EmployeeRecordUpdateNotification that seems to have been lost',
+    "Found missing files: [('EmployeeRecord', 'RIAE_FS_20000101120001.json', 1), ('EmployeeRecordUpdateNotification', 'RIAE_FS_20000101120001.json', 1)] but no Slack webhook configured",
+  ])
+# ---
+# name: test_report[True]
+  list([
+    'Checking employee records waiting for an ASP response',
+    'Found filename=RIAE_FS_20000101120001.json for model=EmployeeRecord that seems to have been lost',
+    'Found filename=RIAE_FS_20000101120001.json for model=EmployeeRecordUpdateNotification that seems to have been lost',
+    "Found missing files: [('EmployeeRecord', 'RIAE_FS_20000101120001.json', 1), ('EmployeeRecordUpdateNotification', 'RIAE_FS_20000101120001.json', 1)] and notification successfully sent to Slack",
+  ])
+# ---

--- a/tests/employee_record/test_detect_missing_asp_files.py
+++ b/tests/employee_record/test_detect_missing_asp_files.py
@@ -1,0 +1,82 @@
+import datetime
+import random
+import re
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from itou.employee_record.enums import NotificationStatus, Status
+from itou.employee_record.models import EmployeeRecordBatch
+from tests.employee_record import factories
+
+
+def process_output(caplog_messages):
+    assert caplog_messages[-1].startswith(
+        "Management command itou.employee_record.management.commands.detect_missing_asp_files succeeded in "
+    )
+    return [re.sub(r"<EmployeeRecord: .+?>", "[EMPLOYEE RECORD]", msg) for msg in caplog_messages[:-1]]
+
+
+@pytest.mark.parametrize("with_slack_webhook", [True, False])
+def test_nothing_to_report(snapshot, caplog, settings, mocker, with_slack_webhook):
+    slack_mock = mocker.patch("itou.employee_record.management.commands.detect_missing_asp_files.send_slack_message")
+    if with_slack_webhook:
+        settings.SLACK_CRON_WEBHOOK_URL = "http://slack.fake"
+
+    call_command("detect_missing_asp_files")
+
+    assert slack_mock.mock_calls == []
+    assert process_output(caplog.messages) == snapshot()
+
+
+@pytest.mark.parametrize("with_slack_webhook", [True, False])
+def test_report(snapshot, caplog, settings, mocker, with_slack_webhook):
+    slack_mock = mocker.patch("itou.employee_record.management.commands.detect_missing_asp_files.send_slack_message")
+    if with_slack_webhook:
+        settings.SLACK_CRON_WEBHOOK_URL = "http://slack.fake"
+    old_batch_file_not_sent = EmployeeRecordBatch.REMOTE_PATH_FORMAT.format(
+        datetime.datetime(2000, 1, 1, 12, 0, 0).strftime(EmployeeRecordBatch.TIMESTAMP_PATTERN)
+    )
+    old_batch_file_sent = EmployeeRecordBatch.REMOTE_PATH_FORMAT.format(
+        datetime.datetime(2000, 1, 1, 12, 0, 1).strftime(EmployeeRecordBatch.TIMESTAMP_PATTERN)
+    )
+    old_batch_file_sent_as_update = EmployeeRecordBatch.REMOTE_PATH_FORMAT.format(
+        datetime.datetime(2000, 1, 1, 12, 0, 1).strftime(EmployeeRecordBatch.TIMESTAMP_PATTERN)
+    )
+    recent_batch_file = EmployeeRecordBatch.REMOTE_PATH_FORMAT.format(
+        timezone.now().strftime(EmployeeRecordBatch.TIMESTAMP_PATTERN)
+    )
+
+    factories.EmployeeRecordFactory(
+        status=random.choice([status for status in Status if status != Status.SENT]),
+        asp_batch_file=old_batch_file_not_sent,
+    )
+    factories.EmployeeRecordFactory(status=Status.SENT, asp_batch_file=recent_batch_file)
+    factories.EmployeeRecordFactory(status=Status.SENT, asp_batch_file=old_batch_file_sent)
+
+    factories.EmployeeRecordUpdateNotificationFactory(
+        status=random.choice([status for status in NotificationStatus if status != NotificationStatus.SENT]),
+        asp_batch_file=old_batch_file_not_sent,
+    )
+    factories.EmployeeRecordUpdateNotificationFactory(
+        status=NotificationStatus.SENT,
+        asp_batch_file=old_batch_file_sent_as_update,
+    )
+
+    call_command("detect_missing_asp_files")
+    assert process_output(caplog.messages) == snapshot()
+    if with_slack_webhook:
+        assert slack_mock.mock_calls == [
+            mocker.call(
+                text=(
+                    "Des fichiers de l'ASP semblent s'être perdus\xa0:\n"
+                    " - RIAE_FS_20000101120001.json\xa0: contenant 1 EmployeeRecord\n"
+                    " - RIAE_FS_20000101120001.json\xa0: contenant 1 EmployeeRecordUpdateNotification\n\n"
+                    "Cf https://app.notion.com/p/gip-inclusion/Fiches-Salari-s-Interconnexion-RIAE-ASP-2415f321b60480c39ff9dfd2078d0c8d"
+                ),
+                url="http://slack.fake",
+            )
+        ]
+    else:
+        assert slack_mock.mock_calls == []


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela arrive de temps en temps (~ 1 à 2 fois par an) et c'est mieux si on arrive à le détecter avant qu'un employeur se plaigne au support.

## :cake: Comment ? <!-- optionnel -->

On regarde si des fiches salariés sont bloquées au status Envoyée depuis plus de 3 jours (un peu plus que le temps d'un weekend).
