### PR TITLE
Tech: Erreurs plus concises pour le job pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       CELLAR_ADDON_KEY_ID_TEST: ${{ secrets.CLEVER_CELLAR_ADDON_KEY_ID_FOR_TESTS }}
       CELLAR_ADDON_SECRET_KEY_TEST: ${{ secrets.CLEVER_CELLAR_ADDON_SECRET_KEY_FOR_TESTS }}
       DJANGO_SETTINGS_MODULE: config.settings.test
+      # Shorten tracebacks to one line per failure to keep the CI logs readable.
+      PYTEST_ADDOPTS: --tb=line
       REDIS_URL: redis://127.0.0.1:6379
       REQUIREMENTS_PATH: requirements/test.txt
     concurrency:


### PR DESCRIPTION
(Il me semble que Damien avait proposé une PR allant dans ce sens il y a quelques mois, non ?)

## :thinking: Pourquoi ?

Les logs de pytest sont selon moi inexploitables côté GitHub car, dès que quelques tests échouent, les traces sont tellement longues qu'on parvient à peine à identifier les tests problématiques.

Désormais on n'aurait plus qu'une ligne par erreur – en gros. Cela ne concerne que la CI/CD (i.e. les jobs de tests avec Github Actions).

## :cake: Comment ? <!-- optionnel -->

Utilisation de l'option [`--tb=line`](https://docs.pytest.org/en/stable/how-to/output.html#modifying-python-traceback-printing) via [la variable d'environnement `PYTEST_ADDOPTS`](https://docs.pytest.org/en/stable/example/simple.html#how-to-change-command-line-options-defaults).

## :desert_island: Comment tester ?

(Faire échouter un test sur cette PR afin qu'on voit ce que ça donne ? Mais à essayer en local sinon.)

## :computer: Captures d'écran <!-- optionnel -->

.