### PR TITLE
Ajout du compte itou-admin dans les comptes de démo

### DIFF
--- a/itou/fixtures/django/account__email_address.json
+++ b/itou/fixtures/django/account__email_address.json
@@ -308,5 +308,15 @@
     },
     "model": "account.emailaddress",
     "pk": 45
+  },
+  {
+    "fields": {
+      "email": "itouadmin@example.com",
+      "primary": true,
+      "user": 148,
+      "verified": true
+    },
+    "model": "account.emailaddress",
+    "pk": 46
   }
 ]

--- a/itou/fixtures/django/auth__group.json
+++ b/itou/fixtures/django/auth__group.json
@@ -1,0 +1,10 @@
+[
+  {
+    "fields": {
+      "name": "itou-admin",
+      "permissions": []
+    },
+    "model": "auth.group",
+    "pk": 3
+  }
+]

--- a/itou/fixtures/django/dumpdata.sh
+++ b/itou/fixtures/django/dumpdata.sh
@@ -43,6 +43,7 @@ echo "Dump models data into $FIXTURES_DIRECTORY"
 ./manage.py dumpdata --format json-no-auto-fields --indent 2 users.jobseekerassignment -o "$FIXTURES_DIRECTORY/users__job_seeker_assignment.json"
 ./manage.py dumpdata --format json-no-auto-fields --indent 2 users.jobseekerprofile -o "$FIXTURES_DIRECTORY/users__jobseeker_profile.json"
 ./manage.py dumpdata --format json-no-auto-fields --indent 2 users.user -o "$FIXTURES_DIRECTORY/users__user.json"
+./manage.py dumpdata --format json-no-auto-fields --indent 2 auth.group -o "$FIXTURES_DIRECTORY/auth__group.json"
 
 
 for file in $(find "$FIXTURES_DIRECTORY" -iname '*.json' | sort); do

--- a/itou/fixtures/django/users__user.json
+++ b/itou/fixtures/django/users__user.json
@@ -3266,5 +3266,50 @@
     },
     "model": "users.user",
     "pk": 130
+  },
+  {
+    "fields": {
+      "address_filled_at": null,
+      "address_line_1": "",
+      "address_line_2": "",
+      "allow_next_sso_sub_update": false,
+      "ban_api_resolved_address": null,
+      "city": "",
+      "coords": null,
+      "created_by": 1,
+      "date_joined": "2026-09-07T15:22:58Z",
+      "department": "",
+      "email": "itouadmin@example.com",
+      "external_data_source_history": null,
+      "fields_history": "[]",
+      "first_login": "2026-09-07T15:32:03.691Z",
+      "first_name": "",
+      "geocoding_score": null,
+      "geocoding_updated_at": null,
+      "groups": [
+        3
+      ],
+      "has_completed_welcoming_tour": false,
+      "identity_provider": "DJANGO",
+      "insee_city": null,
+      "is_active": true,
+      "is_staff": true,
+      "is_superuser": false,
+      "kind": "itou_staff",
+      "last_checked_at": "2026-09-07T15:22:58Z",
+      "last_login": "2026-09-07T15:32:03.691Z",
+      "last_name": "",
+      "password": "pbkdf2_sha256$1200000$8U3FTo9P8BPNU5U9nV1HvN$ets3tTAUxvbPDHX/JRPnPt1qGVNI0M/E5NYWY0QOq7E=",
+      "phone": "",
+      "post_code": "",
+      "public_id": "b6a83559-b18c-412e-8c23-f3d68c8328d1",
+      "terms_accepted_at": null,
+      "title": "",
+      "upcoming_deletion_notified_at": null,
+      "user_permissions": [],
+      "username": "itouadmin"
+    },
+    "model": "users.user",
+    "pk": 148
   }
 ]

--- a/itou/utils/templatetags/demo_accounts.py
+++ b/itou/utils/templatetags/demo_accounts.py
@@ -13,8 +13,13 @@ def admin_accounts_tag():
     action_url = reverse("login:demo")
     return [
         {
-            "title": "Admin",
+            "title": "Super-utilisateur",
             "email": "admin@test.com",
+            "action_url": action_url,
+        },
+        {
+            "title": "Itou admin",
+            "email": "itouadmin@example.com",
             "action_url": action_url,
         },
     ]

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -186,6 +186,7 @@ class TestThemeInclusion:
 
 @pytest.fixture
 def load_test_users():
+    call_command("loaddata", "auth__group.json")
     call_command("loaddata", "users__user.json")
     call_command("loaddata", "account__email_address.json")
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour tester les permissions de ce compte : en testant avec itou-admin plutôt qu'un super-utilisateur j’aurai évité ça : https://github.com/gip-inclusion/les-emplois/pull/8635

## :cake: Comment ? <!-- optionnel -->

En ajoutant itou-admin aux comptes de démo.

