### PR TITLE
Recherche employeur : géolocalisation des structures dans l'admin

### DIFF
--- a/tests/insertion/test_admin.py
+++ b/tests/insertion/test_admin.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.models import Permission
+from django.contrib.gis.geos import Point
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.insertion.models import OrientationProcessLink
-from tests.insertion.factories import OrientationFactory, OrientationProcessLinkFactory
+from tests.cities.factories import create_city_vannes
+from tests.insertion.factories import OrientationFactory, OrientationProcessLinkFactory, StructureFactory
 from tests.users.factories import ItouStaffFactory
 
 
@@ -82,3 +84,42 @@ class TestOrientationProcessLink:
         )
         assert response.status_code == 302
         assert not OrientationProcessLink.objects.exists()
+
+
+def test_structure_admin_shows_geolocation(admin_client):
+    vannes = create_city_vannes()
+    structure = StructureFactory(
+        insee_city=vannes,
+        coordinates=Point(2.35511, 48.869364, srid=4326),
+    )
+
+    response = admin_client.get(reverse("admin:insertion_structure_change", args=(structure.pk,)))
+
+    assertContains(
+        response,
+        f"""
+        <div class="form-row field-insee_city">
+            <div>
+                <div class="flex-container">
+                    <label>Insee city&nbsp;:</label>
+                    <div class="readonly">
+                        <a href="/admin/cities/city/{vannes.pk}/change/">Vannes (56)</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        """,
+        html=True,
+        count=1,
+    )
+    assertContains(
+        response,
+        """
+        <div class="flex-container">
+            <label>Coordinates&nbsp;:</label>
+            <div class="readonly">SRID=4326;POINT (2.35511 48.869364)</div>
+        </div>
+        """,
+        html=True,
+        count=1,
+    )

--- a/tests/insertion/test_import_structures_and_services.py
+++ b/tests/insertion/test_import_structures_and_services.py
@@ -3,10 +3,12 @@ import pathlib
 from operator import attrgetter
 
 import pytest
+from django.contrib.gis.geos import Point
 from django.core.management import call_command
 from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertQuerySetEqual
 
+from itou.cities.models import City
 from itou.insertion.models import GenericReferenceItem, GenericReferenceItemKind, Service, Structure
 from itou.utils import constants as global_constants
 from itou.utils.apis.data_inclusion import DataInclusionApiItemsIterator, DataInclusionApiPaginatedResponse
@@ -177,6 +179,29 @@ def test_data_inclusion_iterator_yields_every_item_across_pages():
     items = list(DataInclusionApiItemsIterator(lambda *, page, size: pages[page]))
 
     assert [item["id"] for item in items] == ["a", "b", "c"]
+
+
+def test_import_fills_structure_coordinates_and_insee_city(apis_mocks):
+    paris = City.objects.create(
+        name="Paris",
+        slug="paris-75",
+        department="75",
+        post_codes=["75010"],
+        code_insee="75056",
+        coords=Point(2.347, 48.859),
+    )
+
+    call_command("import_structures_and_services", wet_run=True)
+
+    structure = Structure.objects.get(uid="dora--cc4e1fbc-533b-46e2-8b33-bc31c33c9ffd")
+    assert structure.insee_city == paris
+    assert structure.coordinates.x == pytest.approx(2.35511)
+    assert structure.coordinates.y == pytest.approx(48.869364)
+    assert structure.coordinates.srid == 4326
+
+    structure_without_location = Structure.objects.get(uid="emplois-de-linclusion--null")
+    assert structure_without_location.insee_city is None
+    assert structure_without_location.coordinates is None
 
 
 def test_import_soft_deletes_structures_and_services_absent_from_api(apis_mocks):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Epic : [Développer un prototype d’annuaire des pro](https://app.notion.com/p/gip-inclusion/D-velopper-un-prototype-d-annuaire-des-pro-3c75f321b604805cbe3aebb3cb336f57)

Ticket : T1 : [Modèle de données & géolocalisation des structures](https://app.notion.com/p/gip-inclusion/T1-Mod-le-de-donn-es-g-olocalisation-des-structures-3cd5f321b6048077ad64f4d57b1eba3c)

Ce que demande le ticket était déjà présent.

## :cake: Comment ?

C'était déjà fait et déjà affiché dans l'admin. J'ai rajouté juste deux tests:
* un test dans l'admin qui vérifie l'affichage des champs concernés, vu que maintenant c'est une exigence produit
* un test qui couvre un petit morceau d'import liés aux coordonnées, qui n'était pas couvert niveau test pour l'instant

J'ai essayé d'afficher la carte OSM, mais en fait cela n'est possible que si les coordonnées ne sont pas en lecture seule, sinon faut bidouiller django (et rajouter un peu de code personnalisé pas joli). C'est d'autant plus inintéressant qu'un [ticket django pour surcharger élégamment les champs en lecture seule dans l'admin est sur le point d'être livré](https://code.djangoproject.com/ticket/30577). 

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Rien pour l'instant
