### PR TITLE
Interface : Mieux expliquer l’absence de résultats de recherche

### DIFF
--- a/itou/templates/search/includes/prescribers_search_results.html
+++ b/itou/templates/search/includes/prescribers_search_results.html
@@ -41,7 +41,13 @@
     {% empty %}
         <div class="c-box c-box--results mb-3 mb-md-4">
             <div class="c-box--results__body">
-                <p class="mb-0">Aucun résultat avec les filtres actuels.</p>
+                <p class="mb-0">
+                    {% if form.is_bound %}
+                        Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville pour lancer la recherche.
+                    {% endif %}
+                </p>
             </div>
         </div>
     {% endfor %}

--- a/itou/templates/search/includes/siaes_search_results.html
+++ b/itou/templates/search/includes/siaes_search_results.html
@@ -8,7 +8,13 @@
     {% empty %}
         <div class="c-box c-box--results mb-3 mb-md-4">
             <div class="c-box--results__body">
-                <p class="mb-0">Aucun résultat avec les filtres actuels.</p>
+                <p class="mb-0">
+                    {% if form.is_bound %}
+                        Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville pour lancer la recherche.
+                    {% endif %}
+                </p>
             </div>
         </div>
     {% endfor %}

--- a/itou/templates/search/services/includes/results.html
+++ b/itou/templates/search/services/includes/results.html
@@ -64,10 +64,10 @@
         <div class="c-box c-box--results mb-3 mb-md-4">
             <div class="c-box--results__body">
                 <p class="mb-0">
-                    {% if suppress_category_error %}
-                        Veuillez sélectionner une thématique pour voir les résultats.
-                    {% else %}
+                    {% if form.is_bound %}
                         Aucun résultat avec les filtres actuels.
+                    {% else %}
+                        Renseignez une ville et une thématique pour lancer la recherche.
                     {% endif %}
                 </p>
             </div>

--- a/itou/www/search_views/views.py
+++ b/itou/www/search_views/views.py
@@ -404,7 +404,6 @@ def search_services_results(request, template_name="search/services/results.html
     form = ServiceSearchForm(data=request.GET or None)
     services = Service.objects.none()
 
-    suppress_category_error = False
     if form.is_valid():
         city = form.cleaned_data["city"]
         category = form.cleaned_data["category"]
@@ -420,19 +419,6 @@ def search_services_results(request, template_name="search/services/results.html
             reception=reception,
             service_types=form.cleaned_data["services"],
         ).select_related("structure", "source")
-    elif len(form.errors) == 1:
-        try:
-            # When searching for a job seeker (param job_seeker_public_id), the
-            # location is pre-filled with their city_slug. A category is
-            # also required, so the initial page load displays an error.
-            [category_error] = form.errors["category"]
-        except (KeyError, ValueError):
-            pass
-        else:
-            # Category not provided or empty.
-            suppress_category_error = not request.GET.get("category")
-            if suppress_category_error:
-                del form.errors["category"]
 
     banner_context = get_orient_for_job_seeker_context(request)
     job_seeker = banner_context["job_seeker"]
@@ -446,7 +432,6 @@ def search_services_results(request, template_name="search/services/results.html
         "form": form,
         "city": city,
         "category": category,
-        "suppress_category_error": suppress_category_error,
         "results": results,
         "detail_query_string": urlencode(detail_query),
         **banner_context,

--- a/tests/www/search_views/test_services.py
+++ b/tests/www/search_views/test_services.py
@@ -100,8 +100,13 @@ class TestSearchServices:
     def test_category_error_suppression(self, client):
         vannes = create_city_vannes()
 
-        response = client.get(self.URL, {"city": vannes.slug})
-        assertContains(response, "Veuillez sélectionner une thématique pour voir les résultats.")
+        response = client.get(self.URL)
+        assertContains(
+            response,
+            '<p class="mb-0">Renseignez une ville et une thématique pour lancer la recherche.</p>',
+            html=True,
+            count=1,
+        )
         assertNotContains(response, "Votre formulaire contient une erreur")
 
         response = client.get(self.URL, {"city": vannes.slug, "category": "invalid"})

--- a/tests/www/search_views/test_services.py
+++ b/tests/www/search_views/test_services.py
@@ -101,16 +101,17 @@ class TestSearchServices:
         vannes = create_city_vannes()
 
         response = client.get(self.URL)
+        error_message = "Votre formulaire contient une erreur"
         assertContains(
             response,
             '<p class="mb-0">Renseignez une ville et une thématique pour lancer la recherche.</p>',
             html=True,
             count=1,
         )
-        assertNotContains(response, "Votre formulaire contient une erreur")
+        assertNotContains(response, error_message)
 
         response = client.get(self.URL, {"city": vannes.slug, "category": "invalid"})
-        assertContains(response, "Votre formulaire contient une erreur")
+        assertContains(response, error_message)
 
     def test_no_results(self, client):
         vannes = create_city_vannes()

--- a/tests/www/search_views/tests.py
+++ b/tests/www/search_views/tests.py
@@ -1662,3 +1662,23 @@ class TestJobDescriptionSearchView:
             "<span>Effacer tout</span></a>"
         )
         assertContains(response, reset_button, html=True)
+
+
+class TestSearchWithoutCity:
+    @pytest.mark.parametrize(
+        "url_name,empty_text",
+        [
+            ("search:employers_results", "Renseignez une ville pour lancer la recherche."),
+            ("search:job_descriptions_results", "Renseignez une ville pour lancer la recherche."),
+            ("search:prescribers_results", "Renseignez une ville pour lancer la recherche."),
+            ("search:services_results", "Renseignez une ville et une thématique pour lancer la recherche."),
+        ],
+    )
+    def test_unsearched_page_does_not_claim_empty_results(self, client, url_name, empty_text):
+        url = reverse(url_name)
+        response = client.get(url)
+        no_results_text = "Aucun résultat avec les filtres actuels"
+        assertContains(response, empty_text)
+        assertNotContains(response, no_results_text)
+        response = client.get(url, {"city": "foo", "thematique": "bar"})
+        assertContains(response, no_results_text)


### PR DESCRIPTION
## :thinking: Pourquoi ?

L’application affichait le message "Aucun résultat avec les filtres actuels." lorsqu’aucun filtre n’est renseigné, ce qui pourrait laisser à penser qu’il n’y a aucun résultat à afficher.

## :cake: Comment ? <!-- optionnel -->

Amélioration du texte.

## :desert_island: Comment tester ?

Visiter :
`/search/employers/results`
`/search/job-descriptions/results`
`/search/prescribers/results`
`/search/services/results`

Vérifier la présence du message indiquant d’utiliser les filtres pour afficher des résultats dans l’encart résultats.

## :computer: Captures d'écran <!-- optionnel -->

### Employeur

<img width="1752" height="730" alt="image" src="https://github.com/user-attachments/assets/87ad9a6d-ca1d-437d-b25c-2f3a0e4a04e4" />

### Poste

<img width="1752" height="730" alt="image" src="https://github.com/user-attachments/assets/3745bbb9-46c2-4ca9-bfe9-c5c9db8965a1" />

### Prescripteur

<img width="1752" height="730" alt="image" src="https://github.com/user-attachments/assets/7587633f-8960-4fd5-8476-cb570639f81d" />

### Service

<img width="1752" height="730" alt="image" src="https://github.com/user-attachments/assets/fb0128b2-e20f-4729-a003-8b9bdc8a6e98" />