### PR TITLE
Vie privée : empêcher l'envoi à Sentry de données personnelles du demandeur d’emploi

### DIFF
--- a/config/sentry.py
+++ b/config/sentry.py
@@ -10,12 +10,16 @@ from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.integrations.redis import RedisIntegration
 
 
+# Keep in sync with the query parameters sent by itou.utils.apis.api_particulier
 HTTP_QUERY_SENSITIVE_KEYS = [
     "anneeDateNaissance",
+    "codeCogInseeCommuneNaissance",
+    "codeCogInseePaysNaissance",
     "jourDateNaissance",
     "moisDateNaissance",
     "nomNaissance",
     "prenoms[]",
+    "sexeEtatCivil",
 ]
 
 

--- a/itou/utils/apis/api_particulier.py
+++ b/itou/utils/apis/api_particulier.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from itou.eligibility.enums import AdministrativeCriteriaKind
 from itou.users.enums import Title
+from itou.utils.logging import redact_query_params
 from itou.utils.types import InclusiveDateRange
 
 
@@ -48,7 +49,14 @@ def _build_params_from(job_seeker):
 def _request(client, endpoint, job_seeker):
     params = _build_params_from(job_seeker=job_seeker)
     params["recipient"] = SIRET_PLATEFORME_INCLUSION
-    return client.get(endpoint, params=params).raise_for_status().json()
+    response = client.get(endpoint, params=params)
+    # Sentry serializes the local variables of every frame of the traceback
+    del params
+    if not response.is_success:
+        # httpx builds the message of HTTPStatusError (and the repr of the request it carries)
+        # from the URL, whose query string identifies the job seeker
+        response.request.url = redact_query_params(response.request.url)
+    return response.raise_for_status().json()
 
 
 USER_REQUIRED_FIELDS = ["first_name", "last_name", "title"]

--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -10,6 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 NO_RECURSIVE_LOG_FLAG = "_no_recursive_log_flag"
+REDACTED = "_REDACTED_"
+
+
+def redact_query_params(url):
+    """Replace every query parameter value of an httpx.URL with a placeholder, keeping the keys."""
+    return url.copy_with(params=[(key, REDACTED) for key, _value in url.params.multi_items()])
 
 
 class ItouDataDogJSONFormatter(DataDogJSONFormatter):
@@ -52,13 +58,12 @@ class HTTPXFilter(logging.Filter):
 
             if isinstance(arg, httpx.URL):
                 if settings.API_PARTICULIER_BASE_URL and str(arg).startswith(settings.API_PARTICULIER_BASE_URL):
-                    redacted_params = [(key, "_REDACTED_") for key, _value in arg.params.multi_items()]
-                    arg = arg.copy_with(params=redacted_params)
+                    arg = redact_query_params(arg)
                 elif str(arg).startswith(f"{settings.BREVO_API_URL}/contacts/"):
                     identifier = arg.path.removeprefix("/v3/contacts/")
                     if "@" in identifier:
                         # This is an email address, redact it
-                        arg = arg.copy_with(path="/v3/contacts/_REDACTED_")
+                        arg = arg.copy_with(path=f"/v3/contacts/{REDACTED}")
             new_args.append(arg)
         record.args = tuple(new_args)
         return super().filter(record)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -2,9 +2,27 @@ import httpx
 import sentry_sdk
 
 
+pytestmark = pytest.mark.usefixtures("clean_sentry_scope")
+
+
+@pytest.fixture(name="clean_sentry_scope")
+def clean_sentry_scope_fixture():
+    """Isolate the test from the breadcrumbs left behind by the previous ones.
+
+    The SDK keeps its scopes for the whole process, and an event is built from the
+    breadcrumbs of the isolation scope *and* of the current one. Without forking
+    both, every HTTP request and INFO log of the test suite ends up in the events
+    captured here. Forking means the buffers can be emptied without affecting the
+    rest of the run.
+    """
+    with sentry_sdk.isolation_scope() as isolation_scope, sentry_sdk.new_scope() as scope:
+        for forked_scope in (isolation_scope, scope):
+            forked_scope.clear()  # clear the entire scope, including breadcrumbs, tags, extras, etc.
+        yield
+
+
 def test_before_send_http_breadcrumb_sanitizer(mocker, respx_mock):
     mocker.spy(sentry_sdk.client._Client, "_prepare_event")
-    sentry_sdk.get_isolation_scope().clear_breadcrumbs()
     url = "https://example.com/"
     params = {
         "foobar": 34,

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,5 +1,17 @@
+import json
+import re
+
 import httpx
+import pytest
 import sentry_sdk
+from django.conf import settings
+
+from config.sentry import HTTP_QUERY_SENSITIVE_KEYS
+from itou.eligibility.enums import AdministrativeCriteriaKind
+from itou.eligibility.tasks import certify_criterion_with_api_particulier
+from itou.utils.apis import api_particulier
+from itou.utils.logging import REDACTED
+from tests.eligibility.factories import IAEEligibilityDiagnosisFactory
 
 
 pytestmark = pytest.mark.usefixtures("clean_sentry_scope")
@@ -46,3 +58,45 @@ def test_before_send_http_breadcrumb_sanitizer(mocker, respx_mock):
     assert http_breadcrumb["data"]["http.query"] == (
         "foobar=34&nomNaissance=_REDACTED_&prenoms%5B%5D=_REDACTED_&jourDateNaissance=_REDACTED_&moisDateNaissance=_REDACTED_&anneeDateNaissance=_REDACTED_"
     )
+
+
+@pytest.mark.usefixtures("api_particulier_settings")
+def test_no_pii_in_event_when_api_particulier_is_down(mocker, respx_mock):
+    """The identity of the job seeker must not reach Sentry when API Particulier fails."""
+    diagnosis = IAEEligibilityDiagnosisFactory(
+        certifiable=True,
+        criteria_kinds=[AdministrativeCriteriaKind.RSA],
+        job_seeker__first_name="Jean-Michel",
+        job_seeker__last_name="Tardiveau",
+        # born in France also sends the birth place to the API
+        job_seeker__born_outside_france=False,
+        job_seeker__born_in_france=True,
+    )
+    criterion = diagnosis.selected_administrative_criteria.get()
+    endpoint = api_particulier.ENDPOINTS[AdministrativeCriteriaKind.RSA]
+    respx_mock.get(settings.API_PARTICULIER_BASE_URL + endpoint).respond(502, text="Bad Gateway (non-JSON response)")
+    mocker.spy(sentry_sdk.client._Client, "_prepare_event")
+
+    # This is what the Huey integration does with a failing task
+    try:
+        certify_criterion_with_api_particulier(criterion)
+    except httpx.HTTPStatusError:
+        sentry_sdk.capture_exception()
+    else:
+        pytest.fail("API Particulier errors should bubble up so that the task is retried.")
+
+    assert sentry_sdk.client._Client._prepare_event.call_count == 1
+    event = sentry_sdk.client._Client._prepare_event.spy_return
+    payload = json.dumps(event, default=repr)
+    assert '"vars"' in payload  # guard against a false negative
+    payload = payload.upper()
+    for pii in [diagnosis.job_seeker.first_name, diagnosis.job_seeker.last_name]:
+        assert pii.upper() not in payload
+    # The birth date and birth place are digits, which collide with unrelated numbers of the
+    # event (package versions, event ids, …), so they cannot be looked up as-is
+    sensitive_keys = "|".join(re.escape(key.removesuffix("[]")) for key in HTTP_QUERY_SENSITIVE_KEYS)
+    for match in re.finditer(rf"(?:{sensitive_keys})(.{{0,32}})", payload):
+        # What separates a key from its value depends on where it appears: "=" in a query
+        # string, "': '" in the repr of the params dict, escaped quotes in nested JSON…
+        value = match.group(1).lstrip("\\'\": =")
+        assert value.startswith(REDACTED), f"PII in the Sentry event: {match.group(0)}"

--- a/tests/utils/apis/test_api_particulier.py
+++ b/tests/utils/apis/test_api_particulier.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from django.conf import settings
 from django.utils import timezone
@@ -95,3 +96,23 @@ def test_not_found(respx_mock, caplog):
     assert crit.certification_period == InclusiveDateRange(empty=True)
     assert "https://fake-api-particulier.com/v3/dss/revenu_solidarite_active/identite" in caplog.text
     assert "nomNaissance=_REDACTED_&prenoms%5B%5D=_REDACTED_" in caplog.text
+
+
+def test_http_status_error_does_not_leak_pii(respx_mock):
+    """httpx builds HTTPStatusError's message from the URL, which identifies the job seeker."""
+    respx_mock.get("https://fake-api-particulier.com/v3/dss/revenu_solidarite_active/identite").respond(
+        502, text="Bad Gateway (non-JSON response)"
+    )
+    first_name, last_name = "Jean-Michel", "Tardiveau"
+    job_seeker = JobSeekerFactory(first_name=first_name, last_name=last_name, born_in_france=True)
+
+    with api_particulier.client() as client, pytest.raises(httpx.HTTPStatusError) as exc_info:
+        api_particulier.certify_criteria(AdministrativeCriteriaKind.RSA, client, job_seeker)
+
+    exception = exc_info.value
+    assert "nomNaissance=_REDACTED_&prenoms%5B%5D=_REDACTED_" in str(exception)
+    assert last_name.upper() not in str(exception).upper()
+    assert first_name.upper() not in str(exception).upper()
+    # the request the exception carries is redacted as well: Sentry serializes its repr
+    assert last_name.upper() not in repr(exception.request).upper()
+    assert last_name.upper() not in repr(exception.response.request).upper()


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Carte Notion](https://app.notion.com/p/gip-inclusion/Fuite-de-donn-es-personnelles-vers-Sentry-3755f321b604802ca571c69db3ed8c4e). En cas d’indisponibilité de l’API Particulier (502, par exemple), l’erreur levée par httpx embarque l’URL complète de la requête, avec en paramètres la chaîne de requête utilisée pour identifier le demandeur d’emploi : nom de naissance, prénoms, date et lieu de naissance. Cette URL se retrouve telle quelle dans le message de l’exception, dans son `repr()`, et dans les variables locales capturées par Sentry (`include_local_variables`), ce qui fait fuiter ces données personnelles vers Sentry à chaque coupure de l’API.

Les breadcrumbs HTTP étaient déjà filtrés côté logging, mais uniquement au niveau des logs, pas au niveau de l’exception elle-même ni de son `request`/`response`.

## :cake: Comment ?

- `itou/utils/apis/api_particulier.py` : avant de lever l’exception en cas d’échec (`raise_for_status`), l’URL de la requête portée par la réponse est réécrite pour remplacer chaque valeur de paramètre par `_REDACTED_`, tout en conservant les clés. `del params` supprime aussi la variable locale correspondante, capturée par Sentry dans chaque frame de la trace.
- `itou/utils/logging.py` : extraction de la logique de redaction des paramètres de requête dans une fonction `redact_query_params`, réutilisée à la fois par le filtre de logs HTTPX existant et par le nouveau code de `api_particulier.py`.
- `config/sentry.py` : complète `HTTP_QUERY_SENSITIVE_KEYS` avec les clés manquantes envoyées par l’API Particulier (code commune et pays de naissance, sexe état civil), pour que le scrubber Sentry les caviarde également dans les breadcrumbs.

## :desert_island: Comment tester ?

- cf. `tests/test_sentry.py::test_no_pii_in_event_when_api_particulier_is_down` et `tests/utils/apis/test_api_particulier.py::test_http_status_error_does_not_leak_pii`.
- En local, simuler une panne de l’API Particulier (mock ?) lors d’une tentative de certification de critère et vérifier que l’événement remonté à Sentry ne contient pas de PII.