### PR TITLE
Prescripteur : Mettre en avant la demande de bilan d’accompagnement en fin de contrat

### DIFF
--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -34,6 +34,17 @@
                     </a>
                 </li>
             {% endif %}
+            {% if contracts_ending_soon_count is not None %}
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    <a href="{% url 'job_seekers_views:list' %}?contract_ending_soon=on" class="btn-link btn-ico" {% matomo_event "dashboard" "clic" "fins-de-contrat" %}>
+                        <i class="ri-history-line ri-lg fw-normal" aria-hidden="true"></i>
+                        <span>Fins de contrat de travail</span>
+                    </a>
+                    {% if contracts_ending_soon_count %}
+                        <span class="badge rounded-pill badge-xs bg-warning">{{ contracts_ending_soon_count }}</span>
+                    {% endif %}
+                </li>
+            {% endif %}
         {% endfragment %}
         {% if stalled_job_seekers_count %}
             {% fragment as extra_boxes %}

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -46,7 +46,7 @@
                                 </div>
                                 {% if contract_ending_soon_date %}
                                     <div class="col-12 order-1 order-xxl-1">
-                                        {% include "job_seekers_views/includes/end_of_contract_card_banner.html" with contract_ending_soon_date=contract_ending_soon_date suggest_next_step_url=suggest_next_step_url fiche_banner_extra_id=fiche_banner_extra_id request=request only %}
+                                        {% include "job_seekers_views/includes/end_of_contract_card_banner.html" with contract_ending_soon_date=contract_ending_soon_date suggest_next_step_url=suggest_next_step_url pro_support_request_mailto=pro_support_request_mailto fiche_banner_extra_id=fiche_banner_extra_id request=request only %}
                                     </div>
                                 {% endif %}
                                 <div class="col-12 col-xxl-8 col-xxxl-9 order-3 order-xxl-2">

--- a/itou/templates/job_seekers_views/includes/end_of_contract_card_banner.html
+++ b/itou/templates/job_seekers_views/includes/end_of_contract_card_banner.html
@@ -4,16 +4,31 @@
 {% if contract_ending_soon_date %}
     {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id=fiche_banner_extra_id extra_classes="mb-3 mb-md-4" %}
         {% fragment as title %}
-            Le contrat arrive bientôt à échéance
+            {% if request.from_employer %}
+                Le contrat arrive bientôt à échéance
+            {% else %}
+                Ce bénéficiaire arrive en fin de contrat de travail
+            {% endif %}
         {% endfragment %}
         {% fragment as content %}
             <p class="mb-0">
-                Le contrat de ce salarié arrive à échéance le {{ contract_ending_soon_date|date:"d/m/Y" }}. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+                {% if request.from_employer %}
+                    Le contrat de ce salarié arrive à échéance le {{ contract_ending_soon_date|date:"d/m/Y" }}. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+                {% else %}
+                    Son contrat de travail se termine le {{ contract_ending_soon_date|date:"d/m/Y" }}. Demandez un bilan à la structure qui l’accompagne pour préparer la suite de son parcours.
+                {% endif %}
             </p>
         {% endfragment %}
         {% if suggest_next_step_url %}
             {% fragment as call_to_action %}
                 <a class="btn btn-sm btn-primary has-external-link" href="{{ suggest_next_step_url }}" target="_blank" rel="noopener noreferrer" {% matomo_event "employeurs" "clic" "suggerer-suite-parcours-fiche" %}>Suggérer une suite de parcours</a>
+            {% endfragment %}
+        {% elif pro_support_request_mailto %}
+            {% fragment as call_to_action %}
+                <a class="btn btn-sm btn-primary" href="{{ pro_support_request_mailto }}" {% matomo_event "candidat" "clic" "demande-bilan-accompagnement-fiche" %}>Demander un bilan d’accompagnement</a>
+            {% endfragment %}
+        {% else %}
+            {% fragment as call_to_action %}
             {% endfragment %}
         {% endif %}
     {% endcomponent_alert %}

--- a/itou/templates/job_seekers_views/includes/end_of_contracts_banner.html
+++ b/itou/templates/job_seekers_views/includes/end_of_contracts_banner.html
@@ -4,35 +4,70 @@
 
 {% if show_end_of_contracts_banner %}
     <div id="fins-de-contrats-banner"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
-        {% if end_of_journey_filter_active %}
-            {% component_alert title=title content=content variant="info" dismissible_once=True extra_id="end-of-contract-info-suggest" extra_classes="mb-3 mb-md-4" %}
-                {% fragment as title %}
-                    Suggérer une suite de parcours aux salariés
-                {% endfragment %}
-                {% fragment as content %}
-                    <p class="mb-0">
-                        Vous pouvez suggérer une suite de parcours directement depuis la fiche du salarié ou en cliquant sur « ⋮ » à droite de sa ligne.
-                    </p>
-                {% endfragment %}
-            {% endcomponent_alert %}
-        {% elif contracts_ending_soon_count %}
-            {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id="end-of-contract-ending-soon-banner" extra_classes="mb-3 mb-md-4" %}
-                {% fragment as title %}
-                    Vous avez {{ contracts_ending_soon_count }} salarié{{ contracts_ending_soon_count|pluralizefr }} en fin de contrat
-                {% endfragment %}
-                {% fragment as content %}
-                    <p class="mb-0">
-                        {% if contracts_ending_soon_count == 1 %}
-                            Le contrat de ce salarié arrive à échéance dans moins de 30 jours. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
-                        {% else %}
-                            Le contrat de ces salariés arrive à échéance dans moins de 30 jours. Préparez au mieux leur fin de contrat en suggérant une suite de parcours adaptée à leur situation.
-                        {% endif %}
-                    </p>
-                {% endfragment %}
-                {% fragment as call_to_action %}
-                    <a class="btn btn-sm btn-primary" href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" {% matomo_event "employeurs" "clic" "afficher-fins-de-contrats" %}>Afficher ce{{ contracts_ending_soon_count|pluralizefr }} salarié{{ contracts_ending_soon_count|pluralizefr }}</a>
-                {% endfragment %}
-            {% endcomponent_alert %}
+        {% if request.from_employer %}
+            {% if end_of_journey_filter_active %}
+                {% component_alert title=title content=content variant="info" dismissible_once=True extra_id="end-of-contract-info-suggest" extra_classes="mb-3 mb-md-4" %}
+                    {% fragment as title %}
+                        Suggérer une suite de parcours aux salariés
+                    {% endfragment %}
+                    {% fragment as content %}
+                        <p class="mb-0">
+                            Vous pouvez suggérer une suite de parcours directement depuis la fiche du salarié ou en cliquant sur « ⋮ » à droite de sa ligne.
+                        </p>
+                    {% endfragment %}
+                {% endcomponent_alert %}
+            {% elif contracts_ending_soon_count %}
+                {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id="end-of-contract-ending-soon-banner" extra_classes="mb-3 mb-md-4" %}
+                    {% fragment as title %}
+                        Vous avez {{ contracts_ending_soon_count }} salarié{{ contracts_ending_soon_count|pluralizefr }} en fin de contrat
+                    {% endfragment %}
+                    {% fragment as content %}
+                        <p class="mb-0">
+                            {% if contracts_ending_soon_count == 1 %}
+                                Le contrat de ce salarié arrive à échéance dans moins de 30 jours. Préparez au mieux sa fin de contrat en suggérant une suite de parcours adaptée à sa situation.
+                            {% else %}
+                                Le contrat de ces salariés arrive à échéance dans moins de 30 jours. Préparez au mieux leur fin de contrat en suggérant une suite de parcours adaptée à leur situation.
+                            {% endif %}
+                        </p>
+                    {% endfragment %}
+                    {% fragment as call_to_action %}
+                        <a class="btn btn-sm btn-primary" href="{% url 'job_seekers_views:list_organization' %}?contract_ending_soon=on" {% matomo_event "employeurs" "clic" "afficher-fins-de-contrats" %}>Afficher ce{{ contracts_ending_soon_count|pluralizefr }} salarié{{ contracts_ending_soon_count|pluralizefr }}</a>
+                    {% endfragment %}
+                {% endcomponent_alert %}
+            {% endif %}
+        {% else %}
+            {% if end_of_journey_filter_active %}
+                {% component_alert title=title content=content variant="info" dismissible_once=True extra_id="end-of-contract-info-support-request" extra_classes="mb-3 mb-md-4" %}
+                    {% fragment as title %}
+                        Demandez un bilan d’accompagnement à la SIAE
+                    {% endfragment %}
+                    {% fragment as content %}
+                        {# Reached directly from the dashboard, so it also states what the list holds. #}
+                        <p class="mb-0">
+                            Les bénéficiaires affichés arrivent en fin de contrat de travail. Pour chacun, ouvrez le menu « ⋮ » à droite de sa ligne et cliquez sur « Demander un bilan d’accompagnement à la SIAE ».
+                        </p>
+                    {% endfragment %}
+                {% endcomponent_alert %}
+            {% elif contracts_ending_soon_count %}
+                {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible_once=True extra_id="end-of-contract-ending-soon-prescriber-banner" extra_classes="mb-3 mb-md-4" %}
+                    {% fragment as title %}
+                        Vous accompagnez {{ contracts_ending_soon_count }} bénéficiaire{{ contracts_ending_soon_count|pluralizefr }} en fin de contrat de travail
+                    {% endfragment %}
+                    {% fragment as content %}
+                        <p class="mb-0">
+                            {% if contracts_ending_soon_count == 1 %}
+                                Le contrat de travail de ce bénéficiaire arrive à échéance dans moins de 30 jours. Agissez avant sa sortie pour éviter une rupture de parcours.
+                            {% else %}
+                                Le contrat de travail de ces bénéficiaires arrive à échéance dans moins de 30 jours. Agissez avant leur sortie pour éviter une rupture de parcours.
+                            {% endif %}
+                        </p>
+                    {% endfragment %}
+                    {% fragment as call_to_action %}
+                        {# Prescribers have two lists: keep the one they are on. #}
+                        <a class="btn btn-sm btn-primary" href="{{ request.path }}?contract_ending_soon=on" {% matomo_event "candidat" "clic" "afficher-fins-de-contrat" %}>Afficher ce{{ contracts_ending_soon_count|pluralizefr }} bénéficiaire{{ contracts_ending_soon_count|pluralizefr }}</a>
+                    {% endfragment %}
+                {% endcomponent_alert %}
+            {% endif %}
         {% endif %}
     </div>
 {% endif %}

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -198,6 +198,17 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                     prescriber_organization=current_org,
                     status=ProlongationRequestStatus.PENDING,
                 ).count()
+                today = timezone.localdate()
+                contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
+                # Contracts are not scoped to a company: a prescriber follows the whole IAE journey.
+                assigned_job_seekers = User.objects.filter(
+                    pk__in=User.objects.assigned_job_seeker_ids(request.user, current_org)
+                )
+                context["contracts_ending_soon_count"] = (
+                    annotate_last_contract_end_date(assigned_job_seekers)
+                    .filter(last_contract_end_date__range=contract_window)
+                    .count()
+                )
     elif request.from_institution:
         current_org = get_current_institution_or_404(request)
         six_months_ago = timezone.now() - timezone.timedelta(days=182)

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -448,6 +448,25 @@ Merci.
 """  # noqa: E501 # Line too long
 
 
+def _pro_support_request_company_email():
+    # Contracts are the most precise, but they are delayed. Fallback to job applications if needs be.
+    return Coalesce(
+        Subquery(
+            Contract.objects.filter(job_seeker=OuterRef("pk"), company__isnull=False)
+            .exclude(company__email="")
+            .order_by(F("start_date").desc())
+            .values("company__email")[:1]
+        ),
+        Subquery(
+            JobApplication.objects.accepted()
+            .filter(job_seeker=OuterRef("pk"))
+            .exclude(to_company__email="")
+            .order_by(F("hiring_start_at").desc(nulls_last=True))
+            .values("to_company__email")[:1]
+        ),
+    )
+
+
 def _build_pro_support_request_mailto(to_email, job_seeker_full_name):
     # V1 opens a pre-filled mailto to the employing SIAE: no email is
     # sent nor stored server-side.
@@ -525,25 +544,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
             form.cleaned_data.get("approval_ending_soon") or form.cleaned_data.get("contract_ending_soon")
         )
         if end_of_journey_filter_active and request.from_authorized_prescriber:
-            # Contracts are the most precise, but they are delayed.
-            # Fallback to job applications if needs be.
-            queryset = queryset.annotate(
-                pro_support_request_company_email=Coalesce(
-                    Subquery(
-                        Contract.objects.filter(job_seeker=OuterRef("pk"), company__isnull=False)
-                        .exclude(company__email="")
-                        .order_by(F("start_date").desc())
-                        .values("company__email")[:1]
-                    ),
-                    Subquery(
-                        JobApplication.objects.accepted()
-                        .filter(job_seeker=OuterRef("pk"))
-                        .exclude(to_company__email="")
-                        .order_by(F("hiring_start_at").desc(nulls_last=True))
-                        .values("to_company__email")[:1]
-                    ),
-                )
-            )
+            queryset = queryset.annotate(pro_support_request_company_email=_pro_support_request_company_email())
 
     queryset = (
         queryset.annotate(

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -192,38 +192,51 @@ class JobSeekerDetailTabView(BaseJobSeekerDetailView):
         if self.request.from_authorized_prescriber and self.approval is None:
             can_edit_iae_eligibility = True
 
-        # SIAE job seeker card banner: shown when a contract with this SIAE ends within 30 days and the
-        # Tally form is configured. Same business definition (scoped to the current SIAE) as the list.
+        # Job seeker card banner, shown when an IAE contract ends within 30 days: the SIAE is offered the
+        # Tally form for its own contract, the authorized prescriber a support request for the whole journey.
         # Lives in the details tab view only, so the query does not run on the other tabs.
         contract_ending_soon_date = None
         suggest_next_step_url = None
-        if (
+        pro_support_request_mailto = None
+        show_suggest_next_step = (
             self.request.from_employer
             and self.request.current_organization.is_subject_to_iae_rules
             and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID
-        ):
+        )
+        if show_suggest_next_step or self.request.from_authorized_prescriber:
             today = timezone.localdate()
-            last_contract_end_date = (
-                Contract.objects.filter(
-                    job_seeker=self.object, company=self.request.current_organization, end_date__isnull=False
-                )
-                .order_by("-end_date")
-                .values_list("end_date", flat=True)
-                .first()
-            )
+            contracts = Contract.objects.filter(job_seeker=self.object, end_date__isnull=False)
+            if show_suggest_next_step:
+                # A SIAE only looks at its own contract; a prescriber follows the whole IAE journey.
+                contracts = contracts.filter(company=self.request.current_organization)
+            last_contract_end_date = contracts.order_by("-end_date").values_list("end_date", flat=True).first()
             if last_contract_end_date and today <= last_contract_end_date <= today + datetime.timedelta(
                 days=IAE_CONTRACT_ENDING_SOON_DAYS
             ):
                 contract_ending_soon_date = last_contract_end_date
-                suggest_next_step_url = get_tally_form_url(
-                    settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID,
-                    iduser=self.request.user.pk,
-                    kindcompany=self.request.current_organization.kind,
-                )
+                if show_suggest_next_step:
+                    suggest_next_step_url = get_tally_form_url(
+                        settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID,
+                        iduser=self.request.user.pk,
+                        kindcompany=self.request.current_organization.kind,
+                    )
+                else:
+                    company_email = (
+                        User.objects.filter(pk=self.object.pk)
+                        .annotate(company_email=_pro_support_request_company_email())
+                        .values_list("company_email", flat=True)
+                        .first()
+                    )
+                    # The job seeker's name is in the mail body: no action when it must stay masked.
+                    if company_email and context["can_view_personal_information"]:
+                        pro_support_request_mailto = _build_pro_support_request_mailto(
+                            company_email, self.object.get_full_name()
+                        )
 
         return context | {
             "approval": self.approval,
             "contract_ending_soon_date": contract_ending_soon_date,
+            "pro_support_request_mailto": pro_support_request_mailto,
             "suggest_next_step_url": suggest_next_step_url,
             "fiche_banner_extra_id": f"fin-de-contrat-fiche-{self.object.public_id}",
             "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
@@ -565,16 +578,20 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         )
     )
 
-    show_end_of_contracts_banner = request.from_employer and request.current_organization.is_subject_to_iae_rules
+    show_suggest_next_step = request.from_employer and request.current_organization.is_subject_to_iae_rules
+    # Authorized prescribers get the same banners, pointing to the support request instead of the Tally form.
+    show_end_of_contracts_banner = show_suggest_next_step or request.from_authorized_prescriber
     today = timezone.localdate()
     contract_window = (today, today + datetime.timedelta(days=IAE_CONTRACT_ENDING_SOON_DAYS))
 
-    # Discovery banner: count over the SIAE assigned job seekers (unfiltered), only shown when the
-    # end-of-journey filter is not active.
+    # Discovery banner: count over the assigned job seekers (unfiltered), only shown when the
+    # end-of-journey filter is not active. A SIAE only counts its own contracts, a prescriber all of them.
     contracts_ending_soon_count = None
     if show_end_of_contracts_banner and not end_of_journey_filter_active:
         contracts_ending_soon_count = (
-            annotate_last_contract_end_date(base_queryset, company=request.current_organization)
+            annotate_last_contract_end_date(
+                base_queryset, company=request.current_organization if request.from_employer else None
+            )
             .filter(last_contract_end_date__range=contract_window)
             .count()
         )
@@ -582,7 +599,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     # SIAE "suggest a next step" action (Tally). Offered on each row whose IAE contract with this SIAE ends
     # soon, mirroring the job seeker card banner. Hidden while the form id is not configured.
     suggest_next_step_url = None
-    if show_end_of_contracts_banner and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID:
+    if show_suggest_next_step and settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID:
         suggest_next_step_url = get_tally_form_url(
             settings.TALLY_SUGGEST_NEXT_STEP_FORM_ID,
             iduser=request.user.pk,
@@ -594,7 +611,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     except ValueError:
         order = JobSeekerOrder.LAST_ACTION_AT_DESC
     queryset = queryset.order_by(*order.order_by)
-    if show_end_of_contracts_banner:
+    if show_suggest_next_step:
         queryset = annotate_last_contract_end_date(queryset, company=request.current_organization)
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_LARGE)
@@ -613,7 +630,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
                 job_seeker.get_full_name(),
             )
         job_seeker.contract_ending_soon = bool(
-            show_end_of_contracts_banner
+            show_suggest_next_step
             and job_seeker.last_contract_end_date
             and contract_window[0] <= job_seeker.last_contract_end_date <= contract_window[1]
         )

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -21,7 +21,7 @@ from itou.eligibility.models.geiq import GEIQAdministrativeCriteria, GEIQEligibi
 from itou.employee_record.enums import Status
 from itou.institutions.enums import InstitutionKind
 from itou.job_applications.enums import JobApplicationState
-from itou.prescribers.enums import PrescriberOrganizationKind
+from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.models import Sanctions
@@ -234,6 +234,52 @@ class TestDashboardView:
         # The dashboard counter matches the filtered "Accompagnements" list results.
         list_response = client.get(reverse("job_seekers_views:list_organization"), {"contract_ending_soon": "on"})
         assert list(list_response.context["page_obj"].object_list) == [job_seeker]
+
+    @freeze_time("2026-01-15")
+    def test_dashboard_contracts_ending_soon_count_for_prescriber(self, client):
+        organization = prescribers_factories.PrescriberOrganizationFactory(authorized=True, with_membership=True)
+        prescriber = organization.members.first()
+        client.force_login(prescriber)
+        today = date(2026, 1, 15)
+        url = reverse("dashboard:index")
+
+        # No contract ending soon yet: the entry is shown without a badge.
+        response = client.get(url)
+        assertContains(response, "Fins de contrat de travail")
+        assert response.context["contracts_ending_soon_count"] == 0
+
+        # A job seeker followed by the prescriber, whose contract ends in 20 days, is counted whatever the SIAE.
+        job_seeker = JobSeekerAssignmentFactory(
+            professional=prescriber, prescriber_organization=organization
+        ).job_seeker
+        ContractFactory(
+            job_seeker=job_seeker,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=20),
+        )
+        # A contract ending later is not counted.
+        other_job_seeker = JobSeekerAssignmentFactory(
+            professional=prescriber, prescriber_organization=organization
+        ).job_seeker
+        ContractFactory(
+            job_seeker=other_job_seeker,
+            start_date=today - timedelta(days=200),
+            end_date=today + timedelta(days=90),
+        )
+
+        response = client.get(url)
+        assert response.context["contracts_ending_soon_count"] == 1
+
+        # The dashboard counter matches the filtered "Mes accompagnements" list results.
+        list_response = client.get(reverse("job_seekers_views:list"), {"contract_ending_soon": "on"})
+        assert list(list_response.context["page_obj"].object_list) == [job_seeker]
+
+        # An unauthorized prescriber gets neither the entry nor the counter.
+        organization.authorization_status = PrescriberAuthorizationStatus.NOT_SET
+        organization.save()
+        response = client.get(url)
+        assertNotContains(response, "Fins de contrat de travail")
+        assert response.context["contracts_ending_soon_count"] is None
 
     def test_dashboard_applications_to_process(self, client):
         non_geiq_url = reverse("apply:list_for_siae") + "?states=new&amp;states=processing"

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -8768,7 +8768,7 @@
 # ---
 # name: test_with_approval_and_diagnosis_from_employer[SQL queries]
   dict({
-    'num_queries': 19,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -9450,6 +9450,21 @@
       }),
       dict({
         'origin': list([
+          'QuerySet.first[<site-packages>/django/db/models/query.py]',
+          'JobSeekerDetailTabView.get_context_data[www/job_seekers_views/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_contract"."end_date" AS "end_date"
+          FROM "companies_contract"
+          WHERE ("companies_contract"."end_date" IS NOT NULL
+                 AND "companies_contract"."job_seeker_id" = %s)
+          ORDER BY 1 DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
           'can_view_approval_details[approvals/perms.py]',
           'approval_details_box[utils/templatetags/approvals.py]',
           'InclusionNode[job_seekers_views/details.html]',
@@ -10064,7 +10079,7 @@
 # ---
 # name: test_with_approval_and_diagnosis_from_prescriber[SQL queries]
   dict({
-    'num_queries': 23,
+    'num_queries': 24,
     'queries': list([
       dict({
         'origin': list([
@@ -10765,6 +10780,21 @@
           FROM "approvals_suspension"
           WHERE "approvals_suspension"."approval_id" IN (%s)
           ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'QuerySet.first[<site-packages>/django/db/models/query.py]',
+          'JobSeekerDetailTabView.get_context_data[www/job_seekers_views/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_contract"."end_date" AS "end_date"
+          FROM "companies_contract"
+          WHERE ("companies_contract"."end_date" IS NOT NULL
+                 AND "companies_contract"."job_seeker_id" = %s)
+          ORDER BY 1 DESC
+          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -3093,7 +3093,7 @@
 # ---
 # name: test_multiple.1
   dict({
-    'num_queries': 18,
+    'num_queries': 19,
     'queries': list([
       dict({
         'origin': list([
@@ -3450,6 +3450,44 @@
                     GROUP BY V0."id",
                              1))
           ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s
+                                  AND U0."professional_id" = %s)))
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id") subquery
         ''',
       }),
       dict({
@@ -4162,7 +4200,7 @@
 # ---
 # name: test_multiple_with_job_seekers_created_by_organization.1
   dict({
-    'num_queries': 17,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -4517,6 +4555,43 @@
                     GROUP BY V0."id",
                              1))
           ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT
+               (SELECT U0."end_date" AS "end_date"
+                FROM "companies_contract" U0
+                WHERE (U0."end_date" IS NOT NULL
+                       AND U0."job_seeker_id" = ("users_user"."id"))
+                ORDER BY 1 DESC
+                LIMIT 1) AS "last_contract_end_date"
+             FROM "users_user"
+             LEFT OUTER JOIN "users_jobseekerassignment" ON ("users_user"."id" = "users_jobseekerassignment"."job_seeker_id")
+             WHERE ("users_user"."kind" = %s
+                    AND "users_user"."id" IN
+                      (SELECT DISTINCT U0."job_seeker_id" AS "job_seeker_id"
+                       FROM "users_jobseekerassignment" U0
+                       WHERE ((U0."company_id" IS NULL
+                               AND U0."prescriber_organization_id" IS NULL
+                               AND U0."professional_id" = %s)
+                              OR (U0."company_id" IS NULL
+                                  AND U0."prescriber_organization_id" = %s)))
+                    AND
+                      (SELECT U0."end_date" AS "end_date"
+                       FROM "companies_contract" U0
+                       WHERE (U0."end_date" IS NOT NULL
+                              AND U0."job_seeker_id" = ("users_user"."id"))
+                       ORDER BY 1 DESC
+                       LIMIT 1) BETWEEN %s AND %s)
+             GROUP BY "users_user"."id") subquery
         ''',
       }),
       dict({

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -15,6 +15,7 @@ from pytest_django.asserts import assertContains, assertNotContains, assertRedir
 from itou.asp.models import Commune
 from itou.companies.models import Company
 from itou.job_applications.enums import JobApplicationState
+from itou.prescribers.enums import PrescriberAuthorizationStatus
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
@@ -1302,6 +1303,46 @@ def test_end_of_contracts_banners_for_siae(client):
 
 
 @freeze_time("2026-01-15")
+def test_end_of_contracts_banners_for_prescriber(client):
+    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
+    prescriber = organization.members.first()
+    client.force_login(prescriber)
+    url = reverse("job_seekers_views:list")
+    today = datetime.date(2026, 1, 15)
+    pedagogic_banner = "Demandez un bilan d’accompagnement à la SIAE"
+
+    # No contract ending soon: neither banner.
+    response = client.get(url)
+    assertNotContains(response, "Afficher ce bénéficiaire")
+    assertNotContains(response, "Afficher ces bénéficiaires")
+    assertNotContains(response, pedagogic_banner)
+
+    # A job seeker with a contract ending soon: discovery banner on the unfiltered list. Unlike the SIAE
+    # one, the contract is counted whatever the company.
+    job_seeker = JobSeekerAssignmentFactory(professional=prescriber, prescriber_organization=organization).job_seeker
+    ContractFactory(
+        job_seeker=job_seeker,
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    response = client.get(url)
+    assertContains(response, "Vous accompagnez 1 bénéficiaire en fin de contrat de travail")
+    assertContains(response, "Afficher ce bénéficiaire")
+    assertNotContains(response, pedagogic_banner)
+
+    # When the end-of-journey filter is active: pedagogic banner replaces the discovery banner.
+    response = client.get(url, {"contract_ending_soon": "on"})
+    assertContains(response, pedagogic_banner)
+    assertNotContains(response, "Afficher ce bénéficiaire")
+
+    # An unauthorized prescriber gets no banner.
+    organization.authorization_status = PrescriberAuthorizationStatus.NOT_SET
+    organization.save()
+    response = client.get(url)
+    assertNotContains(response, "Vous accompagnez 1 bénéficiaire en fin de contrat de travail")
+
+
+@freeze_time("2026-01-15")
 @override_settings(TALLY_URL="https://tally.example", TALLY_SUGGEST_NEXT_STEP_FORM_ID="wSUGGEST")
 def test_suggest_next_step_action_in_list(client):
     membership = CompanyMembershipFactory(company__subject_to_iae_rules=True)
@@ -1352,6 +1393,43 @@ def test_suggest_next_step_banner_on_job_seeker_card(client):
     assertContains(response, "Le contrat arrive bientôt à échéance")
     assertContains(response, "04/02/2026")
     assertContains(response, f"https://tally.example/r/wSUGGEST?iduser={employer.pk}&kindcompany={company.kind}")
+
+
+@freeze_time("2026-01-15")
+def test_pro_support_request_banner_on_job_seeker_card(client):
+    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
+    prescriber = organization.members.first()
+    client.force_login(prescriber)
+    today = datetime.date(2026, 1, 15)
+    job_seeker = IAEEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        author=prescriber,
+        author_prescriber_organization=organization,
+        job_seeker__first_name="Jean",
+        job_seeker__last_name="Dupont",
+        with_job_seeker_assignment=True,
+    ).job_seeker
+    contract = ContractFactory(
+        job_seeker=job_seeker,
+        company__email="",
+        start_date=today - datetime.timedelta(days=200),
+        end_date=today + datetime.timedelta(days=20),
+    )
+    url = reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id})
+
+    # The employing SIAE has no e-mail: the banner still warns, without the action.
+    response = client.get(url)
+    assertContains(response, "Ce bénéficiaire arrive en fin de contrat de travail")
+    assertContains(response, "04/02/2026")
+    assertNotContains(response, "Demander un bilan d’accompagnement")
+
+    # With an e-mail, the action is offered and the mail is pre-filled.
+    contract.company.email = "siae@example.com"
+    contract.company.save()
+    response = client.get(url)
+    assertContains(response, "Demander un bilan d’accompagnement")
+    assertContains(response, "mailto:siae@example.com?subject=Demande%20de%20bilan%20d%E2%80%99accompagnement")
+    assertContains(response, "Jean%20DUPONT%20arrive")
 
 
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
@@ -1757,9 +1835,10 @@ def test_pro_support_request_action_for_authorized_prescriber(client, view):
     assertNotContains(response, mailto_label)
 
     # With the filter active, the action should be displayed, unless
-    # the company does not have any email.
+    # the company does not have any email. The label alone is not a reliable signal: the banner
+    # explaining where to find the action also spells it out.
     response = client.get(url, {"approval_ending_soon": "on"})
-    assertNotContains(response, mailto_label)
+    assertNotContains(response, "mailto:")
 
     # Now with a company that has an e-mail.
     company = job_application.to_company


### PR DESCRIPTION
## :thinking: Pourquoi ?

La demande de bilan d’accompagnement à la SIAE, livrée en #8632, n’est accessible que depuis le menu « ⋮ » d’une ligne, dans une liste que le prescripteur doit avoir pensé à filtrer au préalable. Il faut donc déjà savoir qu’elle existe pour la trouver.

Sa jumelle côté employeur, « Suggérer une suite de parcours » (#8628), dispose au contraire d’une entrée au tableau de bord, de deux bannières dans la liste et d’un bandeau sur la fiche du salarié.

Deux conséquences :

1. Les prescripteurs — France Travail en premier lieu — n’ont aucun moyen simple de repérer les bénéficiaires dont le contrat de travail se termine, alors que c’est le moment où se joue la rupture de parcours.
2. À exposition inégale, l’écart d’usage entre les deux publics est ininterprétable : impossible de dire si le sujet mobilise moins les prescripteurs, ou si nous ne le leur avons jamais montré.

Cette PR transpose le dispositif employeur aux prescripteurs habilités, en réutilisant les mêmes composants.

## :cake: Comment ?

Le critère est le contrat IAE se terminant sous `IAE_CONTRACT_ENDING_SOON_DAYS` — le même que côté employeur, pour que la comparaison entre les deux publics porte sur une population équivalente. Il n’est en revanche **pas restreint à une structure** : une SIAE ne regarde que ses propres contrats, un prescripteur suit le parcours dans sa globalité. C’est le comportement qu’applique déjà le filtre « Contrat IAE bientôt terminé » pour ce public.

- `show_end_of_contracts_banner` couvre désormais les deux publics. `show_suggest_next_step` isole ce qui reste propre aux SIAE : le formulaire Tally et l’action sur la ligne.
- La recherche du destinataire du courriel, jusqu’ici écrite en ligne dans la vue liste, est extraite (1er commit) pour que la fiche du bénéficiaire s’appuie sur la même définition.
- Le compteur du tableau de bord reprend le périmètre de « Mes accompagnements », identique à celui du compteur « Usagers sans solution » voisin, pour que le nombre annoncé corresponde exactement à la liste obtenue au clic.
- Le nom du bénéficiaire figurant dans le corps du courriel, l’action reste masquée lorsque `can_view_personal_information` est faux.

Trois points sur lesquels attirer votre attention :

- **Une requête supplémentaire** sur la liste (le comptage de la bannière) et une sur la fiche (la dernière date de fin de contrat), visibles dans les snapshots. Côté prescripteur le comptage n’est pas restreint à une structure : il est donc plus large que son équivalent SIAE.
- **Un test existant modifié.** `test_pro_support_request_action_for_authorized_prescriber` vérifiait l’absence de l’action en cherchant son libellé dans la page. La bannière qui explique où la trouver cite désormais ce libellé, qui n’est donc plus un signal fiable : l’assertion porte sur l’absence du lien `mailto:`.
- Le diff de `end_of_contracts_banner.html` est gonflé par la réindentation du bloc existant, l’ajout se limite à la branche prescripteur. `?w=1` le rend lisible.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ? Non, aucun changement cassant.
- [ ] Ajouter l’étiquette « Bug » ? Non, nouvelle fonctionnalité.

## :desert_island: Comment tester ?

En tant que **prescripteur habilité**, avec un bénéficiaire suivi dont un contrat IAE se termine dans moins de 30 jours :

1. **Tableau de bord**, bloc « Accompagnements » : une entrée « Fins de contrat de travail » avec le nombre de bénéficiaires concernés en pastille. Elle reste affichée sans pastille quand il n’y en a aucun, et disparaît pour un prescripteur non habilité.
2. **Le clic** ouvre « Mes accompagnements » avec le filtre « Contrat IAE bientôt terminé » déjà appliqué, et la bannière qui indique où trouver l’action.
3. **Sans filtre**, la bannière annonce le nombre de bénéficiaires concernés et propose de les afficher.
4. **Sur la fiche du bénéficiaire**, un bandeau daté propose « Demander un bilan d’accompagnement ». Il reste affiché mais sans le bouton lorsque la SIAE employeuse n’a pas d’adresse e-mail renseignée.

## :computer: Captures d’écran
