### PR TITLE
Tech: vérifier le verbe utilisé pour clore un PASS IAE

### DIFF
--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -19,6 +19,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 from itoutils.urls import add_url_params
 
 from itou.approvals.admin_forms import ManuallyAddApprovalFromJobApplicationForm, ProlongationDerogationForm
@@ -182,6 +183,7 @@ def manually_refuse_approval(
     return render(request, template_name, context)
 
 
+@require_POST
 def terminate_approval(request, model_admin, approval_id):
     opts = model_admin.model._meta
     app_label = opts.app_label

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -353,6 +353,11 @@ class TestApprovalAdmin:
         response = admin_client.post(reverse("admin:approvals_approval_terminate_approval", args=(approval.pk,)))
         assert response.status_code == 404
 
+    def test_terminate_approval_wrong_method(self, admin_client):
+        approval = ApprovalFactory(start_at=timezone.localdate() - timedelta(days=10))
+        response = admin_client.get(reverse("admin:approvals_approval_terminate_approval", args=(approval.pk,)))
+        assert response.status_code == 405
+
     @freeze_time("2025-08-21")
     def test_terminate_approval(self, admin_client, caplog):
         start_at = timezone.localdate() - timedelta(days=10)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter une CSRF.
Cf https://yeswehack.com/vulnerability-center/reports/816372

## :cake: Comment ? <!-- optionnel -->

En n'acceptant que le verbe POST
