### PR TITLE
Accompagnements: correction d'un message d'erreur quand un prescripteur ajoute un usager

### DIFF
--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -57,7 +57,7 @@
                 {% component_alert content=content variant="info" extra_classes="mb-3" %}
                     {% fragment as content %}
                         <p class="mb-0">{{ request.user.is_job_seeker|yesno:"Vous ne possédez,L’usager ne possède" }} pas de numéro de sécurité sociale ?</p>
-                        <a href="{{ invalid_nir_url }}" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>Cliquez ici pour accéder à l'étape suivante.</a>
+                        <a href="{{ invalid_nir_url }}" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>Cliquez ici pour accéder à l’étape suivante.</a>
                     {% endfragment %}
                 {% endcomponent_alert %}
             {% else %}
@@ -71,7 +71,7 @@
                                aria-label="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"
                                rel="noopener"
                                class="has-external-link"
-                               target="_blank">ameli.fr</a>, le site de l'assurance maladie, vous explique comment l'obtenir.
+                               target="_blank">ameli.fr</a>, le site de l’assurance maladie, vous explique comment l’obtenir.
                         </p>
                     {% endfragment %}
                 {% endcomponent_info %}
@@ -103,9 +103,9 @@
                                 {% if standalone_creation %}
                                     {% if active_assignment %}
                                         {% if active_assignment.advisor == request.user and active_assignment.organization == request.current_organization %}
-                                            Cet usager figure déjà dans votre liste d'accompagnements. Vous pouvez préciser les détails de votre intervention.
+                                            Cet usager figure déjà dans votre liste d’accompagnements. Vous pouvez préciser les détails de votre intervention.
                                         {% elif active_assignment.organization == request.current_organization %}
-                                            Cet usager figure déjà dans la liste d'accompagnements de votre structure.
+                                            Cet usager figure déjà dans la liste d’accompagnements de votre structure.
                                             <br>
                                             Vous pouvez vous désigner comme accompagnateur et ajouter votre intervention auprès de cet usager.
                                         {% endif %}
@@ -113,7 +113,7 @@
                                         Vous pouvez vous désigner comme accompagnateur et ajouter votre intervention auprès de cet usager.
                                     {% endif %}
                                 {% else %}
-                                    Si cette candidature n'est pas pour <b>{{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
+                                    Si cette candidature n’est pas pour <b>{{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Ce n’est pas mon candidat » afin de modifier le numéro de sécurité sociale.
                                 {% endif %}
                             </p>
                         </div>
@@ -127,7 +127,7 @@
                                 {% endif %}
                             {% else %}
                                 {# Reload this page with a new form. #}
-                                {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% bootstrap_button "Ce n’est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
                                 {# Go to the next step. #}
                                 {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                             {% endif %}

--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -56,14 +56,14 @@
             {% if form.errors %}
                 {% component_alert content=content variant="info" extra_classes="mb-3" %}
                     {% fragment as content %}
-                        <p class="mb-0">Vous ne possédez pas de numéro de sécurité sociale ?</p>
+                        <p class="mb-0">{{ request.user.is_job_seeker|yesno:"Vous ne possédez,L’usager ne possède" }} pas de numéro de sécurité sociale ?</p>
                         <a href="{{ invalid_nir_url }}" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>Cliquez ici pour accéder à l'étape suivante.</a>
                     {% endfragment %}
                 {% endcomponent_alert %}
             {% else %}
                 {% component_info c_info__summary=c_info__summary c_info__detail=c_info__detail extra_classes="mb-3" %}
                     {% fragment as c_info__summary %}
-                        {{ request.user.is_job_seeker|yesno:"Vous n'avez,Le candidat n'a" }} pas de numéro de sécurité sociale ?
+                        {{ request.user.is_job_seeker|yesno:"Vous n’avez,L’usager n’a" }} pas de numéro de sécurité sociale ?
                     {% endfragment %}
                     {% fragment as c_info__detail %}
                         <p>

--- a/tests/www/apply/test_hire_views.py
+++ b/tests/www/apply/test_hire_views.py
@@ -1146,7 +1146,7 @@ class TestFindJobSeekerForHireView:
                 data-matomo-category="nir-temporaire"
                 data-matomo-action="etape-suivante"
                 data-matomo-option="candidature">
-               Cliquez ici pour accéder à l'étape suivante.
+               Cliquez ici pour accéder à l’étape suivante.
             </a>
             """,
             html=True,

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -103,14 +103,14 @@ def assert_contains_apply_nir_modal(response, job_seeker, with_personal_informat
                 {mask_unless(job_seeker.get_inverted_full_name(), with_personal_information)}.</b>
             </p>
             <p>
-                Si cette candidature n'est pas pour
+                Si cette candidature n’est pas pour
                 <b>{mask_unless(job_seeker.get_inverted_full_name(), with_personal_information)}</b>,
-                cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
+                cliquez sur « Ce n’est pas mon candidat » afin de modifier le numéro de sécurité sociale.
             </p>
         </div>
         <div class="modal-footer">
             <button class="btn btn-sm btn-outline-primary" name="cancel" type="submit" value="1">
-            Ce n'est pas mon candidat</button>
+            Ce n’est pas mon candidat</button>
             <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Continuer</button>
         </div>
         """,
@@ -739,7 +739,7 @@ class TestApplyAsJobSeeker:
                 data-matomo-category="nir-temporaire"
                 data-matomo-action="etape-suivante"
                 data-matomo-option="candidature">
-               Cliquez ici pour accéder à l'étape suivante.
+               Cliquez ici pour accéder à l’étape suivante.
             </a>
             """,
             html=True,
@@ -1710,7 +1710,7 @@ class TestApplyAsAuthorizedPrescriber:
                 data-matomo-category="nir-temporaire"
                 data-matomo-action="etape-suivante"
                 data-matomo-option="candidature">
-               Cliquez ici pour accéder à l'étape suivante.
+               Cliquez ici pour accéder à l’étape suivante.
             </a>
             """,
             html=True,

--- a/tests/www/job_seekers_views/__snapshots__/test_create_or_update.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_create_or_update.ambr
@@ -184,7 +184,7 @@
                       </b>
                   </p>
                   <p>
-                      Cet usager figure déjà dans votre liste d'accompagnements. Vous pouvez préciser les détails de votre intervention.
+                      Cet usager figure déjà dans votre liste d’accompagnements. Vous pouvez préciser les détails de votre intervention.
                   </p>
               </div>
               <div class="modal-footer">
@@ -300,7 +300,7 @@
                       </b>
                   </p>
                   <p>
-                      Cet usager figure déjà dans votre liste d'accompagnements. Vous pouvez préciser les détails de votre intervention.
+                      Cet usager figure déjà dans votre liste d’accompagnements. Vous pouvez préciser les détails de votre intervention.
                   </p>
               </div>
               <div class="modal-footer">
@@ -474,7 +474,7 @@
                       </b>
                   </p>
                   <p>
-                      Cet usager figure déjà dans la liste d'accompagnements de votre structure.
+                      Cet usager figure déjà dans la liste d’accompagnements de votre structure.
                       <br/>
                       Vous pouvez vous désigner comme accompagnateur et ajouter votre intervention auprès de cet usager.
                   </p>
@@ -534,7 +534,7 @@
                       </b>
                   </p>
                   <p>
-                      Cet usager figure déjà dans votre liste d'accompagnements. Vous pouvez préciser les détails de votre intervention.
+                      Cet usager figure déjà dans votre liste d’accompagnements. Vous pouvez préciser les détails de votre intervention.
                   </p>
               </div>
               <div class="modal-footer">

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -156,6 +156,7 @@ class TestGetOrCreateForJobSeeker:
 
         response = client.get(next_url)
         assertContains(response, company.display_name)
+        assertContains(response, "Vous n’avez pas de numéro de sécurité sociale ?")
         assertContains(
             response,
             f"""
@@ -340,6 +341,7 @@ class TestGetOrCreateForSender:
         )
 
         assertContains(response, company.display_name)
+        assertContains(response, "L’usager n’a pas de numéro de sécurité sociale ?")
 
     @pytest.mark.parametrize(
         "born_in_france", [pytest.param(True, id="born_in_france"), pytest.param(False, id="born_outside_france")]


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte Notion](https://app.notion.com/p/gip-inclusion/Connaissance-du-parcours-3915f321b60480af8a48cacf51cbe596?p=3ce5f321b60480988ec2cd963be39135&pm=s)

Le message d'erreur d'origine s'adressait au candidat et non au prescripteur qui réalise l'action.

## :cake: Comment ?

Une difficulté est que ce formulaire est affiché dans plusieurs flows sur le site (j'en identifie au moins 3) : une personne qui candidate pour elle même, quelqu'un qui fait une candidature pour quelqu'un d'autre, quelqu'un qui ajoute un usager dans l'onglet Accompagnements (le cas qui nous intéresse ici). Le wording et le contenu exact de la page varient en fonction. Il y a parfois un mélange de termes employés : "candidat" et "usager".

Après discussion, on décide de ne garder que 2 wordings différents pour ce message d'erreur : "Vous ne possédez pas" ou "L'usager ne possède pas" car le mot "candidat" est progressivement remplacé partout par "usager". Une autre [carte Notion dédiée](https://app.notion.com/p/gip-inclusion/Identifier-et-remplacer-Candidat-par-Usager-sur-l-ensemble-du-site-3d65f321b60480b1a763dff239c6e0be?v=2715f321b60480088826000c5284ddfc) est prévue pour terminer le remplacement (sur le reste de cette page et partout ailleurs).

## :desert_island: Comment tester ?

Le problème de wording apparaissait par exemple lorsqu'on cliquait sur le bouton "Ajouter un usager" depuis le menu "Accompagnements" en tant que prescripteur habilité.
Faut-il une recette jetable ?