### PR TITLE
Tech: Utilisation d'une valeur par défaut pour le champ `created_at` de `JobSeekerAssignment`

### DIFF
--- a/itou/users/migrations/0058_alter_jobseekerassignment_created_at_and_more.py
+++ b/itou/users/migrations/0058_alter_jobseekerassignment_created_at_and_more.py
@@ -11,11 +11,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name="jobseekerassignment",
-            name="created_at",
-            field=models.DateTimeField(auto_now_add=True, verbose_name="date de création"),
-        ),
-        migrations.AlterField(
-            model_name="jobseekerassignment",
             name="updated_at",
             field=models.DateTimeField(auto_now=True, verbose_name="date de modification"),
         ),

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1642,7 +1642,7 @@ class JobSeekerAssignment(models.Model):
     An assignment of a job seeker to a professional, with or without organization or company.
     """
 
-    created_at = models.DateTimeField(verbose_name="date de création", auto_now_add=True)
+    created_at = models.DateTimeField(verbose_name="date de création", default=timezone.now)
     updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True)
     job_seeker = models.ForeignKey(
         User,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lors de la création du champ `last_action_at`, on a également modifié les champs `created_at` et `updated_at`, qui utilisaient jusqu'à présent une valeur par défaut, pour qu'ils utilisent désormais respectivement `auto_now_add=True` et `auto_now=True`.
Problème : il n'est [pas possible](https://docs.djangoproject.com/en/6.0/ref/models/fields/#django.db.models.DateField.auto_now_add) de donner la valeur de son choix à un champ avec `auto_now_add=True`. Toutes les dates dans nos fixtures d'accompagnements sont donc complètement ignorées, et on brise le continuum espace-temps avec des accompagnateurs qui ont commencé leur accompagnement après l'avoir terminé.

## :cake: Comment ? <!-- optionnel -->

Rebasculons sur une valeur par défaut pour `created_at`. Ca ne change rien en pratique à ma connaissance, et on aura des fixtures cohérentes.
Pour `updated_at`, on ne l'utilise plus vraiment depuis que `last_action_at` est là. Je pense qu'on peut le laisser tel quel.